### PR TITLE
Remove .tool-versions from versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ explorer-*.tar
 # Allow folks to use their own .iex.exs
 .iex.exs
 
+# Allow folks to use their local .tool-versions for asdf
+.tool-versions
+
 # For the Mac users
 .DS_Store
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-elixir 1.12.1-otp-24
-erlang 24.0.2


### PR DESCRIPTION
This makes easier to develop when you are using different versions of
Elixir and OTP.