### PR TITLE
Add workflow for building precompiled NIFs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,176 @@
+name: Build precompiled NIFs
+
+env:
+  NIF_DIRECTORY: "native/explorer"
+
+on:
+  push:
+    branches:
+      - main
+      - ps-add-precompilation-support
+    tags:
+      - '*'
+
+defaults:
+  run:
+    # Sets the working dir for "run" scripts.
+    # Note that this won't change the directory for actions (tasks with "uses").
+    working-directory: "./native/explorer"
+
+jobs:
+  build_release:
+    name: NIF ${{ matrix.job.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          # NIF version 2.16
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.16", use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , nif: "2.16", use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-11     , nif: "2.16" }
+          - { target: x86_64-apple-darwin         , os: macos-11     , nif: "2.16" }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.16" }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , nif: "2.16", use-cross: true }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019 , nif: "2.16" }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.16" }
+          # NIF version 2.15
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.15", use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , nif: "2.15", use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-11     , nif: "2.15" }
+          - { target: x86_64-apple-darwin         , os: macos-11     , nif: "2.15" }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.15" }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , nif: "2.15", use-cross: true }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019 , nif: "2.15" }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.15" }
+          # # NIF version 2.14
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.14", use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , nif: "2.14", use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-11     , nif: "2.14" }
+          - { target: x86_64-apple-darwin         , os: macos-11     , nif: "2.14" }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.14" }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , nif: "2.14", use-cross: true }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019 , nif: "2.14" }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.14" }
+
+    env:
+      RUSTLER_NIF_VERSION: ${{ matrix.job.nif }}
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+
+    - name: Install prerequisites
+      shell: bash
+      run: |
+        case ${{ matrix.job.target }} in
+          arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
+        esac
+
+    - name: Extract crate information
+      shell: bash
+      run: |
+        echo "PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
+        # Get the project version from mix.exs
+        echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' ../../mix.exs | head -n1)" >> $GITHUB_ENV
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.job.target }}
+        override: true
+        profile: minimal
+
+    - name: Show version information (Rust, cargo, GCC)
+      shell: bash
+      run: |
+        gcc --version || true
+        rustup -V
+        rustup toolchain list
+        rustup default
+        cargo -V
+        rustc -V
+        rustc --print=cfg
+
+    - name: Download cross from GitHub releases
+      uses: giantswarm/install-binary-action@v1.0.0
+      if: ${{ matrix.job.use-cross }}
+      with:
+        binary: "cross"
+        version: "v0.2.1"
+        download_url: "https://github.com/rust-embedded/cross/releases/download/${version}/cross-${version}-x86_64-unknown-linux-gnu.tar.gz"
+        tarball_binary_path: "${binary}"
+        smoke_test: "${binary} --version"
+
+    - name: Build
+      shell: bash
+      run: |
+        if [ "${{ matrix.job.use-cross }}" == "true" ]; then
+          cross build --release --target=${{ matrix.job.target }}
+        else
+          cargo build --release --target=${{ matrix.job.target }}
+        fi
+
+    - name: Rename lib to the final name
+      id: rename
+      shell: bash
+      run: |
+        LIB_PREFIX="lib"
+        case ${{ matrix.job.target }} in
+          *-pc-windows-*) LIB_PREFIX="" ;;
+        esac;
+
+        # Figure out suffix of lib
+        # See: https://doc.rust-lang.org/reference/linkage.html
+        LIB_SUFFIX=".so"
+        case ${{ matrix.job.target }} in
+          *-apple-darwin) LIB_SUFFIX=".dylib" ;;
+          *-pc-windows-*) LIB_SUFFIX=".dll" ;;
+        esac;
+
+        CICD_INTERMEDIATES_DIR=$(mktemp -d) 
+
+        # Setup paths
+        LIB_DIR="${CICD_INTERMEDIATES_DIR}/released-lib"
+        mkdir -p "${LIB_DIR}"
+        LIB_NAME="${LIB_PREFIX}${{ env.PROJECT_NAME }}${LIB_SUFFIX}"
+        LIB_PATH="${LIB_DIR}/${LIB_NAME}"
+
+        # Copy the release build lib to the result location
+        cp "target/${{ matrix.job.target }}/release/${LIB_NAME}" "${LIB_DIR}"
+
+        # Final paths
+        # In the end we use ".so" for MacOS in the final build
+        # See: https://www.erlang.org/doc/man/erlang.html#load_nif-2
+        LIB_FINAL_SUFFIX="${LIB_SUFFIX}"
+        case ${{ matrix.job.target }} in
+          *-apple-darwin) LIB_FINAL_SUFFIX=".so" ;;
+        esac;
+
+        LIB_FINAL_NAME="${LIB_PREFIX}${PROJECT_NAME}-v${PROJECT_VERSION}-nif-${RUSTLER_NIF_VERSION}-${{ matrix.job.target }}${LIB_FINAL_SUFFIX}"
+
+        # Copy lib to final name on this directory
+        cp "${LIB_PATH}" "${LIB_FINAL_NAME}"
+
+        tar -cvzf "${LIB_FINAL_NAME}.tar.gz" "${LIB_FINAL_NAME}"
+
+        # Passes the path relative to the root of the project.
+        LIB_FINAL_PATH="${NIF_DIRECTORY}/${LIB_FINAL_NAME}.tar.gz"
+
+        # Let subsequent steps know where to find the lib
+        echo ::set-output name=LIB_FINAL_PATH::${LIB_FINAL_PATH}
+        echo ::set-output name=LIB_FINAL_NAME::${LIB_FINAL_NAME}.tar.gz
+
+    - name: "Artifact upload"
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.rename.outputs.LIB_FINAL_NAME }}
+        path: ${{ steps.rename.outputs.LIB_FINAL_PATH }}
+
+    - name: Publish archives and packages
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ${{ steps.rename.outputs.LIB_FINAL_PATH }}
+      if: startsWith(github.ref, 'refs/tags/')

