### PR TITLE
Add and/or operations for series

### DIFF
--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -70,6 +70,9 @@ defmodule Explorer.Backend.Series do
   @callback lt_eq(s, s | number()) :: s
   @callback all_equal?(s, s) :: boolean()
 
+  @callback and_(s, s) :: s
+  @callback or_(s, s) :: s
+
   # Coercion
 
   # Sort

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -70,8 +70,8 @@ defmodule Explorer.Backend.Series do
   @callback lt_eq(s, s | number()) :: s
   @callback all_equal?(s, s) :: boolean()
 
-  @callback s and s :: s
-  @callback s or s :: s
+  @callback binary_and(s, s) :: s
+  @callback binary_or(s, s) :: s
 
   # Coercion
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -70,8 +70,8 @@ defmodule Explorer.Backend.Series do
   @callback lt_eq(s, s | number()) :: s
   @callback all_equal?(s, s) :: boolean()
 
-  @callback and_(s, s) :: s
-  @callback or_(s, s) :: s
+  @callback s and s :: s
+  @callback s or s :: s
 
   # Coercion
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -399,6 +399,17 @@ defmodule Explorer.DataFrame do
         b integer [2, 3]
       >
 
+    You can combine masks using `Explorer.Series.and_/2` or `Explorer.Series.or_/2`:
+      iex> df = Explorer.DataFrame.from_map(%{a: ["a", "b", "c"], b: [1, 2, 3]})
+      iex> b_gt = Explorer.Series.greater(df["b"], 1)
+      iex> a_eq = Explorer.Series.equal(df["a"], "b")
+      iex> Explorer.DataFrame.filter(df, Explorer.Series.and_(a_eq, b_gt))
+      #Explorer.DataFrame<
+        [rows: 1, columns: 2]
+        a string ["b"]
+        b integer [2]
+      >
+
     Including a list:
 
       iex> df = Explorer.DataFrame.from_map(%{a: ["a", "b", "c"], b: [1, 2, 3]})
@@ -453,7 +464,7 @@ defmodule Explorer.DataFrame do
   @doc """
   Creates and modifies columns.
 
-  Columns are added as keyword list arguments. New variables overwrite existing variables of the 
+  Columns are added as keyword list arguments. New variables overwrite existing variables of the
   same name. Column names are coerced from atoms to strings.
 
   ## Examples
@@ -965,7 +976,7 @@ defmodule Explorer.DataFrame do
   ## Examples
 
       iex> df = Explorer.Datasets.fossil_fuels()
-      iex> Explorer.DataFrame.slice(df, 1, 2) 
+      iex> Explorer.DataFrame.slice(df, 1, 2)
       #Explorer.DataFrame<
         [rows: 2, columns: 10]
         year integer [2010, 2010]
@@ -983,7 +994,7 @@ defmodule Explorer.DataFrame do
     Negative offsets count from the end of the series:
 
       iex> df = Explorer.Datasets.fossil_fuels()
-      iex> Explorer.DataFrame.slice(df, -10, 2) 
+      iex> Explorer.DataFrame.slice(df, -10, 2)
       #Explorer.DataFrame<
         [rows: 2, columns: 10]
         year integer [2014, 2014]
@@ -1001,7 +1012,7 @@ defmodule Explorer.DataFrame do
     If the length would run past the end of the dataframe, the result may be shorter than the length:
 
       iex> df = Explorer.Datasets.fossil_fuels()
-      iex> Explorer.DataFrame.slice(df, -10, 20) 
+      iex> Explorer.DataFrame.slice(df, -10, 20)
       #Explorer.DataFrame<
         [rows: 10, columns: 10]
         year integer [2014, 2014, 2014, 2014, 2014, "..."]
@@ -1128,8 +1139,8 @@ defmodule Explorer.DataFrame do
   @doc """
   Pivot data from wide to long.
 
-  `Explorer.DataFrame.pivot_longer/3` "lengthens" data, increasing the number of rows and 
-  decreasing the number of columns. The inverse transformation is 
+  `Explorer.DataFrame.pivot_longer/3` "lengthens" data, increasing the number of rows and
+  decreasing the number of columns. The inverse transformation is
   `Explorer.DataFrame.pivot_wider/4`.
 
   The second argument (`columns`) can be either an array of column names to use or a filter callback on
