### PR TITLE
use strings (not atoms) for column names in dtype specification

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -15,7 +15,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback read_csv(
               filename :: String.t(),
               names :: list(String.t()) | nil,
-              dtypes :: list(atom()) | nil,
+              dtypes :: list({String.t(), atom()}) | nil,
               delimiter :: String.t(),
               null_character :: String.t(),
               skip_rows :: Integer.t(),

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -54,7 +54,7 @@ defmodule Explorer.DataFrame do
   ## Options
 
     * `delimiter` - A single character used to separate fields within a record. (default: `","`)
-    * `dtypes` - A keyword list of `[column_name: dtype]`. If `nil`, dtypes are imputed from the first 1000 rows. (default: `nil`)
+    * `dtypes` - A list of `{"column_name", dtype}` tuples. Uses column names as read, not as defined in options. If `nil`, dtypes are imputed from the first 1000 rows. (default: `nil`)
     * `header?` - Does the file have a header of column names as the first row or not? (default: `true`)
     * `max_rows` - Maximum number of lines to read. (default: `Inf`)
     * `names` - A list of column names. Must match the width of the dataframe. (default: nil)

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -33,7 +33,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
     dtypes =
       if dtypes do
         Enum.map(dtypes, fn {colname, dtype} ->
-          {Atom.to_string(colname), Shared.internal_from_dtype(dtype)}
+          {colname, Shared.internal_from_dtype(dtype)}
         end)
       end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -92,7 +92,7 @@ defmodule Explorer.DataFrameTest do
         3,4
         """)
 
-      df = DF.read_csv!(csv, dtypes: [a: :string])
+      df = DF.read_csv!(csv, dtypes: [{"a", :string}])
 
       assert DF.to_map(df) == %{
                a: ["1", "3"],
@@ -226,7 +226,7 @@ defmodule Explorer.DataFrameTest do
         3,4
         """)
 
-      df = DF.read_csv!(csv, dtypes: [a: :string], names: ["a2", "b2"])
+      df = DF.read_csv!(csv, dtypes: [{"a", :string}], names: ["a2", "b2"])
 
       assert DF.to_map(df) == %{
                a2: ["1", "3"],


### PR DESCRIPTION
See #58