### PR TITLE
add mix format check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 env:
-  ELIXIR_VERSION: 1.12
-  OTP_VERSION: 24.0
+  ELIXIR_VERSION: 1.13
+  OTP_VERSION: 24.2
   MIX_ENV: test
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,13 @@ jobs:
       - run: mix deps.get
       - run: mix compile --warnings-as-errors
       - run: mix test --warnings-as-errors
+  format:
+    runs-on: ubuntu-latest
+    name: mix format
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "${{ env.OTP_VERSION }}"
+          elixir-version: "${{ env.ELIXIR_VERSION }}"
+      - run: mix format --check-formatted

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ELIXIR_VERSION: 1.12
-  OTP_VERSION: 24.0
+  ELIXIR_VERSION: 1.13
+  OTP_VERSION: 24.2
 
 jobs:
   deploy:


### PR DESCRIPTION
As on the tin. This adds a CI check for `mix format`. Also bumps Elixir and OTP versions for the CI.