@@ -1221,8 +1232,8 @@ defmodule Explorer.DataFrame do
   @doc """
   Pivot data from long to wide.
 
-  `Explorer.DataFrame.pivot_wider/4` "widens" data, increasing the number of columns and 
-  decreasing the number of rows. The inverse transformation is 
+  `Explorer.DataFrame.pivot_wider/4` "widens" data, increasing the number of columns and
+  decreasing the number of rows. The inverse transformation is
   `Explorer.DataFrame.pivot_longer/3`.
 
   Due to a restriction upstream, `values_from` must be a numeric type.
@@ -1398,7 +1409,7 @@ defmodule Explorer.DataFrame do
   @doc """
   Group the dataframe by one or more variables.
 
-  When the dataframe has grouping variables, operations are performed per group. 
+  When the dataframe has grouping variables, operations are performed per group.
   `Explorer.DataFrame.ungroup/2` removes grouping.
 
   ## Examples
@@ -1422,7 +1433,7 @@ defmodule Explorer.DataFrame do
       >
 
     Or you can group by multiple:
-    
+
       iex> df = Explorer.Datasets.fossil_fuels()
       iex> Explorer.DataFrame.group_by(df, ["country", "year"])
       #Explorer.DataFrame<

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -399,11 +399,11 @@ defmodule Explorer.DataFrame do
         b integer [2, 3]
       >
 
-    You can combine masks using `Explorer.Series.and_/2` or `Explorer.Series.or_/2`:
+    You can combine masks using `Explorer.Series.and/2` or `Explorer.Series.or/2`:
       iex> df = Explorer.DataFrame.from_map(%{a: ["a", "b", "c"], b: [1, 2, 3]})
       iex> b_gt = Explorer.Series.greater(df["b"], 1)
       iex> a_eq = Explorer.Series.equal(df["a"], "b")
-      iex> Explorer.DataFrame.filter(df, Explorer.Series.and_(a_eq, b_gt))
+      iex> Explorer.DataFrame.filter(df, Explorer.Series.and(a_eq, b_gt))
       #Explorer.DataFrame<
         [rows: 1, columns: 2]
         a string ["b"]

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -93,6 +93,7 @@ defmodule Explorer.PolarsBackend.Native do
 
   # Series
   def s_add(_s, _other), do: err()
+  def s_and(_s, _s2), do: err()
   def s_append(_s, _other), do: err()
   def s_arg_true(_s), do: err()
   def s_argsort(_s, _reverse), do: err()
@@ -138,6 +139,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_new_u64(_name, _val), do: err()
   def s_not(_s), do: err()
   def s_null_count(_s), do: err()
+  def s_or(_s, _s2), do: err()
   def s_peak_max(_s), do: err()
   def s_peak_min(_s), do: err()
   def s_pow(_s, _exponent), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -261,6 +261,11 @@ defmodule Explorer.PolarsBackend.Series do
   def all_equal?(left, right),
     do: Shared.apply_native(left, :s_series_equal, [Shared.to_polars_s(right), true])
 
+  @impl true
+  def and_(left, %Series{} = right), do: Shared.apply_native(left, :s_and, [Shared.to_polars_s(right)])
+
+  @impl true
+  def or_(left, %Series{} = right), do: Shared.apply_native(left, :s_or, [Shared.to_polars_s(right)])
   # Sort
 
   @impl true

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -262,10 +262,10 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_native(left, :s_series_equal, [Shared.to_polars_s(right), true])
 
   @impl true
-  def and_(left, %Series{} = right), do: Shared.apply_native(left, :s_and, [Shared.to_polars_s(right)])
+  def left and right, do: Shared.apply_native(left, :s_and, [Shared.to_polars_s(right)])
 
   @impl true
-  def or_(left, %Series{} = right), do: Shared.apply_native(left, :s_or, [Shared.to_polars_s(right)])
+  def left or right, do: Shared.apply_native(left, :s_or, [Shared.to_polars_s(right)])
   # Sort
 
   @impl true

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -262,10 +262,10 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_native(left, :s_series_equal, [Shared.to_polars_s(right), true])
 
   @impl true
-  def left and right, do: Shared.apply_native(left, :s_and, [Shared.to_polars_s(right)])
+  def binary_and(left, right), do: Shared.apply_native(left, :s_and, [Shared.to_polars_s(right)])
 
   @impl true
