### PR TITLE
turned on polars decompress support for csv

### DIFF
--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "csv-core",
  "dirs 3.0.2",
  "fast-float",
+ "flate2",
  "lazy_static",
  "lexical",
  "memmap2",

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -36,5 +36,6 @@ features = [
   "strings",
   "temporal",
   "cum_agg",
-  "rolling_window"
+  "rolling_window",
+  "decompress"
 ]

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -233,6 +233,28 @@ defmodule Explorer.DataFrameTest do
                b2: [2, 4]
              }
     end
+
+    @tag :tmp_dir
+    test "automatically detects gz and uncompresses", config do
+      csv = Path.join(config.tmp_dir, "tmp.csv.gz")
+
+      :ok =
+        File.write!(
+          csv,
+          :zlib.gzip("""
+          a,b
+          1,2
+          3,4
+          """)
+        )
+
+      df = DF.read_csv!(csv)
+
+      assert DF.to_map(df) == %{
+               a: [1, 3],
+               b: [2, 4]
+             }
+    end
   end
 
   describe "parquet read and write" do


### PR DESCRIPTION
Added a test for read_csv! of a gzip compressed CSV. 

Added one line to the Cargo.toml of polars to turn on support for the decompression feature.

This should close https://github.com/elixir-nx/explorer/issues/89.