### PR TITLE
Add `rustler_precompiled` and workflow for precompiling NIFs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,176 @@
+name: Build precompiled NIFs
+
+env:
+  NIF_DIRECTORY: "native/explorer"
+
+on:
+  push:
+    branches:
+      - main
+      - ps-add-precompilation-support
+    tags:
+      - '*'
+
+defaults:
+  run:
+    # Sets the working dir for "run" scripts.
+    # Note that this won't change the directory for actions (tasks with "uses").
+    working-directory: "./native/explorer"
+
+jobs:
+  build_release:
+    name: NIF ${{ matrix.job.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        job:
+          # NIF version 2.16
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.16", use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , nif: "2.16", use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-11     , nif: "2.16" }
+          - { target: x86_64-apple-darwin         , os: macos-11     , nif: "2.16" }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.16" }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , nif: "2.16", use-cross: true }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019 , nif: "2.16" }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.16" }
+          # NIF version 2.15
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.15", use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , nif: "2.15", use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-11     , nif: "2.15" }
+          - { target: x86_64-apple-darwin         , os: macos-11     , nif: "2.15" }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.15" }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , nif: "2.15", use-cross: true }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019 , nif: "2.15" }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.15" }
+          # # NIF version 2.14
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-20.04 , nif: "2.14", use-cross: true }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-20.04 , nif: "2.14", use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-11     , nif: "2.14" }
+          - { target: x86_64-apple-darwin         , os: macos-11     , nif: "2.14" }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-20.04 , nif: "2.14" }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-20.04 , nif: "2.14", use-cross: true }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2019 , nif: "2.14" }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2019 , nif: "2.14" }
+
+    env:
+      RUSTLER_NIF_VERSION: ${{ matrix.job.nif }}
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v2
+
+    - name: Install prerequisites
+      shell: bash
+      run: |
+        case ${{ matrix.job.target }} in
+          arm-unknown-linux-*) sudo apt-get -y update ; sudo apt-get -y install gcc-arm-linux-gnueabihf ;;
+          aarch64-unknown-linux-gnu) sudo apt-get -y update ; sudo apt-get -y install gcc-aarch64-linux-gnu ;;
+        esac
+
+    - name: Extract crate information
+      shell: bash
+      run: |
+        echo "PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
+        # Get the project version from mix.exs
+        echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' ../../mix.exs | head -n1)" >> $GITHUB_ENV
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.job.target }}
+        override: true
+        profile: minimal
+
+    - name: Show version information (Rust, cargo, GCC)
+      shell: bash
+      run: |
+        gcc --version || true
+        rustup -V
+        rustup toolchain list
+        rustup default
+        cargo -V
+        rustc -V
+        rustc --print=cfg
+
+    - name: Download cross from GitHub releases
+      uses: giantswarm/install-binary-action@v1.0.0
+      if: ${{ matrix.job.use-cross }}
+      with:
+        binary: "cross"
+        version: "v0.2.1"
+        download_url: "https://github.com/rust-embedded/cross/releases/download/${version}/cross-${version}-x86_64-unknown-linux-gnu.tar.gz"
+        tarball_binary_path: "${binary}"
+        smoke_test: "${binary} --version"
+
+    - name: Build
+      shell: bash
+      run: |
+        if [ "${{ matrix.job.use-cross }}" == "true" ]; then
+          cross build --release --target=${{ matrix.job.target }}
+        else
+          cargo build --release --target=${{ matrix.job.target }}
+        fi
+
+    - name: Rename lib to the final name
+      id: rename
+      shell: bash
+      run: |
+        LIB_PREFIX="lib"
+        case ${{ matrix.job.target }} in
+          *-pc-windows-*) LIB_PREFIX="" ;;
+        esac;
+
+        # Figure out suffix of lib
+        # See: https://doc.rust-lang.org/reference/linkage.html
+        LIB_SUFFIX=".so"
+        case ${{ matrix.job.target }} in
+          *-apple-darwin) LIB_SUFFIX=".dylib" ;;
+          *-pc-windows-*) LIB_SUFFIX=".dll" ;;
+        esac;
+
+        CICD_INTERMEDIATES_DIR=$(mktemp -d) 
+
+        # Setup paths
+        LIB_DIR="${CICD_INTERMEDIATES_DIR}/released-lib"
+        mkdir -p "${LIB_DIR}"
+        LIB_NAME="${LIB_PREFIX}${{ env.PROJECT_NAME }}${LIB_SUFFIX}"
+        LIB_PATH="${LIB_DIR}/${LIB_NAME}"
+
+        # Copy the release build lib to the result location
+        cp "target/${{ matrix.job.target }}/release/${LIB_NAME}" "${LIB_DIR}"
+
+        # Final paths
+        # In the end we use ".so" for MacOS in the final build
+        # See: https://www.erlang.org/doc/man/erlang.html#load_nif-2
+        LIB_FINAL_SUFFIX="${LIB_SUFFIX}"
+        case ${{ matrix.job.target }} in
+          *-apple-darwin) LIB_FINAL_SUFFIX=".so" ;;
+        esac;
+
+        LIB_FINAL_NAME="${LIB_PREFIX}${PROJECT_NAME}-v${PROJECT_VERSION}-nif-${RUSTLER_NIF_VERSION}-${{ matrix.job.target }}${LIB_FINAL_SUFFIX}"
+
+        # Copy lib to final name on this directory
+        cp "${LIB_PATH}" "${LIB_FINAL_NAME}"
+
+        tar -cvzf "${LIB_FINAL_NAME}.tar.gz" "${LIB_FINAL_NAME}"
+
+        # Passes the path relative to the root of the project.
+        LIB_FINAL_PATH="${NIF_DIRECTORY}/${LIB_FINAL_NAME}.tar.gz"
+
+        # Let subsequent steps know where to find the lib
+        echo ::set-output name=LIB_FINAL_PATH::${LIB_FINAL_PATH}
+        echo ::set-output name=LIB_FINAL_NAME::${LIB_FINAL_NAME}.tar.gz
+
+    - name: "Artifact upload"
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ steps.rename.outputs.LIB_FINAL_NAME }}
+        path: ${{ steps.rename.outputs.LIB_FINAL_PATH }}
+
+    - name: Publish archives and packages
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          ${{ steps.rename.outputs.LIB_FINAL_PATH }}
+      if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - ps-add-precompilation-support
     tags:
       - '*'
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -1,9 +1,15 @@
 defmodule Explorer.PolarsBackend.Native do
   @moduledoc false
 
