### PR TITLE
add nil check masks to series

### DIFF
--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -101,6 +101,8 @@ defmodule Explorer.Backend.Series do
   # Nulls
 
   @callback fill_missing(s, strategy :: :backward | :forward | :min | :max | :mean) :: s
+  @callback nil?(s) :: s
+  @callback not_nil?(s) :: s
 
   # Escape hatch
 

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -320,6 +320,12 @@ defmodule Explorer.PolarsBackend.Series do
   def fill_missing(series, strategy),
     do: Shared.apply_native(series, :s_fill_none, [Atom.to_string(strategy)])
 
+  @impl true
+  def nil?(series), do: Shared.apply_native(series, :s_is_null)
+
+  @impl true
+  def not_nil?(series), do: Shared.apply_native(series, :s_is_not_null)
+
   # Escape hatch
   @impl true
   def map(series, fun), do: series |> to_list() |> Enum.map(fun) |> from_list(dtype(series))

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1396,7 +1396,38 @@ defmodule Explorer.Series do
         [1, 2, 2, 4]
       >
   """
+  @spec fill_missing(Series.t(), atom()) :: Series.t()
   def fill_missing(series, strategy), do: apply_impl(series, :fill_missing, [strategy])
+
+  @doc """
+  Returns a mask of nil values.
+
+  ## Examples
+
+      iex> s = Explorer.Series.from_list([1, 2, nil, 4])
+      iex> Explorer.Series.nil?(s)
+      #Explorer.Series<
+        boolean[4]
+        [false, false, true, false]
+      >
+  """
+  @spec nil?(Series.t()) :: Series.t()
+  def nil?(series), do: apply_impl(series, :nil?)
+
+  @doc """
+  Returns a mask of not nil values.
+
+  ## Examples
+
+      iex> s = Explorer.Series.from_list([1, 2, nil, 4])
+      iex> Explorer.Series.not_nil?(s)
+      #Explorer.Series<
+        boolean[4]
+        [true, true, false, true]
+      >
+  """
+  @spec not_nil?(Series.t()) :: Series.t()
+  def not_nil?(series), do: apply_impl(series, :not_nil?)
 
   # Helpers
 


### PR DESCRIPTION
See: tin. I wasn't sure about naming on this one. But basically it adds the ability to mask for nil/not-nil values. Very useful when doing something like:
```elixir
iex> [1, 2, nil, 3] |> Series.from_list() |> Series.filter(&Series.not_nil?/1)
#Explorer.Series<
  integer[3]
  [1, 2, 3]
>
```