### PR TITLE
Always build NIF on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 env:
   ELIXIR_VERSION: 1.13
   OTP_VERSION: 24.2
+  EXPLORER_BUILD: true
   MIX_ENV: test
 
 jobs:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,6 +12,7 @@ concurrency:
 env:
   ELIXIR_VERSION: 1.13
   OTP_VERSION: 24.2
+  EXPLORER_BUILD: true
 
 jobs:
   deploy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      # Just run on main branch if "native" path changed. Tags will always run.
+      - 'native/**'
     tags:
       - '*'
 


### PR DESCRIPTION
This change makes sure that we always build the NIF on CI. Even if we
are releasing an official version, we should build from source.
This will prevent the build to fail in those occasions, where the
precompiled NIFs won't be available yet - they take 30 minutes to build.

This change also includes a restriction for running the "release"
workflow - that builds the precompiled NIFs - only if the "native" code
changed. This is because we almost don't depend on Elixir code for that
workflow.

This is related to the previous PR #123 