-  def left or right, do: Shared.apply_native(left, :s_or, [Shared.to_polars_s(right)])
+  def binary_or(left, right), do: Shared.apply_native(left, :s_or, [Shared.to_polars_s(right)])
   # Sort
 
   @impl true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -20,6 +20,7 @@ defmodule Explorer.Series do
   """
 
   alias __MODULE__, as: Series
+  alias Kernel, as: K
 
   import Explorer.Shared, only: [impl!: 1]
   import Nx.Defn.Kernel, only: [keyword!: 2]
@@ -790,14 +791,14 @@ defmodule Explorer.Series do
   """
   @spec add(left :: Series.t(), right :: Series.t() | number()) :: Series.t()
   def add(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
+      when K.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :add, [right])
 
   def add(%Series{dtype: left_dtype}, %Series{dtype: right_dtype}),
     do: dtype_mismatch_error("add/2", left_dtype, right_dtype)
 
   def add(%Series{dtype: dtype} = left, right)
-      when Kernel.and(dtype in [:integer, :float], is_number(right)),
+      when K.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :add, [right])
 
   def add(%Series{dtype: dtype}, _), do: dtype_error("add/2", dtype, [:integer, :float])
@@ -814,14 +815,14 @@ defmodule Explorer.Series do
   """
   @spec subtract(left :: Series.t(), right :: Series.t() | number()) :: Series.t()
   def subtract(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
+      when K.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :subtract, [right])
 
   def subtract(%Series{dtype: left_dtype}, %Series{dtype: right_dtype}),
     do: dtype_mismatch_error("subtract/2", left_dtype, right_dtype)
 
   def subtract(%Series{dtype: dtype} = left, right)
-      when Kernel.and(dtype in [:integer, :float], is_number(right)),
+      when K.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :subtract, [right])
 
   def subtract(%Series{dtype: dtype}, _), do: dtype_error("subtract/2", dtype, [:integer, :float])
@@ -838,14 +839,14 @@ defmodule Explorer.Series do
   """
   @spec multiply(left :: Series.t(), right :: Series.t() | number()) :: Series.t()
   def multiply(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
+      when K.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :multiply, [right])
 
   def multiply(%Series{dtype: left_dtype}, %Series{dtype: right_dtype}),
     do: dtype_mismatch_error("multiply/2", left_dtype, right_dtype)
 
   def multiply(%Series{dtype: dtype} = left, right)
-      when Kernel.and(dtype in [:integer, :float], is_number(right)),
+      when K.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :multiply, [right])
 
   def multiply(%Series{dtype: dtype}, _), do: dtype_error("multiply/2", dtype, [:integer, :float])
@@ -862,14 +863,14 @@ defmodule Explorer.Series do
   """
   @spec divide(left :: Series.t(), right :: Series.t() | number()) :: Series.t()
   def divide(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
+      when K.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :divide, [right])
 
   def divide(%Series{dtype: left_dtype}, %Series{dtype: right_dtype}),
     do: dtype_mismatch_error("divide/2", left_dtype, right_dtype)
 
   def divide(%Series{dtype: dtype} = left, right)
-      when Kernel.and(dtype in [:integer, :float], is_number(right)),
+      when K.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :divide, [right])
 
   def divide(%Series{dtype: dtype}, _), do: dtype_error("divide/2", dtype, [:integer, :float])
@@ -911,7 +912,7 @@ defmodule Explorer.Series do
     do: apply_impl(left, :eq, [right])
 
   def equal(%Series{dtype: dtype} = left, right)
-      when Kernel.and(dtype in [:integer, :float], is_number(right)),
+      when K.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :eq, [right])
 
   def equal(%Series{dtype: :date} = left, %Date{} = right),
@@ -947,7 +948,7 @@ defmodule Explorer.Series do
     do: apply_impl(left, :neq, [right])
 
   def not_equal(%Series{dtype: dtype} = left, right)
-      when Kernel.and(dtype in [:integer, :float], is_number(right)),
+      when K.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :neq, [right])
 
   def not_equal(%Series{dtype: :date} = left, %Date{} = right),
@@ -991,11 +992,11 @@ defmodule Explorer.Series do
       do: apply_impl(left, :gt, [right])
 
   def greater(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
+      when K.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :gt, [right])
 
   def greater(%Series{dtype: dtype} = left, right)
-      when Kernel.and(dtype in [:integer, :float], is_number(right)),
+      when K.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :gt, [right])
 
   def greater(%Series{dtype: :date} = left, %Date{} = right),
@@ -1036,11 +1037,11 @@ defmodule Explorer.Series do
       do: apply_impl(left, :gt_eq, [right])
 
   def greater_equal(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
+      when K.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :gt_eq, [right])
 
   def greater_equal(%Series{dtype: dtype} = left, right)
-      when Kernel.and(dtype in [:integer, :float], is_number(right)),
+      when K.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :gt_eq, [right])
 
   def greater_equal(%Series{dtype: :date} = left, %Date{} = right),
@@ -1081,11 +1082,11 @@ defmodule Explorer.Series do
       do: apply_impl(left, :lt, [right])
 
   def less(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
+      when K.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :lt, [right])
 
   def less(%Series{dtype: dtype} = left, right)
-      when Kernel.and(dtype in [:integer, :float], is_number(right)),
+      when K.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :lt, [right])
 
   def less(%Series{dtype: :date} = left, %Date{} = right),
@@ -1126,11 +1127,11 @@ defmodule Explorer.Series do
       do: apply_impl(left, :lt_eq, [right])
 
   def less_equal(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
+      when K.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :lt_eq, [right])
 
   def less_equal(%Series{dtype: dtype} = left, right)
-      when Kernel.and(dtype in [:integer, :float], is_number(right)),
+      when K.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :lt_eq, [right])
 
   def less_equal(%Series{dtype: :date} = left, %Date{} = right),
@@ -1158,7 +1159,7 @@ defmodule Explorer.Series do
 
   """
   def (%Series{} = left) and (%Series{} = right),