-  use Rustler,
+  mix_config = Mix.Project.config()
+  version = mix_config[:version]
+  github_url = mix_config[:package][:links]["GitHub"]
+
+  use RustlerPrecompiled,
     otp_app: :explorer,
-    crate: :explorer
+    version: version,
+    base_url: "#{github_url}/releases/download/v#{version}",
+    force_build: System.get_env("EXPLORER_BUILD") in ["1", "true"]
 
   defstruct [:inner]
 

--- a/mix.exs
+++ b/mix.exs
@@ -58,11 +58,10 @@ defmodule Explorer.MixProject do
         "lib",
         "native",
         "datasets",
-        # "notebooks", should we include this one?
         "checksum-*.exs",
         "mix.exs",
         "README.md",
-        # "CHANGELOG.md",
+        "CHANGELOG.md",
         "LICENSE"
       ],
       licenses: ["MIT"],

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,7 @@ defmodule Explorer.MixProject do
       name: "Explorer",
       version: @version,
       elixir: "~> 1.12",
+      package: package(),
       deps: deps(),
       docs: docs()
     ]
@@ -26,7 +27,7 @@ defmodule Explorer.MixProject do
     [
       {:ex_doc, "~> 0.24", only: :dev, runtime: false},
       {:nx, "~> 0.1.0"},
-      {:rustler, "~> 0.23.0"},
+      {:rustler_precompiled, "~> 0.2"},
       {:table_rex, "~> 3.1.1"}
     ]
   end
