### PR TITLE
Change encode of date and datetime to use integers

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -478,7 +478,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~N[2021-01-01 00:00:00], ~N[1999-12-31 00:00:00]])
       iex> Explorer.Series.min(s)
-      ~N[1999-12-31 00:00:00]
+      ~N[1999-12-31 00:00:00.000]
 
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.min(s)
@@ -517,7 +517,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~N[2021-01-01 00:00:00], ~N[1999-12-31 00:00:00]])
       iex> Explorer.Series.max(s)
-      ~N[2021-01-01 00:00:00]
+      ~N[2021-01-01 00:00:00.000]
 
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.max(s)
@@ -668,7 +668,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~N[2021-01-01 00:00:00], ~N[1999-12-31 00:00:00]])
       iex> Explorer.Series.quantile(s, 0.5)
-      ~N[2021-01-01 00:00:00]
+      ~N[2021-01-01 00:00:00.000]
 
       iex> s = Explorer.Series.from_list([true, false, true])
       iex> Explorer.Series.quantile(s, 0.5)

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -41,8 +41,8 @@ macro_rules! init_method {
 
 init_method!(s_new_i64, i64);
 init_method!(s_new_bool, bool);
-init_method!(s_new_date32, &str, Date32Type);
-init_method!(s_new_date64, &str, Date64Type);
+init_method!(s_new_date32, i32, Date32Type);
+init_method!(s_new_date64, i64, Date64Type);
 init_method!(s_new_f64, f64);
 init_method!(s_new_str, String);
 

--- a/test/explorer/polars_backend/series_test.exs
+++ b/test/explorer/polars_backend/series_test.exs
@@ -1,0 +1,47 @@
+defmodule Explorer.PolarsBackend.SeriesTest do
+  use ExUnit.Case, async: true
+  alias Explorer.PolarsBackend.Series
+
+  test "from_list/2 of dates" do
+    dates = [~D[1643-01-04], ~D[-0030-08-12], ~D[1994-05-01]]
+
+    assert Series.from_list(dates, :date) |> Series.to_list() == dates
+
+    today_in_days = Date.utc_today() |> Date.to_gregorian_days()
+
+    dates =
+      for _i <- 0..:rand.uniform(100) do
+        days = :rand.uniform(today_in_days)
+
+        Date.from_gregorian_days(days)
+      end
+
+    assert Series.from_list(dates, :date) |> Series.to_list() == dates
+
+    dates = Enum.intersperse(dates, nil)
+    assert Series.from_list(dates, :date) |> Series.to_list() == dates
+  end
+
+  test "from_list/2 of naive datetime" do
+    dates = [~N[1022-01-04 21:18:31.224], ~N[1988-11-23 06:36:16.158], ~N[2353-03-07 00:39:35.702]]
+
+    assert Series.from_list(dates, :datetime) |> Series.to_list() == dates
+
+    today_in_days = Date.utc_today() |> Date.to_gregorian_days()
+    day_in_seconds = 86_400
+
+    dates =
+      for _i <- 0..:rand.uniform(100) do
+        days = :rand.uniform(today_in_days)
+        seconds = days * day_in_seconds
+
+        seconds
+        |> NaiveDateTime.from_gregorian_seconds({:rand.uniform(100) * 1_000, 3})
+        |> NaiveDateTime.add(:rand.uniform(24) * 60 * 60, :second)
+        |> NaiveDateTime.add(:rand.uniform(60) * 60, :second)
+        |> NaiveDateTime.add(:rand.uniform(60), :second)
+      end
+
+    assert Series.from_list(dates, :datetime) |> Series.to_list() == dates
+  end
+end


### PR DESCRIPTION
This change improves performance and reduce the memory usage.
It uses days for dates and milliseconds for date time.

cc @josevalim (the one that saw the opportunity to improvements :))

## Benchmark results

The benchmark was made using Benchee, and the following script:

```elixir
alias Explorer.PolarsBackend.Series

today_in_days = Date.utc_today() |> Date.to_gregorian_days()
day_in_seconds = 86_400

dates_fun = fn size ->
  for _i <- 0..size do
    days = :rand.uniform(today_in_days)

    NaiveDateTime.from_gregorian_seconds(days * day_in_seconds + :rand.uniform(today_in_days))
  end
end

inputs = %{
  "small" => dates_fun.(1000),
  "medium" => dates_fun.(100_000),
  "large" => dates_fun.(1_000_000)
}

Benchee.run(
  %{
    # Note that `:datetime_n` was only used for this benchmark and represents the new version. The code was reverted.
    "integer dates" => fn dates -> Series.from_list(dates, :datetime_n) |> Series.to_list() end,
    "strings dates" => fn dates -> Series.from_list(dates, :datetime) |> Series.to_list() end
  },
  inputs: inputs,
  time: 10,
  memory_time: 2
)
```

Operating System: Linux
CPU Information: AMD Ryzen 9 5950X 16-Core Processor
Number of Available Cores: 32
Available memory: 15.58 GB
Elixir 1.13.1
Erlang 24.1.5

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 2 s
parallel: 1
inputs: large, medium, small
Estimated total run time: 1.40 min

Benchmarking integer dates with input large...
Benchmarking integer dates with input medium...
Benchmarking integer dates with input small...
Benchmarking strings dates with input large...
Benchmarking strings dates with input medium...
Benchmarking strings dates with input small...

##### With input large #####
Name                    ips        average  deviation         median         99th %
integer dates          1.05         0.95 s     ±6.91%         0.96 s         1.06 s
strings dates         0.132         7.56 s     ±0.19%         7.56 s         7.57 s

Comparison:
integer dates          1.05
strings dates         0.132 - 7.94x slower +6.61 s

Memory usage statistics:

Name             Memory usage
integer dates         0.63 GB
strings dates         1.41 GB - 2.23x memory usage +0.78 GB

**All measurements for memory usage were the same**

##### With input medium #####
Name                    ips        average  deviation         median         99th %
integer dates         10.50       95.23 ms    ±15.95%       92.75 ms      178.63 ms
strings dates          1.44      695.82 ms     ±6.28%      678.94 ms      798.70 ms

Comparison:
integer dates         10.50
strings dates          1.44 - 7.31x slower +600.59 ms

Memory usage statistics:

Name             Memory usage
integer dates        64.85 MB
strings dates       145.96 MB - 2.25x memory usage +81.11 MB

**All measurements for memory usage were the same**

##### With input small #####
Name                    ips        average  deviation         median         99th %
integer dates        1.17 K        0.86 ms    ±52.06%        0.82 ms        3.26 ms
strings dates       0.153 K        6.54 ms    ±41.31%        6.00 ms       21.86 ms

Comparison:
integer dates        1.17 K
strings dates       0.153 K - 7.63x slower +5.69 ms

Memory usage statistics:

Name             Memory usage
integer dates         0.66 MB
strings dates         1.45 MB - 2.18x memory usage +0.78 MB

**All measurements for memory usage were the same**
