### PR TITLE
Changes when CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,9 @@
-on: pull_request
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 env:
   ELIXIR_VERSION: 1.12


### PR DESCRIPTION
Right now it was only working for pull requests, but this is not exactly right:
1. It can happen that on merge our CI will fail, even the PR was fine. It happens when PR is stale for some time and is not properly rebased. New code can be pushed in the meantime
2. When you push directly to master
3. Without `workflow_dispatch` you cannot manually trigger the CI, which is sometimes super helpful