-    do: apply_impl(left, :and, [right])
+    do: apply_impl(left, :binary_and, [right])
 
   @doc """
   Returns a boolean mask of `left or right`, element-wise
@@ -1176,7 +1177,7 @@ defmodule Explorer.Series do
 
   """
   def (%Series{} = left) or (%Series{} = right),
-    do: apply_impl(left, :or, [right])
+    do: apply_impl(left, :binary_or, [right])
 
   @doc """
   Checks equality between two entire series.
@@ -1437,7 +1438,7 @@ defmodule Explorer.Series do
   defp check_types_reducer(item, {_prev, type, _types_match?}) do
     new_type = type(item) || type
 
-    if Kernel.and(new_type != type, !is_nil(type)),
+    if K.and(new_type != type, !is_nil(type)),
       do: {:halt, {item, type, false}},
       else: {:cont, {item, new_type, true}}
   end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -100,10 +100,10 @@ defmodule Explorer.Series do
         [1.0, nil, 2.5, 3.1]
       >
 
-  Mixing data types will raise an ArgumentError. 
-  
+  Mixing data types will raise an ArgumentError.
+
     iex> Explorer.Series.from_list([1, 2.9])
-      ** (ArgumentError) Cannot make a series from mismatched types. Type of 2.9 does not match inferred dtype integer.
+    ** (ArgumentError) Cannot make a series from mismatched types. Type of 2.9 does not match inferred dtype integer.
   """
   @spec from_list(list :: list(), opts :: Keyword.t()) :: Series.t()
   def from_list(list, opts \\ []) do

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -100,7 +100,9 @@ defmodule Explorer.Series do
         [1.0, nil, 2.5, 3.1]
       >
 
-  Mixing data types will raise an ArgumentError. iex> Explorer.Series.from_list([1, 2.9])
+  Mixing data types will raise an ArgumentError. 
+  
+    iex> Explorer.Series.from_list([1, 2.9])
       ** (ArgumentError) Cannot make a series from mismatched types. Type of 2.9 does not match inferred dtype integer.
   """
   @spec from_list(list :: list(), opts :: Keyword.t()) :: Series.t()

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -23,7 +23,7 @@ defmodule Explorer.Series do
 
   import Explorer.Shared, only: [impl!: 1]
   import Nx.Defn.Kernel, only: [keyword!: 2]
-  import Kernel, except: [length: 1]
+  import Kernel, except: [length: 1, and: 2]
 
   @type data :: Explorer.Backend.Series.t()
   @type dtype :: :float | :integer | :boolean | :string | :date | :datetime
@@ -99,9 +99,7 @@ defmodule Explorer.Series do
         [1.0, nil, 2.5, 3.1]
       >
 
-    Mixing data types will raise an ArgumentError.
-
-      iex> Explorer.Series.from_list([1, 2.9])
+  Mixing data types will raise an ArgumentError. iex> Explorer.Series.from_list([1, 2.9])
       ** (ArgumentError) Cannot make a series from mismatched types. Type of 2.9 does not match inferred dtype integer.
   """
   @spec from_list(list :: list(), opts :: Keyword.t()) :: Series.t()
