### PR TITLE
expose Series.transform/2 as an escape hatch

### DIFF
--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -106,5 +106,5 @@ defmodule Explorer.Backend.Series do
 
   # Escape hatch
 
-  @callback map(s, fun) :: s
+  @callback transform(s, fun) :: s
 end

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -328,7 +328,7 @@ defmodule Explorer.PolarsBackend.Series do
 
   # Escape hatch
   @impl true
-  def map(series, fun), do: series |> to_list() |> Enum.map(fun) |> from_list(dtype(series))
+  def transform(series, fun), do: series |> to_list() |> Enum.map(fun) |> from_list(dtype(series))
 
   # Polars specific functions
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1510,7 +1510,7 @@ defmodule Explorer.Series do
 
   defp cast_numerics(list, type) when type == :numeric do
     data =
-      Enum.map(list, fn 
+      Enum.map(list, fn
         nil -> nil
         item -> item / 1
       end)

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1442,16 +1442,21 @@ defmodule Explorer.Series do
   Returns an `Explorer.Series` where each element is the result of invoking `fun` on each 
   corresponding element of `series`.
 
+  This is an expensive operation meant to enable the use of arbitrary Elixir functions against 
+  any backend. The implementation will vary by backend but in most (all?) cases will require 
+  converting to an `Elixir.List`, applying `Enum.map/2`, and then converting back to an
+  `Explorer.Series`.
+
   ## Examples
 
       iex> s = Explorer.Series.from_list(["this ", " is", "great   "])
-      iex> Explorer.Series.map(s, &String.trim/1)
+      iex> Explorer.Series.transform(s, &String.trim/1)
       #Explorer.Series<
         string[3]
         ["this", "is", "great"]
       >
   """
-  def map(series, fun), do: apply_impl(series, :map, [fun])
+  def transform(series, fun), do: apply_impl(series, :transform, [fun])
 
   # Helpers
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1436,6 +1436,23 @@ defmodule Explorer.Series do
   @spec not_nil?(Series.t()) :: Series.t()
   def not_nil?(series), do: apply_impl(series, :not_nil?)
 
+  # Escape hatch
+
+  @doc """
+  Returns an `Explorer.Series` where each element is the result of invoking `fun` on each 
+  corresponding element of `series`.
+
+  ## Examples
+
+      iex> s = Explorer.Series.from_list(["this ", " is", "great   "])
+      iex> Explorer.Series.map(s, &String.trim/1)
+      #Explorer.Series<
+        string[3]
+        ["this", "is", "great"]
+      >
+  """
+  def map(series, fun), do: apply_impl(series, :map, [fun])
+
   # Helpers
 
   defp backend_from_options!(opts) do


### PR DESCRIPTION
I realised I never exposed this to the public-facing API. I'm not wedded to the name `map` here. Could be `apply`? Am I missing any obvious gotchas?