### PR TITLE
Explorer.Series.pow integer support

### DIFF
--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -144,6 +144,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_peak_max(_s), do: err()
   def s_peak_min(_s), do: err()
   def s_pow(_s, _exponent), do: err()
+  def s_int_pow(_s, _exponent), do: err()
   def s_quantile(_s, _quantile), do: err()
   def s_rechunk(_s), do: err()
   def s_rename(_s, _name), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -235,9 +235,11 @@ defmodule Explorer.PolarsBackend.Series do
   def divide(left, right) when is_number(right), do: divide(left, scalar_rhs(right, left))
 
   @impl true
-  def pow(left, exponent) when is_number(exponent),
+  def pow(left, exponent) when is_float(exponent),
     do: Shared.apply_native(left, :s_pow, [exponent])
 
+  def pow(left, exponent) when is_integer(exponent),
+    do: Shared.apply_native(left, :s_int_pow, [exponent])
   # Comparisons
 
   @impl true

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -235,9 +235,7 @@ defmodule Explorer.PolarsBackend.Series do
   def divide(left, right) when is_number(right), do: divide(left, scalar_rhs(right, left))
 
   @impl true
-  def pow(left, exponent) when is_float(exponent) do
-        Shared.apply_native(left, :s_pow, [exponent])
-  end
+  def pow(left, exponent) when is_float(exponent), do: Shared.apply_native(left, :s_pow, [exponent])
 
   def pow(left, exponent) when is_integer(exponent) and exponent >= 0 do
     cond do

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -238,7 +238,7 @@ defmodule Explorer.PolarsBackend.Series do
   def pow(left, exponent) when is_float(exponent),
     do: Shared.apply_native(left, :s_pow, [exponent])
 
-  def pow(left, exponent) when is_integer(exponent),
+  def pow(left, exponent) when is_integer(exponent) and exponent >= 0,
     do: Shared.apply_native(left, :s_int_pow, [exponent])
   # Comparisons
 

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -235,11 +235,18 @@ defmodule Explorer.PolarsBackend.Series do
   def divide(left, right) when is_number(right), do: divide(left, scalar_rhs(right, left))
 
   @impl true
-  def pow(left, exponent) when is_float(exponent),
-    do: Shared.apply_native(left, :s_pow, [exponent])
+  def pow(left, exponent) when is_float(exponent) do
+        Shared.apply_native(left, :s_pow, [exponent])
+  end
 
-  def pow(left, exponent) when is_integer(exponent) and exponent >= 0,
-    do: Shared.apply_native(left, :s_int_pow, [exponent])
+  def pow(left, exponent) when is_integer(exponent) and exponent >= 0 do
+    cond do
+     Series.dtype(left) == :integer -> Shared.apply_native(left, :s_int_pow, [exponent])
+     Series.dtype(left) == :float -> Shared.apply_native(left, :s_pow, [exponent/1])
+    end
+  end
+
+
   # Comparisons
 
   @impl true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1485,11 +1485,11 @@ defmodule Explorer.Series do
   # Escape hatch
 
   @doc """
-  Returns an `Explorer.Series` where each element is the result of invoking `fun` on each 
+  Returns an `Explorer.Series` where each element is the result of invoking `fun` on each
   corresponding element of `series`.
 
-  This is an expensive operation meant to enable the use of arbitrary Elixir functions against 
-  any backend. The implementation will vary by backend but in most (all?) cases will require 
+  This is an expensive operation meant to enable the use of arbitrary Elixir functions against
+  any backend. The implementation will vary by backend but in most (all?) cases will require
   converting to an `Elixir.List`, applying `Enum.map/2`, and then converting back to an
   `Explorer.Series`.
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -998,7 +998,7 @@ defmodule Explorer.Series do
       iex> Explorer.Series.pow(s, -3.0)
       #Explorer.Series<
         float[3]
-        [1.0, 0.125, 0.037037037037037035]
+        [0.125, 0.015625, 0.004629629629629629]
       >
   """
   @spec pow(series :: Series.t(), exponent :: number()) :: Series.t()

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -980,11 +980,18 @@ defmodule Explorer.Series do
 
   ## Examples
 
-      iex> s1 = [8, 16, 32] |> Explorer.Series.from_list()
-      iex> Explorer.Series.pow(s1, 2.0)
+      iex> s = [8, 16, 32] |> Explorer.Series.from_list()
+      iex> Explorer.Series.pow(s, 2.0)
       #Explorer.Series<
         float[3]
         [64.0, 256.0, 1024.0]