@@ -792,15 +790,14 @@ defmodule Explorer.Series do
   """
   @spec add(left :: Series.t(), right :: Series.t() | number()) :: Series.t()
   def add(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when left_dtype in [:integer, :float] and
-             right_dtype in [:integer, :float],
+      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :add, [right])
 
   def add(%Series{dtype: left_dtype}, %Series{dtype: right_dtype}),
     do: dtype_mismatch_error("add/2", left_dtype, right_dtype)
 
   def add(%Series{dtype: dtype} = left, right)
-      when dtype in [:integer, :float] and is_number(right),
+      when Kernel.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :add, [right])
 
   def add(%Series{dtype: dtype}, _), do: dtype_error("add/2", dtype, [:integer, :float])
@@ -817,15 +814,14 @@ defmodule Explorer.Series do
   """
   @spec subtract(left :: Series.t(), right :: Series.t() | number()) :: Series.t()
   def subtract(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when left_dtype in [:integer, :float] and
-             right_dtype in [:integer, :float],
+      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :subtract, [right])
 
   def subtract(%Series{dtype: left_dtype}, %Series{dtype: right_dtype}),
     do: dtype_mismatch_error("subtract/2", left_dtype, right_dtype)
 
   def subtract(%Series{dtype: dtype} = left, right)
-      when dtype in [:integer, :float] and is_number(right),
+      when Kernel.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :subtract, [right])
 
   def subtract(%Series{dtype: dtype}, _), do: dtype_error("subtract/2", dtype, [:integer, :float])
@@ -842,15 +838,14 @@ defmodule Explorer.Series do
   """
   @spec multiply(left :: Series.t(), right :: Series.t() | number()) :: Series.t()
   def multiply(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when left_dtype in [:integer, :float] and
-             right_dtype in [:integer, :float],
+      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :multiply, [right])
 
   def multiply(%Series{dtype: left_dtype}, %Series{dtype: right_dtype}),
     do: dtype_mismatch_error("multiply/2", left_dtype, right_dtype)
 
   def multiply(%Series{dtype: dtype} = left, right)
-      when dtype in [:integer, :float] and is_number(right),
+      when Kernel.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :multiply, [right])
 
   def multiply(%Series{dtype: dtype}, _), do: dtype_error("multiply/2", dtype, [:integer, :float])
@@ -867,15 +862,14 @@ defmodule Explorer.Series do
   """
   @spec divide(left :: Series.t(), right :: Series.t() | number()) :: Series.t()
   def divide(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when left_dtype in [:integer, :float] and
-             right_dtype in [:integer, :float],
+      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :divide, [right])
 
   def divide(%Series{dtype: left_dtype}, %Series{dtype: right_dtype}),
     do: dtype_mismatch_error("divide/2", left_dtype, right_dtype)
 
   def divide(%Series{dtype: dtype} = left, right)
-      when dtype in [:integer, :float] and is_number(right),
+      when Kernel.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :divide, [right])
 
   def divide(%Series{dtype: dtype}, _), do: dtype_error("divide/2", dtype, [:integer, :float])
@@ -917,7 +911,7 @@ defmodule Explorer.Series do
     do: apply_impl(left, :eq, [right])
 
   def equal(%Series{dtype: dtype} = left, right)
-      when dtype in [:integer, :float] and is_number(right),
+      when Kernel.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :eq, [right])
 
   def equal(%Series{dtype: :date} = left, %Date{} = right),
@@ -953,7 +947,7 @@ defmodule Explorer.Series do
     do: apply_impl(left, :neq, [right])
 
   def not_equal(%Series{dtype: dtype} = left, right)
-      when dtype in [:integer, :float] and is_number(right),
+      when Kernel.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :neq, [right])
 
   def not_equal(%Series{dtype: :date} = left, %Date{} = right),