@@ -48,6 +49,24 @@ defmodule Explorer.MixProject do
           Explorer.PolarsBackend
         ]
       ]
+    ]
+  end
+
+  defp package do
+    [
+      files: [
+        "lib",
+        "native",
+        "datasets",
+        # "notebooks", should we include this one?
+        "checksum-*.exs",
+        "mix.exs",
+        "README.md",
+        # "CHANGELOG.md",
+        "LICENSE"
+      ],
+      licenses: ["MIT"],
+      links: %{"GitHub" => @source_url}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -60,8 +60,6 @@ defmodule Explorer.MixProject do
         "datasets",
         "checksum-*.exs",
         "mix.exs",
-        "README.md",
-        "CHANGELOG.md",
         "LICENSE"
       ],
       licenses: ["MIT"],

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
 %{
+  "castore": {:hex, :castore, "0.1.15", "dbb300827d5a3ec48f396ca0b77ad47058578927e9ebe792abd99fcbc3324326", [:mix], [], "hexpm", "c69379b907673c7e6eb229f09a0a09b60bb27cfb9625bcb82ea4c04ba82a8442"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.13", "0c98163e7d04a15feb62000e1a891489feb29f3d10cb57d4f845c405852bbef8", [:mix], [], "hexpm", "d602c26af3a0af43d2f2645613f65841657ad6efc9f0e361c3b6c06b578214ba"},
   "ex_doc": {:hex, :ex_doc, "0.25.0", "4070a254664ee5495c2f7cce87c2f43064a8752f7976f2de4937b65871b05223", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "2d90883bd4f3d826af0bde7fea733a4c20adba1c79158e2330f7465821c8949b"},
   "jason": {:hex, :jason, "1.3.0", "fa6b82a934feb176263ad2df0dbd91bf633d4a46ebfdffea0c8ae82953714946", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "53fc1f51255390e0ec7e50f9cb41e751c260d065dcba2bf0d08dc51a4002c2ac"},
@@ -8,6 +9,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.1.0", "3a6fca1550363552e54c216debb6a9e95bd8d32348938e13de5eda962c0d7f89", [:mix], [], "hexpm", "08eb32d66b706e913ff748f11694b17981c0b04a33ef470e33e11b3d3ac8f54b"},
   "nx": {:hex, :nx, "0.1.0", "8f8a047dc0fd2b1798406edf828b43c46cca648b13c58fd5abd52285316b3d86", [:mix], [], "hexpm", "24ce6e184dc9c7b7c6c247923bfbe994101a7fe049bd3fd376b5b0512f787256"},
   "rustler": {:hex, :rustler, "0.23.0", "87162ffdf5a46b6aa03d624a77367070ff1263961ae35332c059225e136c4a87", [:mix], [{:jason, "~> 1.2", [hex: :jason, repo: "hexpm", optional: false]}, {:toml, "~> 0.5.2", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "f5ab6f0ec564f5569009c0f5685b0e5b379fd72655e82a8dc5a3c24f9fdda36a"},
+  "rustler_precompiled": {:hex, :rustler_precompiled, "0.2.0", "8cb0fb2527d51de624e91b45e0a2b12c92e1cb614f8616f8dfc07c3d1180f48a", [:mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:rustler, "~> 0.23", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm", "583be3d480fa292770d45d4e20418ad81b6d9acd2bc42d8776e79f4a283cbae4"},
   "table_rex": {:hex, :table_rex, "3.1.1", "0c67164d1714b5e806d5067c1e96ff098ba7ae79413cc075973e17c38a587caa", [:mix], [], "hexpm", "678a23aba4d670419c23c17790f9dcd635a4a89022040df7d5d772cb21012490"},
   "toml": {:hex, :toml, "0.5.2", "e471388a8726d1ce51a6b32f864b8228a1eb8edc907a0edf2bb50eab9321b526", [:mix], [], "hexpm", "f1e3dabef71fb510d015fad18c0e05e7c57281001141504c6b69d94e99750a07"},
 }

--- a/native/explorer/.cargo/config
+++ b/native/explorer/.cargo/config
@@ -9,3 +9,13 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+# See https://github.com/rust-lang/rust/issues/59302
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+  "-C", "target-feature=-crt-static"
+]
+
+# Provides a small build size, but takes more time to build.
+[profile.release]
+lto = true

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -550,12 +550,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1220,8 +1217,7 @@ dependencies = [
 [[package]]
 name = "rustler"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ac79e5fcfae809c16ff8da548daa291933b7ec8d66eadc197cdccec46891625"
+source = "git+https://github.com/rusterlium/rustler#c5800b584799960993ab705b0f113a711c72b87e"
 dependencies = [
  "lazy_static",
  "rustler_codegen",
@@ -1231,8 +1227,7 @@ dependencies = [
 [[package]]
 name = "rustler_codegen"
 version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d303c303a145c1f3d2a2993527128badb9500101070c55e36ef9bb2417666a"
+source = "git+https://github.com/rusterlium/rustler#c5800b584799960993ab705b0f113a711c72b87e"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1243,9 +1238,9 @@ dependencies = [
 [[package]]
 name = "rustler_sys"
 version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb382fde4f421c51555919e9920b058c0286f6bf59e53d02eb4d281eae6758b"
+source = "git+https://github.com/rusterlium/rustler#c5800b584799960993ab705b0f113a711c72b87e"
 dependencies = [
+ "regex",
  "unreachable",
 ]
 
@@ -1381,12 +1376,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -12,11 +12,15 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = "1"
 chrono = "0.4"
-mimalloc = { version = "*", default-features = false }
 rand = { version = "0.8.4", features = ["alloc"] }
 rand_pcg = "0.3.1"
-rustler = "0.23.0"
+# We are using `rustler` from GitHub until a new version of `rustler-sys` arrives.
+# rustler = "0.23.0"
+rustler = { git = "https://github.com/rusterlium/rustler" }
 thiserror = "1"
+
+[target.'cfg(not(all(windows, target_env = "gnu")))'.dependencies]
+mimalloc = { version = "*", default-features = false }
 
 [dependencies.polars]
 version = "0.18.0"

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -19,6 +19,7 @@ rand_pcg = "0.3.1"
 rustler = { git = "https://github.com/rusterlium/rustler" }
 thiserror = "1"
 
+# This is because when using GCC on Windows MiMalloc won´t compile
 [target.'cfg(not(all(windows, target_env = "gnu")))'.dependencies]
 mimalloc = { version = "*", default-features = false }
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -1,6 +1,8 @@
+#[cfg(not(all(windows, target_env = "gnu")))]
 use mimalloc::MiMalloc;
 use rustler::{Env, Term};
 
+#[cfg(not(all(windows, target_env = "gnu")))]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -1,3 +1,4 @@
+// MiMalloc won´t compile on Windows with the GCC compiler
 #[cfg(not(all(windows, target_env = "gnu")))]
 use mimalloc::MiMalloc;
 use rustler::{Env, Term};


### PR DESCRIPTION
This PR contains the changes necessary to use precompiled NIFs.

It will build on every push to the `main` branch and push of tags. But with tags we are also automatically creating a new release that contains all the precompiled NIFs for the most common architectures and operational systems.
After the release, the Hex package can be published as described in the [Precompilation Guide](https://hexdocs.pm/rustler_precompiled/precompilation_guide.html) (only for project maintainers).

The NIF will be downloaded based on the target system (normally the same of the host system, but can be different for example when building for [Nerves](https://www.nerves-project.org/)) and will be verified with a checksum that was generated in the release of the Hex package.

This shouldn't change much of the development flow, so if you are using a pre-release it won't affect you. Once we have a new release, the users of the Hex package will be able to use Explorer without having to install the Rust toolchain.

Even with a released version, it is still possible to force the compilation by setting a system env var:

    EXPLORER_BUILD=true mix compile --force

Or by setting an application env:

    config :rustler_precompiled, :force_build, explorer: true

For more details about `rustler_precompiled`, please [check the documentation](https://hexdocs.pm/rustler_precompiled).