### PR TITLE
Creates a DataFrame from a list of maps

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -193,6 +193,28 @@ defmodule Explorer.DataFrame do
   def to_map(df, convert_series? \\ true), do: apply_impl(df, :to_map, [convert_series?])
 
   @doc """
+  Converts a list of maps to a dataframe.
+
+  ## Examples
+
+      iex> l = [%{id: 1, name: "José"}, %{id: 2, name: "Christopher"}, %{id: 3, name: "Cristine"}]
+      iex> Explorer.DataFrame.from_list(l)
+      #Explorer.DataFrame<
+        [rows: 3, columns: 2]
+        id integer [1, 2, 3]
+        name string ["José", "Christopher", "Cristine"]
+      >
+  """
+  def from_list([h | t]) do
+    for _record <- t, reduce: record_to_df(h) do
+      acc -> t |> record_to_df() |> then(&DataFrame.concat_rows(acc, &1))
+    end
+  end
+
+  defp wrap_values(map), do: Map.new(map, fn {k, v} -> {k, List.wrap(v)} end) # OK
+  defp record_to_df(map), do: map |> wrap_values() |> DataFrame.from_map() # OK
+
+  @doc """
   Writes a dataframe to a binary representation of a delimited file.
 
   ## Options

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -213,7 +213,7 @@ defmodule Explorer.DataFrame do
     end)
   end
 
-  defp wrap_values(map) do
+  defp wrap_values(map) when is_map(map) do
     Map.new(map, fn {key, value} -> {key, List.wrap(value)} end)
   end
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -198,14 +198,14 @@ defmodule Explorer.DataFrame do
   ## Examples
 
       iex> l = [%{id: 1, name: "José"}, %{id: 2, name: "Christopher"}, %{id: 3, name: "Cristine"}]
-      iex> Explorer.DataFrame.from_list(l)
+      iex> Explorer.DataFrame.from_list_of_maps(l)
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
         id integer [1, 2, 3]
         name string ["José", "Christopher", "Cristine"]
       >
   """
-  def from_list([head | tail]) do
+  def from_list_of_maps([head | tail]) do
     Enum.reduce(tail, record_to_df(head), fn record, acc ->
       record
       |> record_to_df()
@@ -214,9 +214,9 @@ defmodule Explorer.DataFrame do
   end
 
   defp wrap_values(map) do
-    Map.new(map, fn {k, v} -> {k, List.wrap(v)} end)
+    Map.new(map, fn {key, value} -> {key, List.wrap(value)} end)
   end
-  # OK
+
   defp record_to_df(map), do: map |> wrap_values() |> DataFrame.from_map()
 
   @doc """

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -961,6 +961,29 @@ defmodule Explorer.DataFrame do
 
   @doc """
   Turns a set of columns to dummy variables.
+
+  ## Examples
+
+      iex> df = Explorer.DataFrame.from_map(%{a: ["a", "b", "a", "c"], b: ["b", "a", "b", "d"]})
+      iex> Explorer.DataFrame.dummies(df, ["a"])
+      #Explorer.DataFrame<
+        [rows: 4, columns: 3]
+        a_a integer [1, 0, 1, 0]
+        a_b integer [0, 1, 0, 0]
+        a_c integer [0, 0, 0, 1]
+      >
+
+      iex> df = Explorer.DataFrame.from_map(%{a: ["a", "b", "a", "c"], b: ["b", "a", "b", "d"]})
+      iex> Explorer.DataFrame.dummies(df, ["a", "b"])
+      #Explorer.DataFrame<
+        [rows: 4, columns: 6]
+        a_a integer [1, 0, 1, 0]
+        a_b integer [0, 1, 0, 0]
+        a_c integer [0, 0, 0, 1]
+        b_a integer [0, 1, 0, 0]
+        b_b integer [1, 0, 1, 0]
+        b_d integer [0, 0, 0, 1]
+      >
   """
   def dummies(df, columns), do: apply_impl(df, :dummies, [columns])
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -205,14 +205,19 @@ defmodule Explorer.DataFrame do
         name string ["José", "Christopher", "Cristine"]
       >
   """
-  def from_list([h | t]) do
-    for _record <- t, reduce: record_to_df(h) do
-      acc -> t |> record_to_df() |> then(&DataFrame.concat_rows(acc, &1))
-    end
+  def from_list([head | tail]) do
+    Enum.reduce(tail, record_to_df(head), fn record, acc ->
+      record
+      |> record_to_df()
+      |> then(&DataFrame.concat_rows(acc, &1))
+    end)
   end
 
-  defp wrap_values(map), do: Map.new(map, fn {k, v} -> {k, List.wrap(v)} end) # OK
-  defp record_to_df(map), do: map |> wrap_values() |> DataFrame.from_map() # OK
+  defp wrap_values(map) do
+    Map.new(map, fn {k, v} -> {k, List.wrap(v)} end)
+  end
+  # OK
+  defp record_to_df(map), do: map |> wrap_values() |> DataFrame.from_map()
 
   @doc """
   Writes a dataframe to a binary representation of a delimited file.

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -198,14 +198,14 @@ defmodule Explorer.DataFrame do
   ## Examples
 
       iex> l = [%{id: 1, name: "José"}, %{id: 2, name: "Christopher"}, %{id: 3, name: "Cristine"}]
-      iex> Explorer.DataFrame.from_list_of_maps(l)
+      iex> Explorer.DataFrame.from_list(l)
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
         id integer [1, 2, 3]
         name string ["José", "Christopher", "Cristine"]
       >
   """
-  def from_list_of_maps([head | tail]) do
+  def from_list([head | tail]) do
     Enum.reduce(tail, record_to_df(head), fn record, acc ->
       record
       |> record_to_df()

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -205,7 +205,7 @@ defmodule Explorer.DataFrame do
         name string ["José", "Christopher", "Cristine"]
       >
   """
-  def from_list([head | tail]) do
+  def from_list([head | tail]) when is_map(head) do
     Enum.reduce(tail, record_to_df(head), fn record, acc ->
       record
       |> record_to_df()


### PR DESCRIPTION
This pull request adds a function called `Explorer.DataFrame.from_list_of_maps/1`, which accepts a list of maps and transforms it in a DataFrame. Each `map` corresponds to a row in the `DataFrame` and each entry in a map is mapped to a column. All maps must have the same length and the same key names.

If approved, this pull request closes #59.