--- a/native/explorer/.cargo/config
+++ b/native/explorer/.cargo/config
@@ -9,3 +9,13 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+# See https://github.com/rust-lang/rust/issues/59302
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=-crt-static"
+]
+
+# Provides a small build size, but takes more time to build.
+[profile.release]
+lto = true

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -550,12 +550,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1220,8 +1217,7 @@ dependencies = [
 [[package]]
 name = "rustler"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac79e5fcfae809c16ff8da548daa291933b7ec8d66eadc197cdccec46891625"
+source = "git+https://github.com/rusterlium/rustler#c5800b584799960993ab705b0f113a711c72b87e"
 dependencies = [
  "lazy_static",
  "rustler_codegen",
@@ -1231,8 +1227,7 @@ dependencies = [
 [[package]]
 name = "rustler_codegen"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d303c303a145c1f3d2a2993527128badb9500101070c55e36ef9bb2417666a"
+source = "git+https://github.com/rusterlium/rustler#c5800b584799960993ab705b0f113a711c72b87e"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1243,9 +1238,9 @@ dependencies = [
 [[package]]
 name = "rustler_sys"
 version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb382fde4f421c51555919e9920b058c0286f6bf59e53d02eb4d281eae6758b"
+source = "git+https://github.com/rusterlium/rustler#c5800b584799960993ab705b0f113a711c72b87e"
 dependencies = [
+ "regex",
  "unreachable",
 ]
 
@@ -1381,12 +1376,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -12,11 +12,15 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1"
 chrono = "0.4"
-mimalloc = { version = "*", default-features = false }
 rand = { version = "0.8.4", features = ["alloc"] }
 rand_pcg = "0.3.1"
-rustler = "0.23.0"
+# We are using `rustler` from GitHub until a new version of `rustler-sys` arrives.
+# rustler = "0.23.0"
+rustler = { git = "https://github.com/rusterlium/rustler" }
 thiserror = "1"
+
+[target.'cfg(not(all(windows, target_env = "gnu")))'.dependencies]
+mimalloc = { version = "*", default-features = false }
 
 [dependencies.polars]
 version = "0.18.0"

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -1,6 +1,8 @@
+#[cfg(not(all(windows, target_env = "gnu")))]
 use mimalloc::MiMalloc;
 use rustler::{Env, Term};
 
+#[cfg(not(all(windows, target_env = "gnu")))]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 


### PR DESCRIPTION
This is going to be used to precompile the Explorer NIF in order to be
reused later.

This PR only includes the workflow and adjustments to the explorer crate. The workflow is going to run on each tag push and on each push to `main`.

It's building for the most common targets (including the ones used by Raspbarry PI/Nerves). In the future we should be able to adjust more or less targets in [RustlerPrecompiled](https://github.com/philss/rustler_precompiled).

PS: I should remove the current branch name from the list after we decide to merge or not.