### PR TITLE
Clean ups around DataFrame.read_csv/2

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -54,7 +54,7 @@ defmodule Explorer.DataFrame do
   ## Options
 
     * `delimiter` - A single character used to separate fields within a record. (default: `","`)
-    * `dtypes` - A list of `{"column_name", dtype}`, where dtype is str, f64, i64, bool, date32(days), or date64(ms). If `nil`, dtypes are imputed from the first 1000 rows. (default: `nil`)
+    * `dtypes` - A keyword list of `[column_name: dtype]`. If `nil`, dtypes are imputed from the first 1000 rows. (default: `nil`)
     * `header?` - Does the file have a header of column names as the first row or not? (default: `true`)
     * `max_rows` - Maximum number of lines to read. (default: `Inf`)
     * `null_character` - The string that should be interpreted as a nil value. (default: `"NA"`)

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -57,6 +57,7 @@ defmodule Explorer.DataFrame do
     * `dtypes` - A keyword list of `[column_name: dtype]`. If `nil`, dtypes are imputed from the first 1000 rows. (default: `nil`)
     * `header?` - Does the file have a header of column names as the first row or not? (default: `true`)
     * `max_rows` - Maximum number of lines to read. (default: `Inf`)
+    * `names` - A list of column names. Must match the width of the dataframe. (default: nil)
     * `null_character` - The string that should be interpreted as a nil value. (default: `"NA"`)
     * `skip_rows` - The number of lines to skip at the beginning of the file. (default: `0`)
     * `with_columns` - A list of column names to keep. If present, only these columns are read into the dataframe. (default: `nil`)

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -54,14 +54,12 @@ defmodule Explorer.DataFrame do
   ## Options
 
     * `delimiter` - A single character used to separate fields within a record. (default: `","`)
-    * `dtypes` - A keyword list of `[column_name: dtype]`. If `nil`, dtypes are imputed from the first 1000 rows. (default: `nil`)
+    * `dtypes` - A list of `{"column_name", dtype}`, where dtype is str, f64, i64, bool, date32(days), or date64(ms). If `nil`, dtypes are imputed from the first 1000 rows. (default: `nil`)
     * `header?` - Does the file have a header of column names as the first row or not? (default: `true`)
     * `max_rows` - Maximum number of lines to read. (default: `Inf`)
-    * `names` - A list of column names. Must match the width of the dataframe. (default: nil)
     * `null_character` - The string that should be interpreted as a nil value. (default: `"NA"`)
     * `skip_rows` - The number of lines to skip at the beginning of the file. (default: `0`)
