### PR TITLE
More examples for Series functions

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -338,6 +338,24 @@ defmodule Explorer.Series do
 
   @doc """
   Takes every *n*th value in this series, returned as a new series.
+
+  ## Examples
+
+      iex> s1 = 1..10 |> Enum.to_list() |> Explorer.Series.from_list()
+      iex> s1 |> Explorer.Series.take_every(2)
+      #Explorer.Series<
+        integer[5]
+        [1, 3, 5, 7, 9]
+      >
+
+    If *n* is bigger than the length of the series, the result is a new Series with only the first value of supplied one.
+
+      iex> s2 = 1..10 |> Enum.to_list() |> Explorer.Series.from_list()
+      iex> s2 |> Explorer.Series.take_every(20)
+      #Explorer.Series<
+        integer[1]
+        [1]
+      >
   """
   @spec take_every(series :: Series.t(), every_n :: integer()) :: Series.t()
   def take_every(series, every_n), do: apply_impl(series, :take_every, [every_n])

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -348,7 +348,7 @@ defmodule Explorer.Series do
         [1, 3, 5, 7, 9]
       >
 
-    If *n* is bigger than the length of the series, the result is a new Series with only the first value of supplied one.
+    If *n* is bigger than the length of the series, the result is a new series with only the first value of the supplied series.
 
       iex> s = 1..10 |> Enum.to_list() |> Explorer.Series.from_list()
       iex> s |> Explorer.Series.take_every(20)

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -905,6 +905,7 @@ defmodule Explorer.Series do
     * `:float`
 
   ## Examples
+
       iex> s1 = [10, 10 ,10] |> Explorer.Series.from_list()
       iex> s2 = [2, 2, 2] |> Explorer.Series.from_list()
       iex> Explorer.Series.divide(s1, s2)
@@ -936,7 +937,8 @@ defmodule Explorer.Series do
     * `:integer`
     * `:float`
 
-  ## Example
+  ## Examples
+
       iex> s1 = [8, 16, 32] |> Explorer.Series.from_list()
       iex> Explorer.Series.pow(s1, 2.0)
       #Explorer.Series<
@@ -1268,7 +1270,7 @@ defmodule Explorer.Series do
   @doc """
   Sorts the series.
 
-  ## Example
+  ## Examples
 
       iex> s = Explorer.Series.from_list([9, 3, 7, 1])
       iex> s |> Explorer.Series.sort()

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -341,8 +341,8 @@ defmodule Explorer.Series do
 
   ## Examples
 
-      iex> s1 = 1..10 |> Enum.to_list() |> Explorer.Series.from_list()
-      iex> s1 |> Explorer.Series.take_every(2)
+      iex> s = 1..10 |> Enum.to_list() |> Explorer.Series.from_list()
+      iex> s |> Explorer.Series.take_every(2)
       #Explorer.Series<
         integer[5]
         [1, 3, 5, 7, 9]
@@ -350,8 +350,8 @@ defmodule Explorer.Series do
 
     If *n* is bigger than the length of the series, the result is a new Series with only the first value of supplied one.
 
-      iex> s2 = 1..10 |> Enum.to_list() |> Explorer.Series.from_list()
-      iex> s2 |> Explorer.Series.take_every(20)
+      iex> s = 1..10 |> Enum.to_list() |> Explorer.Series.from_list()
+      iex> s |> Explorer.Series.take_every(20)
       #Explorer.Series<
         integer[1]
         [1]

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -762,6 +762,22 @@ defmodule Explorer.Series do
     * `:integer`
     * `:float`
     * `:boolean`
+
+  ## Examples
+
+      iex> s = [1, 2, 3, 4] |> Explorer.Series.from_list()
+      iex> Explorer.Series.cum_sum(s)
+      #Explorer.Series<
+        integer[4]
+        [1, 3, 6, 10]
+      >
+
+      iex> s = [1, 2, nil, 4] |> Explorer.Series.from_list()
+      iex> Explorer.Series.cum_sum(s)
+      #Explorer.Series<
+        integer[4]
+        [1, 3, nil, 7]
+      >
   """
   @spec cum_sum(series :: Series.t(), reverse? :: boolean()) :: Series.t()
   def cum_sum(series, reverse? \\ false)

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -869,6 +869,15 @@ defmodule Explorer.Series do
 
     * `:integer`
     * `:float`
