### PR TITLE
Fix type casting for numeric series

### DIFF
--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -76,7 +76,7 @@ defmodule Explorer.Shared do
   defp type(item, type) when is_integer(item) and type == :float, do: :numeric
   defp type(item, type) when is_float(item) and type == :integer, do: :numeric
 
-  defp type(item, type) when type == :numeri and (is_integer(item) or is_float(item)),
+  defp type(item, type) when type == :numeric and (is_integer(item) or is_float(item)),
     do: :numeric
 
   defp type(item, _type) when is_integer(item), do: :integer

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -5,6 +5,20 @@ defmodule Explorer.SeriesTest do
 
   doctest Explorer.Series
 
+  test "from_list/1" do
+    s = Series.from_list([1, 2, 3])
+
+    assert Series.to_list(s) === [1, 2, 3]
+
+    s = Series.from_list([1, 2.4, 3])
+    assert Series.to_list(s) === [1.0, 2.4, 3.0]
+
+    assert_raise ArgumentError, fn ->
+      s = Series.from_list([1, "foo", 3])
+      Series.to_list(s)
+    end
+  end
+
   test "fetch/2" do
     s = Series.from_list([1, 2, 3])
     assert s[0] === 1


### PR DESCRIPTION
When creating a series with a mix of integers and floats, we should have
a series of floats in the end.

This change fixes a small bug when a list like this would give an error:
`[1, 2.0, 3]`.