### PR TITLE
Drop SIMD/nightly and bump polars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             override: true
       - uses: erlef/setup-beam@v1
         with:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ will always return a new dataframe or series.
 
 ## Getting started
 
-In order to use `Explorer`, you will need Elixir and Rust (nightly) installed. Then create an 
+In order to use `Explorer`, you will need Elixir and Rust (stable) installed. Then create an 
 Elixir project via the `mix` build tool:
 
 ```

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -736,7 +736,7 @@ dependencies = [
 [[package]]
 name = "polars"
 version = "0.15.1"
-source = "git+https://github.com/ritchie46/polars?rev=b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28#b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28"
+source = "git+https://github.com/ritchie46/polars?rev=2055cf205e992c5eb0809ada55e067ef4c293b0d#2055cf205e992c5eb0809ada55e067ef4c293b0d"
 dependencies = [
  "polars-core",
  "polars-io",
@@ -746,7 +746,7 @@ dependencies = [
 [[package]]
 name = "polars-arrow"
 version = "0.15.1"
-source = "git+https://github.com/ritchie46/polars?rev=b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28#b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28"
+source = "git+https://github.com/ritchie46/polars?rev=2055cf205e992c5eb0809ada55e067ef4c293b0d#2055cf205e992c5eb0809ada55e067ef4c293b0d"
 dependencies = [
  "arrow",
  "num",
@@ -756,7 +756,7 @@ dependencies = [
 [[package]]
 name = "polars-core"
 version = "0.15.1"
-source = "git+https://github.com/ritchie46/polars?rev=b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28#b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28"
+source = "git+https://github.com/ritchie46/polars?rev=2055cf205e992c5eb0809ada55e067ef4c293b0d#2055cf205e992c5eb0809ada55e067ef4c293b0d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -781,7 +781,7 @@ dependencies = [
 [[package]]
 name = "polars-io"
 version = "0.15.1"
-source = "git+https://github.com/ritchie46/polars?rev=b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28#b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28"
+source = "git+https://github.com/ritchie46/polars?rev=2055cf205e992c5eb0809ada55e067ef4c293b0d#2055cf205e992c5eb0809ada55e067ef4c293b0d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -804,7 +804,7 @@ dependencies = [
 [[package]]
 name = "polars-lazy"
 version = "0.15.1"
-source = "git+https://github.com/ritchie46/polars?rev=b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28#b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28"
+source = "git+https://github.com/ritchie46/polars?rev=2055cf205e992c5eb0809ada55e067ef4c293b0d#2055cf205e992c5eb0809ada55e067ef4c293b0d"
 dependencies = [
  "ahash",
  "itertools",

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -77,7 +77,6 @@ dependencies = [
  "lexical-core",
  "multiversion",
  "num",
- "packed_simd_2",
  "rand 0.8.4",
  "regex",
  "serde",
@@ -175,12 +174,6 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -210,7 +203,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -219,7 +212,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -229,7 +222,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -240,7 +233,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -253,7 +246,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -358,7 +351,7 @@ version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "miniz_oxide",
@@ -370,7 +363,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -381,7 +374,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
 ]
@@ -478,7 +471,7 @@ version = "5.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f404a90a744e32e8be729034fc33b90cf2a56418fbf594d69aa3c0214ad414e5"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lexical-core",
 ]
 
@@ -490,7 +483,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ryu",
  "static_assertions",
 ]
@@ -500,12 +493,6 @@ name = "libc"
 version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
-
-[[package]]
-name = "libm"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libm"
@@ -528,7 +515,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -688,7 +675,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
- "libm 0.2.1",
+ "libm",
 ]
 
 [[package]]
@@ -714,16 +701,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "packed_simd_2"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e64858a2d3733fdd61adfdd6da89aa202f7ff0e741d2fc7ed1e452ba9dc99d7"
-dependencies = [
- "cfg-if 0.1.10",
- "libm 0.1.4",
 ]
 
 [[package]]

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -19,7 +19,7 @@ rand_pcg = "0.3.1"
 
 [dependencies.polars]
 git = "https://github.com/ritchie46/polars"
-rev = "b079985ce1bb0b2a5bc099fbb3c2acf82ddbbc28"
+rev = "2055cf205e992c5eb0809ada55e067ef4c293b0d"
 default-features = false
 features = [
   "cross_join",

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -32,7 +32,6 @@ features = [
   "plain_fmt",
   "random",
   "rows",
-  "simd",
   "sort_multiple",
   "strings",
   "temporal",

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -139,15 +139,15 @@ pub fn df_as_str(data: ExDataFrame) -> Result<String, ExplorerError> {
 #[rustler::nif]
 pub fn df_fill_none(data: ExDataFrame, strategy: &str) -> Result<ExDataFrame, ExplorerError> {
     let strat = match strategy {
-        "backward" => FillNoneStrategy::Backward,
-        "forward" => FillNoneStrategy::Forward,
-        "min" => FillNoneStrategy::Min,
-        "max" => FillNoneStrategy::Max,
-        "mean" => FillNoneStrategy::Mean,
+        "backward" => FillNullStrategy::Backward,
+        "forward" => FillNullStrategy::Forward,
+        "min" => FillNullStrategy::Min,
+        "max" => FillNullStrategy::Max,
+        "mean" => FillNullStrategy::Mean,
         s => return Err(ExplorerError::Other(format!("Strategy {} not supported", s)).into()),
     };
     df_read!(data, df, {
-        let new_df = df.fill_none(strat)?;
+        let new_df = df.fill_null(strat)?;
         Ok(ExDataFrame::new(new_df))
     })
 }

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -322,16 +322,16 @@ pub fn s_drop_nulls(data: ExSeries) -> Result<ExSeries, ExplorerError> {
 #[rustler::nif]
 pub fn s_fill_none(data: ExSeries, strategy: &str) -> Result<ExSeries, ExplorerError> {
     let strat = match strategy {
-        "backward" => FillNoneStrategy::Backward,
-        "forward" => FillNoneStrategy::Forward,
-        "min" => FillNoneStrategy::Min,
-        "max" => FillNoneStrategy::Max,
-        "mean" => FillNoneStrategy::Mean,
+        "backward" => FillNullStrategy::Backward,
+        "forward" => FillNullStrategy::Forward,
+        "min" => FillNullStrategy::Min,
+        "max" => FillNullStrategy::Max,
+        "mean" => FillNullStrategy::Mean,
         s => return Err(ExplorerError::Other(format!("Strategy {} not supported", s)).into()),
     };
 
     let s = &data.resource.0;
-    let s1 = s.fill_none(strat)?;
+    let s1 = s.fill_null(strat)?;
     Ok(ExSeries::new(s1))
 }
 
@@ -612,19 +612,19 @@ pub fn s_get(env: Env, data: ExSeries, idx: usize) -> Result<Term, ExplorerError
 #[rustler::nif]
 pub fn s_cum_sum(data: ExSeries, reverse: bool) -> Result<ExSeries, ExplorerError> {
     let s = &data.resource.0;
-    Ok(ExSeries::new(s.cum_sum(reverse)))
+    Ok(ExSeries::new(s.cumsum(reverse)))
 }
 
 #[rustler::nif]
 pub fn s_cum_max(data: ExSeries, reverse: bool) -> Result<ExSeries, ExplorerError> {
     let s = &data.resource.0;
-    Ok(ExSeries::new(s.cum_max(reverse)))
+    Ok(ExSeries::new(s.cummax(reverse)))
 }
 
 #[rustler::nif]
 pub fn s_cum_min(data: ExSeries, reverse: bool) -> Result<ExSeries, ExplorerError> {
     let s = &data.resource.0;
-    Ok(ExSeries::new(s.cum_min(reverse)))
+    Ok(ExSeries::new(s.cummin(reverse)))
 }
 
 #[rustler::nif]


### PR DESCRIPTION
SIMD is optional and it's the only option with polars that requires nightly. Given we haven't made a push on performance yet, and given that it's been causing instability for the project from the start, I'm removing SIMD and moving to stable until I've refactored to lazy-by-default and can do some proper benchmarking.