### PR TITLE
Parse dates and limit infer schema row number exposed

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -22,7 +22,9 @@ defmodule Explorer.Backend.DataFrame do
               header? :: boolean(),
               encoding :: String.t(),
               max_rows :: Integer.t() | Inf,
-              with_columns :: list(String.t()) | nil
+              with_columns :: list(String.t()) | nil,
+              infer_schema_length :: Integer.t() | nil,
+              parse_dates :: boolean()
             ) :: result(df)
   @callback write_csv(df, filename :: String.t(), header? :: boolean(), delimiter :: String.t()) ::
               result(String.t())

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -13,6 +13,7 @@ defmodule Explorer.DataFrame do
   @type t :: %DataFrame{data: data}
 
   @enforce_keys [:data, :groups]
+  @default_infer_schema_length 1000
   defstruct [:data, :groups]
 
   # Access
@@ -61,6 +62,8 @@ defmodule Explorer.DataFrame do
     * `null_character` - The string that should be interpreted as a nil value. (default: `"NA"`)
     * `skip_rows` - The number of lines to skip at the beginning of the file. (default: `0`)
     * `with_columns` - A list of column names to keep. If present, only these columns are read into the dataframe. (default: `nil`)
+    * `infer_schema_length` Maximum number of rows read for schema inference. Setting this to nil will do a full table scan and will be slow (default: `1000`).
+    * `parse_dates` - Automatically try to parse dates/ datetimes and time. If parsing fails, columns remain of dtype `[DataType::Utf8]
   """
   @spec read_csv(filename :: String.t(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}
@@ -75,7 +78,9 @@ defmodule Explorer.DataFrame do
         names: nil,
         null_character: "NA",
         skip_rows: 0,
-        with_columns: nil
+        with_columns: nil,
+        infer_schema_length: @default_infer_schema_length,
+        parse_dates: false
       )
 
     backend = backend_from_options!(opts)
@@ -90,7 +95,9 @@ defmodule Explorer.DataFrame do
       opts[:header?],
       opts[:encoding],
       opts[:max_rows],
-      opts[:with_columns]
+      opts[:with_columns],
+      opts[:infer_schema_length],
+      opts[:parse_dates]
     )
   end
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -13,6 +13,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @behaviour Explorer.Backend.DataFrame
 
+  @default_infer_schema_length 1000
+
   # IO
 
   @impl true
@@ -26,9 +28,16 @@ defmodule Explorer.PolarsBackend.DataFrame do
         header?,
         encoding,
         max_rows,
-        with_columns
+        with_columns,
+        infer_schema_length,
+        parse_dates
       ) do
     max_rows = if max_rows == Inf, do: nil, else: max_rows
+
+    infer_schema_length =
+      if infer_schema_length == nil,
+        do: max_rows || @default_infer_schema_length,
+        else: infer_schema_length
 
     dtypes =
       if dtypes do
@@ -40,7 +49,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
     df =
       Native.df_read_csv(
         filename,
-        1000,
+        infer_schema_length,
         header?,
         max_rows,
         skip_rows,
@@ -50,7 +59,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
         with_columns,
         dtypes,
         encoding,
-        null_character
+        null_character,
+        parse_dates
       )
 
     case {df, names} do

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -19,7 +19,8 @@ defmodule Explorer.PolarsBackend.Native do
         _with_columns,
         _dtypes,
         _encoding,
-        _null_char
+        _null_char,
+        _parse_dates
       ),
       do: err()
 

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -44,6 +44,7 @@ pub fn df_read_csv(
     dtypes: Option<Vec<(&str, &str)>>,
     encoding: &str,
     null_char: String,
+    parse_dates: bool,
 ) -> Result<ExDataFrame, ExplorerError> {
     let encoding = match encoding {
         "utf8-lossy" => CsvEncoding::LossyUtf8,
@@ -62,6 +63,7 @@ pub fn df_read_csv(
     let df = CsvReader::from_path(filename)?
         .infer_schema(infer_schema_length)
         .has_header(has_header)
+        .with_parse_dates(parse_dates)
         .with_stop_after_n_rows(stop_after_n_rows)
         .with_delimiter(sep.as_bytes()[0])
         .with_skip_rows(skip_rows)

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -102,6 +102,44 @@ defmodule Explorer.DataFrameTest do
     end
 
     @tag :tmp_dir
+    test "dtypes - parse datetime", config do
+      csv =
+        tmp_csv(config.tmp_dir, """
+        a,b,c
+        1,2,"2020-10-15 00:00:01",
+        3,4,2020-10-15 00:00:18
+        """)
+
+      df = DF.read_csv!(csv, parse_dates: true)
+      assert [:datetime] = DF.select(df, ["c"]) |> Explorer.DataFrame.dtypes()
+
+      assert DF.to_map(df) == %{
+               a: [1, 3],
+               b: [2, 4],
+               c: [~N[2020-10-15 00:00:01.000], ~N[2020-10-15 00:00:18.000]]
+             }
+    end
+
+    @tag :tmp_dir
+    test "dtypes - do not parse datetime(default)", config do
+      csv =
+        tmp_csv(config.tmp_dir, """
+        a,b,c
+        1,2,"2020-10-15 00:00:01",
+        3,4,2020-10-15 00:00:18
+        """)
+
+      df = DF.read_csv!(csv, parse_dates: false)
+      assert [:string] = DF.select(df, ["c"]) |> Explorer.DataFrame.dtypes()
+
+      assert DF.to_map(df) == %{
+               a: [1, 3],
+               b: [2, 4],
+               c: ["2020-10-15 00:00:01", "2020-10-15 00:00:18"]
+             }
+    end
+
+    @tag :tmp_dir
     test "header?", config do
       csv =
         tmp_csv(config.tmp_dir, """


### PR DESCRIPTION
This PR exposing parse_dates and infer_schema_length options that polar-rs lib supports. 