@@ -997,11 +991,11 @@ defmodule Explorer.Series do
       do: apply_impl(left, :gt, [right])
 
   def greater(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when left_dtype in [:integer, :float] and right_dtype in [:integer, :float],
+      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :gt, [right])
 
   def greater(%Series{dtype: dtype} = left, right)
-      when dtype in [:integer, :float] and is_number(right),
+      when Kernel.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :gt, [right])
 
   def greater(%Series{dtype: :date} = left, %Date{} = right),
@@ -1042,11 +1036,11 @@ defmodule Explorer.Series do
       do: apply_impl(left, :gt_eq, [right])
 
   def greater_equal(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when left_dtype in [:integer, :float] and right_dtype in [:integer, :float],
+      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :gt_eq, [right])
 
   def greater_equal(%Series{dtype: dtype} = left, right)
-      when dtype in [:integer, :float] and is_number(right),
+      when Kernel.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :gt_eq, [right])
 
   def greater_equal(%Series{dtype: :date} = left, %Date{} = right),
@@ -1087,11 +1081,11 @@ defmodule Explorer.Series do
       do: apply_impl(left, :lt, [right])
 
   def less(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when left_dtype in [:integer, :float] and right_dtype in [:integer, :float],
+      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :lt, [right])
 
   def less(%Series{dtype: dtype} = left, right)
-      when dtype in [:integer, :float] and is_number(right),
+      when Kernel.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :lt, [right])
 
   def less(%Series{dtype: :date} = left, %Date{} = right),