+
+  ## Examples
+      iex> s1 = [10, 10 ,10] |> Explorer.Series.from_list()
+      iex> s2 = [2, 2, 2] |> Explorer.Series.from_list()
+      #Explorer.Series<
+        integer[3]
+        [5, 5, 5]
+      >
+
   """
   @spec divide(left :: Series.t(), right :: Series.t() | number()) :: Series.t()
   def divide(%Series{dtype: left_dtype} = left, %Series{dtype: right_dtype} = right)
@@ -1485,11 +1494,11 @@ defmodule Explorer.Series do
   # Escape hatch
 
   @doc """
-  Returns an `Explorer.Series` where each element is the result of invoking `fun` on each 
+  Returns an `Explorer.Series` where each element is the result of invoking `fun` on each
   corresponding element of `series`.
 
-  This is an expensive operation meant to enable the use of arbitrary Elixir functions against 
-  any backend. The implementation will vary by backend but in most (all?) cases will require 
+  This is an expensive operation meant to enable the use of arbitrary Elixir functions against
+  any backend. The implementation will vary by backend but in most (all?) cases will require
   converting to an `Elixir.List`, applying `Enum.map/2`, and then converting back to an
   `Explorer.Series`.
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -873,6 +873,7 @@ defmodule Explorer.Series do
   ## Examples
       iex> s1 = [10, 10 ,10] |> Explorer.Series.from_list()
       iex> s2 = [2, 2, 2] |> Explorer.Series.from_list()
+      iex> Explorer.Series.divide(s1, s2)
       #Explorer.Series<
         integer[3]
         [5, 5, 5]
@@ -900,6 +901,14 @@ defmodule Explorer.Series do
 
     * `:integer`
     * `:float`
+
+  ## Example
+      iex> s1 = [8, 16, 32] |> Explorer.Series.from_list()
+      iex> Explorer.Series.pow(s1, 2.0)
+      #Explorer.Series<
+        float[3]
+        [64.0, 256.0, 1024.0]
+      >
   """
   @spec pow(series :: Series.t(), exponent :: number()) :: Series.t()
   def pow(%Series{dtype: dtype} = series, exponent) when dtype in [:integer, :float],
@@ -1224,6 +1233,16 @@ defmodule Explorer.Series do
 
   @doc """
   Sorts the series.
+
+  ## Example
+
+      iex> s = Explorer.Series.from_list([9, 3, 7, 1])
+      iex> s |> Explorer.Series.sort()
+      #Explorer.Series<
+        integer[4]
+        [1, 3, 7, 9]
+      >
+
   """
   def sort(series, reverse? \\ false), do: apply_impl(series, :sort, [reverse?])
 
@@ -1233,7 +1252,16 @@ defmodule Explorer.Series do
   def argsort(series, reverse? \\ false), do: apply_impl(series, :argsort, [reverse?])
 
   @doc """
-  Reverses the series.
+  Reverses the series order.
+
+  ## Example
+
+      iex> s = [1, 2, 3] |> Explorer.Series.from_list()
+      iex> Explorer.Series.reverse(s)
+      #Explorer.Series<
+        integer[3]
+        [3, 2, 1]
+      >
   """
   def reverse(series), do: apply_impl(series, :reverse)
 


### PR DESCRIPTION
It adds examples for: `Series.(divide|reverse|sort|pow|take_every|cum_sum)`.

Sending examples while trying to understand how the Rust-Elixir interop works :)