-    * `with_columns` - A list of column names to keep. If present, only these columns are read
-    * into the dataframe. (default: `nil`)
+    * `with_columns` - A list of column names to keep. If present, only these columns are read into the dataframe. (default: `nil`)
   """
   @spec read_csv(filename :: String.t(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -42,8 +42,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
         true,
         with_columns,
         dtypes,
-        null_character,
-        encoding
+        encoding,
+        null_character
       )
 
     case df do

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -30,6 +30,13 @@ defmodule Explorer.PolarsBackend.DataFrame do
       ) do
     max_rows = if max_rows == Inf, do: nil, else: max_rows
 
+    dtypes =
+      if dtypes do
+        Enum.map(dtypes, fn {colname, dtype} ->
+          {Atom.to_string(colname), Shared.internal_from_dtype(dtype)}
+        end)
+      end
+
     df =
       Native.df_read_csv(
         filename,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -18,8 +18,8 @@ defmodule Explorer.PolarsBackend.Native do
         _rechunk,
         _with_columns,
         _dtypes,
-        _null_char,
-        _encoding
+        _encoding,
+        _null_char
       ),
       do: err()
 

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -55,4 +55,11 @@ defmodule Explorer.PolarsBackend.Shared do
   def normalise_dtype("date32(days)"), do: :date
   def normalise_dtype("date64(ms)"), do: :datetime
   def normalise_dtype("list [u32]"), do: :list
+
+  def internal_from_dtype(:integer), do: "i64"
+  def internal_from_dtype(:float), do: "f64"
+  def internal_from_dtype(:boolean), do: "bool"
+  def internal_from_dtype(:string), do: "str"
+  def internal_from_dtype(:date), do: "date32(days)"
+  def internal_from_dtype(:datetime), do: "date64(ms)"
 end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -8,17 +8,10 @@ defmodule Explorer.DataFrameTest do
     {:ok, df: Explorer.Datasets.fossil_fuels()}
   end
 
-  setup do
-    :ok = File.touch!("tmp_test.csv")
-
-    on_exit(fn ->
-      File.rm!("tmp_test.csv")
-    end)
-  end
-
-  def tmp_csv(contents) do
-    :ok = File.write!("tmp_test.csv", contents)
-    "tmp_test.csv"
+  defp tmp_csv(tmp_dir, contents) do
+    path = Path.join(tmp_dir, "tmp.csv")
+    :ok = File.write!(path, contents)
+    path
   end
 
   describe "filter/2" do
@@ -73,9 +66,10 @@ defmodule Explorer.DataFrameTest do
   end
 
   describe "read_csv/2 options" do
-    test "delimiter" do
+    @tag :tmp_dir
+    test "delimiter", config do
       csv =
-        tmp_csv("""
+        tmp_csv(config.tmp_dir, """
         a*b
         c*d
         e*f
@@ -89,9 +83,10 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
-    test "dtypes" do
+    @tag :tmp_dir
+    test "dtypes", config do
       csv =
-        tmp_csv("""
+        tmp_csv(config.tmp_dir, """
         a,b
         1,2
         3,4
@@ -105,9 +100,10 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
-    test "header?" do
+    @tag :tmp_dir
+    test "header?", config do
       csv =
-        tmp_csv("""
+        tmp_csv(config.tmp_dir, """
         a,b
         c,d
         e,f
@@ -121,9 +117,10 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
-    test "max_rows" do
+    @tag :tmp_dir
+    test "max_rows", config do
       csv =
-        tmp_csv("""
+        tmp_csv(config.tmp_dir, """
         a,b
         c,d
         e,f
@@ -137,9 +134,10 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
-    test "null_character" do
+    @tag :tmp_dir
+    test "null_character", config do
       csv =
-        tmp_csv("""
+        tmp_csv(config.tmp_dir, """
         a,b
         n/a,NA
         nil,
@@ -154,9 +152,10 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
-    test "skip_rows" do
+    @tag :tmp_dir
+    test "skip_rows", config do
       csv =
-        tmp_csv("""
+        tmp_csv(config.tmp_dir, """
         a,b
         c,d
         e,f
@@ -170,9 +169,10 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
-    test "with_columns" do
+    @tag :tmp_dir
+    test "with_columns", config do
       csv =
-        tmp_csv("""
+        tmp_csv(config.tmp_dir, """
         a,b
         c,d
         e,f

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -92,7 +92,7 @@ defmodule Explorer.DataFrameTest do
         3,4
         """)
 
-      df = DF.read_csv!(csv, dtypes: [{"a", "str"}])
+      df = DF.read_csv!(csv, dtypes: [a: :string])
 
       assert DF.to_map(df) == %{
                a: ["1", "3"],

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -184,5 +184,54 @@ defmodule Explorer.DataFrameTest do
                b: ["d", "f"]
              }
     end
+
+    @tag :tmp_dir
+    test "names", config do
+      csv =
+        tmp_csv(config.tmp_dir, """
+        a,b
+        c,d
+        e,f
+        """)
+
+      df = DF.read_csv!(csv, names: ["a2", "b2"])
+
+      assert DF.to_map(df) == %{
+               a2: ["c", "e"],
+               b2: ["d", "f"]
+             }
+    end
+
+    @tag :tmp_dir
+    test "names raises exception on invalid length", config do
+      csv =
+        tmp_csv(config.tmp_dir, """
+        a,b
+        c,d
+        """)
+
+      assert_raise(
+        ArgumentError,
+        "Expected length of provided names (1) to match number of columns in dataframe (2).",
+        fn -> DF.read_csv(csv, names: ["a2"]) end
+      )
+    end
+
+    @tag :tmp_dir
+    test "names and dtypes options work together", config do
+      csv =
+        tmp_csv(config.tmp_dir, """
+        a,b
+        1,2
+        3,4
+        """)
+
+      df = DF.read_csv!(csv, dtypes: [a: :string], names: ["a2", "b2"])
+
+      assert DF.to_map(df) == %{
+               a2: ["1", "3"],
+               b2: [2, 4]
+             }
+    end
   end
 end


### PR DESCRIPTION
Thanks for the great project! I was excited to play around with it but ran into some issues loading my CSVs. This PR does a few things:

* Adds tests for the various read_csv options - I like to look at tests to get a feel for using a function and I didn't see any about loading CSVs or how the options worked. And it helped me realize that three listed options (`:null_character`, `:names`, and `:dtypes`) had issues.  Not sure the best place to put these tests; if they should be for the Polars backend specifically, or doc tests, or something. I'm happy to move them.
* Fixes a bug with with the `null_character` option - The `Native.df_read_csv` function call didn't have the arguments in the same order as the corresponding rust function.
* Fixes the comment documentation for the `dtypes` option, which is said to take a keyword list of column name (as atom) to dtype. It doesn't specify the dtype format, but I assumed `:string`, `:integer`, etc. But it actually takes a list of tuples of column strings, and the type is specified like `"str"` or `"i64"`. Here I just documented the current behavior correctly. But if you *want* the `dtype` to be specified like `:string`, for example, I could update `dataframe.rs` to work with atoms and do that. I know rust somewhat, but not rustler specifically, and this change seems straightforward enough. But from a skim of the docs I'm not entirely sure how to make the *columns*, which aren't known at compile time, atoms.
* Removes the documentation for the `names` option which allegedly allows you to rename columns upon reading the CSV, but which appears to not be implemented. From a scan of the [polars docs](https://pola-rs.github.io/polars/polars/prelude/struct.CsvReader.html) I didn't see any methods provided to handle it.