### PR TITLE
parse date and datetime in rust

### DIFF
--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -15,53 +15,28 @@ defmodule Explorer.PolarsBackend.Series do
 
   @behaviour Explorer.Backend.Series
 
-  @unix_epoch_in_gregorian_days 719_528
-  @unix_epoch_in_gregorian_secs 62_167_219_200
-
   # Conversion
 
   @impl true
   def from_list(data, type, name \\ "") when is_list(data) do
     series =
       case type do
-        :integer ->
-          Native.s_new_i64(name, data)
-
-        :float ->
-          Native.s_new_f64(name, data)
-
-        :boolean ->
-          Native.s_new_bool(name, data)
-
-        :string ->
-          Native.s_new_str(name, data)
-
-        :date ->
-          data
-          |> Enum.map(&encode_date/1)
-          |> then(&Native.s_new_date32(name, &1))
-
-        :datetime ->
-          data
-          |> Enum.map(&encode_datetime/1)
-          |> then(&Native.s_new_date64(name, &1))
+        :integer -> Native.s_new_i64(name, data)
+        :float -> Native.s_new_f64(name, data)
+        :boolean -> Native.s_new_bool(name, data)
+        :string -> Native.s_new_str(name, data)
+        :date -> Native.s_new_date32(name, data)
+        :datetime -> Native.s_new_date64(name, data)
       end
 
     %Series{data: series, dtype: type}
   end
 
   @impl true
-  def to_list(%Series{data: series, dtype: dtype}) do
-    list =
-      case Native.s_to_list(series) do
-        {:ok, list} -> list
-        {:error, e} -> raise "#{e}"
-      end
-
-    case dtype do
-      :date -> Enum.map(list, &decode_date/1)
-      :datetime -> Enum.map(list, &decode_datetime/1)
-      _ -> list
+  def to_list(%Series{data: series}) do
+    case Native.s_to_list(series) do
+      {:ok, list} -> list
+      {:error, e} -> raise "#{e}"
     end
   end
 
@@ -115,15 +90,9 @@ defmodule Explorer.PolarsBackend.Series do
     do: Shared.apply_native(series, :s_take, [indices])
 
   @impl true
-  def get(%Series{dtype: dtype} = series, idx) do
+  def get(series, idx) do
     idx = if idx < 0, do: length(series) + idx, else: idx
-    value = Shared.apply_native(series, :s_get, [idx])
-
-    case dtype do
-      :date -> decode_date(value)
-      :datetime -> decode_datetime(value)
-      _ -> value
-    end
+    Shared.apply_native(series, :s_get, [idx])
   end
 
   # Aggregation
@@ -132,33 +101,9 @@ defmodule Explorer.PolarsBackend.Series do
   def sum(series), do: Shared.apply_native(series, :s_sum)
 
   @impl true
-  def min(%Series{dtype: :date} = series),
-    do:
-      series
-      |> Shared.apply_native(:s_min)
-      |> decode_date()
-
-  def min(%Series{dtype: :datetime} = series),
-    do:
-      series
-      |> Shared.apply_native(:s_min)
-      |> decode_datetime()
-
   def min(series), do: Shared.apply_native(series, :s_min)
 
   @impl true
-  def max(%Series{dtype: :date} = series),
-    do:
-      series
-      |> Shared.apply_native(:s_max)
-      |> decode_date()
-
-  def max(%Series{dtype: :datetime} = series),
-    do:
-      series
-      |> Shared.apply_native(:s_max)
-      |> decode_datetime()
-
   def max(series), do: Shared.apply_native(series, :s_max)
 
   @impl true
@@ -174,22 +119,7 @@ defmodule Explorer.PolarsBackend.Series do
   def std(series), do: Shared.apply_native(series, :s_std)
 
   @impl true
-  def quantile(%{dtype: dtype} = series, quantile) when dtype in [:date, :datetime] do
-    series
-    |> cast(:integer)
-    |> Shared.apply_native(:s_quantile, [quantile])
-    |> get(0)
-    |> then(fn value ->
-      case dtype do
-        :date -> decode_date(value)
-        :datetime -> decode_datetime(value)
-      end
-    end)
-  end
-
-  def quantile(series, quantile) do
-    series |> Shared.apply_native(:s_quantile, [quantile]) |> get(0)
-  end
+  def quantile(series, quantile), do: Shared.apply_native(series, :s_quantile, [quantile])
 
   # Cumulative
 