+      >
+
+      iex> s = [2, 4, 6] |> Explorer.Series.from_list()
+      iex> Explorer.Series.pow(s, 3)
+      #Explorer.Series<
+        integer[3]
+        [8, 64, 216]
       >
   """
   @spec pow(series :: Series.t(), exponent :: number()) :: Series.t()

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1007,6 +1007,13 @@ defmodule Explorer.Series do
         float[3]
         [1.0, 8.0, 27.0]
       >
+
+      iex> s = [2.0, 4.0, 6.0] |> Explorer.Series.from_list()
+      iex> s |> Explorer.Series.pow(2)
+      #Explorer.Series<
+        float[3]
+        [4.0, 16.0, 36.0]
+      >
   """
   @spec pow(series :: Series.t(), exponent :: number()) :: Series.t()
   def pow(%Series{dtype: dtype} = series, exponent) when dtype in [:integer, :float],

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -993,6 +993,13 @@ defmodule Explorer.Series do
         integer[3]
         [8, 64, 216]
       >
+
+      iex> s = [2, 4, 6] |> Explorer.Series.from_list()
+      iex> Explorer.Series.pow(s, -3.0)
+      #Explorer.Series<
+        float[3]
+        [1.0, 0.125, 0.037037037037037035]
+      >
   """
   @spec pow(series :: Series.t(), exponent :: number()) :: Series.t()
   def pow(%Series{dtype: dtype} = series, exponent) when dtype in [:integer, :float],

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1000,6 +1000,13 @@ defmodule Explorer.Series do
         float[3]
         [0.125, 0.015625, 0.004629629629629629]
       >
+
+      iex> s = [1.0, 2.0, 3.0] |> Explorer.Series.from_list()
+      iex> s |> Explorer.Series.pow(3.0)
+      #Explorer.Series<
+        float[3]
+        [1.0, 8.0, 27.0]
+      >
   """
   @spec pow(series :: Series.t(), exponent :: number()) :: Series.t()
   def pow(%Series{dtype: dtype} = series, exponent) when dtype in [:integer, :float],

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -130,6 +130,7 @@ rustler::init!(
         s_peak_max,
         s_peak_min,
         s_pow,
+        s_int_pow,
         s_quantile,
         s_rechunk,
         s_rename,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -709,6 +709,14 @@ pub fn s_pow(data: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif]
+pub fn s_int_pow(data: ExSeries, exponent: i64) -> Result<ExSeries, ExplorerError> {
+    let s = &data.resource.0;
+    let s = s.i64()?.apply(|v| v.pow(exponent as u32)).into_series();
+
+    Ok(ExSeries::new(s))
+}
+
+#[rustler::nif]
 pub fn s_cast(data: ExSeries, to_type: &str) -> Result<ExSeries, ExplorerError> {
     let s = &data.resource.0;
     Ok(ExSeries::new(cast(s, to_type)?))

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -712,7 +712,6 @@ pub fn s_pow(data: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
 pub fn s_int_pow(data: ExSeries, exponent: i64) -> Result<ExSeries, ExplorerError> {
     let s = &data.resource.0;
     let s = s.i64()?.apply(|v| v.pow(exponent as u32)).into_series();
-
     Ok(ExSeries::new(s))
 }
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -705,7 +705,11 @@ pub fn s_n_unique(data: ExSeries) -> Result<usize, ExplorerError> {
 #[rustler::nif]
 pub fn s_pow(data: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
     let s = &data.resource.0;
-    Ok(ExSeries::new(s.pow(exponent)?))
+    let s = cast(s, "float")?
+        .f64()?
+        .apply(|v| v.powf(exponent))
+        .into_series();
+    Ok(ExSeries::new(s))
 }
 
 #[rustler::nif]

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -709,9 +709,9 @@ pub fn s_pow(data: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif]
-pub fn s_int_pow(data: ExSeries, exponent: i64) -> Result<ExSeries, ExplorerError> {
+pub fn s_int_pow(data: ExSeries, exponent: u32) -> Result<ExSeries, ExplorerError> {
     let s = &data.resource.0;
-    let s = s.i64()?.apply(|v| v.pow(exponent as u32)).into_series();
+    let s = s.i64()?.apply(|v| v.pow(exponent)).into_series();
     Ok(ExSeries::new(s))
 }
 


### PR DESCRIPTION
Adds support for Integers on Series.pow()

The version in this PR supports only positive integers. 

This pull request, when completed, closes #105. 