@@ -1132,11 +1126,11 @@ defmodule Explorer.Series do
       do: apply_impl(left, :lt_eq, [right])
 
   def less_equal(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
-      when left_dtype in [:integer, :float] and right_dtype in [:integer, :float],
+      when Kernel.and(left_dtype in [:integer, :float], right_dtype in [:integer, :float]),
       do: apply_impl(left, :lt_eq, [right])
 
   def less_equal(%Series{dtype: dtype} = left, right)
-      when dtype in [:integer, :float] and is_number(right),
+      when Kernel.and(dtype in [:integer, :float], is_number(right)),
       do: apply_impl(left, :lt_eq, [right])
 
   def less_equal(%Series{dtype: :date} = left, %Date{} = right),
@@ -1156,14 +1150,16 @@ defmodule Explorer.Series do
       iex> s1 = Explorer.Series.from_list([1, 2, 3])
       iex> mask1 = Explorer.Series.greater(s1, 1)
       iex> mask2 = Explorer.Series.less(s1, 3)
-      iex> Explorer.Series.and_(mask1, mask2)
+      iex> Explorer.Series.and(mask1, mask2)
       #Explorer.Series<
         boolean[3]
         [false, true, false]
       >
 
   """
-  def and_(%Series{} = left, %Series{} = right), do: apply_impl(left, :and_, [right])
+  def (%Series{} = left) and (%Series{} = right),
+    do: apply_impl(left, :and, [right])
+
   @doc """
   Returns a boolean mask of `left or right`, element-wise
 
@@ -1172,14 +1168,16 @@ defmodule Explorer.Series do
       iex> s1 = Explorer.Series.from_list([1, 2, 3])
       iex> mask1 = Explorer.Series.less(s1, 2)
       iex> mask2 = Explorer.Series.greater(s1, 2)
-      iex> Explorer.Series.or_(mask1, mask2)
+      iex> Explorer.Series.or(mask1, mask2)
       #Explorer.Series<
         boolean[3]
         [true, false, true]
       >
 
   """
-  def or_(%Series{} = left, %Series{} = right), do: apply_impl(left, :or_, [right])
+  def (%Series{} = left) or (%Series{} = right),
+    do: apply_impl(left, :or, [right])
+
   @doc """
   Checks equality between two entire series.
 
@@ -1439,7 +1437,7 @@ defmodule Explorer.Series do
   defp check_types_reducer(item, {_prev, type, _types_match?}) do
     new_type = type(item) || type
 
-    if new_type != type and !is_nil(type),
+    if Kernel.and(new_type != type, !is_nil(type)),
       do: {:halt, {item, type, false}},
       else: {:cont, {item, new_type, true}}
   end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -79,7 +79,7 @@ defmodule Explorer.Series do
 
   ## Options
 
-    * `:backend` - The backend to allocate the series on. 
+    * `:backend` - The backend to allocate the series on.
 
   ## Examples
 
@@ -375,10 +375,10 @@ defmodule Explorer.Series do
   def slice(series, offset, length), do: apply_impl(series, :slice, [offset, length])
 
   @doc """
-  Returns the elements at the given indices as a new series. 
+  Returns the elements at the given indices as a new series.
 
   ## Examples
-    
+
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.take(s, [0, 2])
       #Explorer.Series<
@@ -418,7 +418,7 @@ defmodule Explorer.Series do
 
     * `:integer`
     * `:float`
-    * `:boolean` 
+    * `:boolean`
 
   ## Examples
 
@@ -1148,6 +1148,38 @@ defmodule Explorer.Series do
   def less_equal(%Series{dtype: dtype}, _),
     do: dtype_error("less_equal/2", dtype, [:integer, :float, :date, :datetime])
 
+  @doc """
+  Returns a boolean mask of `left and right`, element-wise
+
+  ## Examples
+
+      iex> s1 = Explorer.Series.from_list([1, 2, 3])
+      iex> mask1 = Explorer.Series.greater(s1, 1)
+      iex> mask2 = Explorer.Series.less(s1, 3)
+      iex> Explorer.Series.and_(mask1, mask2)
+      #Explorer.Series<
+        boolean[3]
+        [false, true, false]
+      >
+
+  """
+  def and_(%Series{} = left, %Series{} = right), do: apply_impl(left, :and_, [right])
+  @doc """
+  Returns a boolean mask of `left or right`, element-wise
+
+  ## Examples
+
+      iex> s1 = Explorer.Series.from_list([1, 2, 3])
+      iex> mask1 = Explorer.Series.less(s1, 2)
+      iex> mask2 = Explorer.Series.greater(s1, 2)
+      iex> Explorer.Series.or_(mask1, mask2)
+      #Explorer.Series<
+        boolean[3]
+        [true, false, true]
+      >
+
+  """
+  def or_(%Series{} = left, %Series{} = right), do: apply_impl(left, :or_, [right])
   @doc """
   Checks equality between two entire series.
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -79,6 +79,7 @@ rustler::init!(
         df_with_column,
         // series
         s_add,
+        s_and,
         s_append,
         s_arg_true,
         s_argsort,
@@ -124,6 +125,7 @@ rustler::init!(
         s_new_str,
         s_not,
         s_null_count,
+        s_or,
         s_peak_max,
         s_peak_min,
         s_pow,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -308,6 +308,22 @@ pub fn s_not(data: ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif]
+pub fn s_and(lhs: ExSeries, rhs:ExSeries) -> Result<ExSeries, ExplorerError> {
+    let s = &lhs.resource.0;
+    let s1 = &rhs.resource.0;
+    let and = s.bool()? & s1.bool()?;
+    Ok(ExSeries::new(and.into_series()))
+}
+
+#[rustler::nif]
+pub fn s_or(lhs: ExSeries, rhs:ExSeries) -> Result<ExSeries, ExplorerError> {
+    let s = &lhs.resource.0;
+    let s1 = &rhs.resource.0;
+    let or = s.bool()? | s1.bool()?;
+    Ok(ExSeries::new(or.into_series()))
+}
+
+#[rustler::nif]
 pub fn s_len(data: ExSeries) -> Result<usize, ExplorerError> {
     let s = &data.resource.0;
     Ok(s.len())

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -308,7 +308,7 @@ pub fn s_not(data: ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif]
-pub fn s_and(lhs: ExSeries, rhs:ExSeries) -> Result<ExSeries, ExplorerError> {
+pub fn s_and(lhs: ExSeries, rhs: ExSeries) -> Result<ExSeries, ExplorerError> {
     let s = &lhs.resource.0;
     let s1 = &rhs.resource.0;
     let and = s.bool()? & s1.bool()?;
@@ -316,7 +316,7 @@ pub fn s_and(lhs: ExSeries, rhs:ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif]
-pub fn s_or(lhs: ExSeries, rhs:ExSeries) -> Result<ExSeries, ExplorerError> {
+pub fn s_or(lhs: ExSeries, rhs: ExSeries) -> Result<ExSeries, ExplorerError> {
     let s = &lhs.resource.0;
     let s1 = &rhs.resource.0;
     let or = s.bool()? | s1.bool()?;


### PR DESCRIPTION
Adds `Explorer.Series.and_/2` & `Explorer.Series.or_/2` by using `bitor/and` on the series.

closes #56 