@@ -396,30 +326,6 @@ defmodule Explorer.PolarsBackend.Series do
       scalar
       |> List.duplicate(PolarsSeries.length(lhs))
       |> Series.from_list()
-
-  defp encode_date(%Date{} = date) do
-    Date.to_gregorian_days(date) - @unix_epoch_in_gregorian_days
-  end
-
-  defp encode_date(date) when is_nil(date), do: nil
-
-  defp encode_datetime(%module{} = datetime) when module in [NaiveDateTime, DateTime] do
-    {secs, microsecs} = module.to_gregorian_seconds(datetime)
-
-    (secs - @unix_epoch_in_gregorian_secs) * 1_000 + div(microsecs, 1000)
-  end
-
-  defp encode_datetime(datetime) when is_nil(datetime), do: nil
-
-  defp decode_date(date) when is_integer(date), do: Date.add(~D[1970-01-01], date)
-  defp decode_date(date) when is_nil(date), do: nil
-
-  # Note that we lost microseconds in the conversion, since Polars only works with milliseconds.
-  defp decode_datetime(epoch_date_in_ms) when is_integer(epoch_date_in_ms) do
-    DateTime.from_unix!(epoch_date_in_ms, :millisecond) |> DateTime.to_naive()
-  end
-
-  defp decode_datetime(date) when is_nil(date), do: nil
 end
 
 defimpl Inspect, for: Explorer.PolarsBackend.Series do

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -377,6 +377,7 @@ name = "explorer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "mimalloc",
  "polars",
  "rand",

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -1219,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "rustler"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b787d3b2a80007f41cd4c0c310cdeb3936192768159585f65ecc7e96faf97fc3"
+checksum = "8ac79e5fcfae809c16ff8da548daa291933b7ec8d66eadc197cdccec46891625"
 dependencies = [
  "lazy_static",
  "rustler_codegen",
@@ -1230,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "rustler_codegen"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a1f867002b6f0130f47abf215cac4405646db6f5d7b009b21c890980490aa4"
+checksum = "10d303c303a145c1f3d2a2993527128badb9500101070c55e36ef9bb2417666a"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -15,7 +15,7 @@ chrono = "0.4"
 mimalloc = { version = "*", default-features = false }
 rand = { version = "0.8.4", features = ["alloc"] }
 rand_pcg = "0.3.1"
-rustler = "0.22.0"
+rustler = "0.23.0"
 thiserror = "1"
 
 [dependencies.polars]

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -10,12 +10,13 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-rustler = "0.22.0"
-thiserror = "1"
 anyhow = "1"
+chrono = "0.4"
 mimalloc = { version = "*", default-features = false }
 rand = { version = "0.8.4", features = ["alloc"] }
 rand_pcg = "0.3.1"
+rustler = "0.22.0"
+thiserror = "1"
 
 [dependencies.polars]
 version = "0.18.0"

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -1,9 +1,13 @@
+use chrono::prelude::*;
 use polars::prelude::*;
 use rustler::resource::ResourceArc;
-use rustler::{Encoder, Env, NifStruct, Term};
+use rustler::{Atom, Encoder, Env, NifMap, NifStruct, Term};
+use std::convert::TryInto;
 use std::sync::RwLock;
 
 use std::result::Result;
+
+use crate::atoms;
 
 pub struct ExDataFrameRef(pub RwLock<DataFrame>);
 pub struct ExSeriesRef(pub Series);
@@ -46,6 +50,112 @@ impl ExSeries {
             resource: ResourceArc::new(ExSeriesRef::new(s)),
         }
     }
+}
+
+#[derive(NifMap)]
+pub struct ExDate {
+    pub __struct__: Atom,
+    pub calendar: Atom,
+    pub day: u32,
+    pub month: u32,
+    pub year: i32,
+}
+
+impl ExDate {
+    fn new_from_chrono(d: NaiveDate) -> Self {
+        ExDate {
+            __struct__: atoms::date(),
+            calendar: atoms::calendar(),
+            day: d.day(),
+            month: d.month(),
+            year: d.year(),
+        }
+    }
+
+    pub fn new_from_days(ts: i32) -> Self {
+        let seconds = ts * 86_400;
+        let dt = NaiveDateTime::from_timestamp(seconds.into(), 0);
+        ExDate::new_from_chrono(NaiveDate::from_yo(dt.year(), dt.ordinal()))
+    }
+
+    pub fn to_days(&self) -> i32 {
+        NaiveDate::from_ymd(self.year, self.month, self.day)
+            .signed_duration_since(NaiveDate::from_ymd(1970, 1, 1))
+            .num_days()
+            .try_into()
+            .unwrap()
+    }
+}
+
+fn encode_date<'b>(s: &Series, env: Env<'b>) -> Term<'b> {
+    s.date()
+        .unwrap()
+        .as_date_iter()
+        .map(|d| d.map(ExDate::new_from_chrono))
+        .collect::<Vec<Option<ExDate>>>()
+        .encode(env)
+}
+
+#[derive(NifMap)]
+pub struct ExDateTime {
+    pub __struct__: Atom,
+    pub calendar: Atom,
+    pub day: u32,
+    pub month: u32,
+    pub year: i32,
+    pub hour: u32,
+    pub minute: u32,
+    pub second: u32,
+    pub microsecond: (u32, u32),
+}
+
+impl ExDateTime {
+    fn new_from_chrono(dt: NaiveDateTime) -> Self {
+        ExDateTime {
+            __struct__: atoms::datetime(),
+            calendar: atoms::calendar(),
+            day: dt.day(),
+            month: dt.month(),
+            year: dt.year(),
+            hour: dt.hour(),
+            minute: dt.minute(),
+            second: dt.second(),
+            microsecond: (dt.timestamp_subsec_micros(), 3),
+        }
+    }
+
+    pub fn new_from_milliseconds(ms: i64) -> Self {
+        let sign = ms.signum();
+        let seconds = match sign {
+            -1 => ms / 1_000 - 1,
+            _ => ms / 1_000,
+        };
+        let remainder = match sign {
+            -1 => 1_000 + ms % 1_000,
+            _ => ms % 1_000,
+        };
+        let nanoseconds = remainder.abs() * 1_000_000;
+        ExDateTime::new_from_chrono(NaiveDateTime::from_timestamp(
+            seconds,
+            nanoseconds.try_into().unwrap(),
+        ))
+    }
+
+    pub fn to_milliseconds(&self) -> i64 {
+        NaiveDate::from_ymd(self.year, self.month, self.day)
+            .and_hms_micro(self.hour, self.minute, self.second, self.microsecond.0)
+            .signed_duration_since(NaiveDate::from_ymd(1970, 1, 1).and_hms(0, 0, 0))
+            .num_milliseconds()
+    }
+}
+
+fn encode_datetime<'b>(s: &Series, env: Env<'b>) -> Term<'b> {
+    s.datetime()
+        .unwrap()
+        .into_iter()
+        .map(|d| d.map(ExDateTime::new_from_milliseconds))
+        .collect::<Vec<Option<ExDateTime>>>()
+        .encode(env)
 }
 
 macro_rules! encode {
@@ -99,8 +209,8 @@ impl<'a> Encoder for ExSeriesRef {
             DataType::Int64 => encode!(s, env, i64),
             DataType::UInt32 => encode!(s, env, u32),
             DataType::Float64 => encode!(s, env, f64),
-            DataType::Date => encode!(s, env, date, i32),
-            DataType::Datetime => encode!(s, env, datetime, i64),
+            DataType::Date => encode_date(s, env),
+            DataType::Datetime => encode_datetime(s, env),
             DataType::List(t) if t as &DataType == &DataType::UInt32 => {
                 encode_list!(s, env, u32, u32)
             }

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -20,6 +20,14 @@ fn on_load(env: Env, _info: Term) -> bool {
     true
 }
 
+mod atoms {
+    rustler::atoms! {
+        date = "Elixir.Date",
+        datetime = "Elixir.NaiveDateTime",
+        calendar = "Elixir.Calendar.ISO"
+    }
+}
+
 rustler::init!(
     "Elixir.Explorer.PolarsBackend.Native",
     [


### PR DESCRIPTION
This changes date and datetime serialisation/deserialisation so we don't have to translate both ways on the Elixir side.

Notably, this avoids traversing the `Series` when using `to_list` by deserialising dates directly to `Date` and `NaiveDateTime` structs via `NifMap`

## Riders
- I've also fixed `s_quantile` to call `get` directly and avoid a copy of the series
- I've bumped the Rust dep on `rustler` to `0.23.0` to follow the `mix` deps
- I've added a dependency on `chrono` on the Rust side