### PR TITLE
add `DataFrame.from_rows/2`

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -35,6 +35,7 @@ defmodule Explorer.Backend.DataFrame do
   # Conversion
 
   @callback from_columns(map() | Keyword.t()) :: df
+  @callback from_rows(list(map() | Keyword.t())) :: df
   @callback to_map(df, convert_series? :: boolean()) :: map()
   @callback to_binary(df, header? :: boolean(), delimiter :: String.t()) :: String.t()
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -193,6 +193,53 @@ defmodule Explorer.DataFrame do
   end
 
   @doc """
+  Creates a new dataframe from a list of maps or keyword lists.
+
+  Each map in the list should have the same keys, but missing keys will yield a null value for
+  that row. All values for a given key should be of the same dtype.
+
+  Keyword lists should all be in the same order.
+
+  ## Options
+
+    * `backend` - The Explorer backend to use. Defaults to the value returned by `Explorer.default_backend/0`.
+
+  ## Examples
+
+      iex> rows = [%{id: 1, name: "José"}, %{id: 2, name: "Christopher"}, %{id: 3, name: "Cristine"}]
+      iex> Explorer.DataFrame.from_rows(rows)
+      #Explorer.DataFrame<
+        [rows: 3, columns: 2]
+        id integer [1, 2, 3]
+        name string ["José", "Christopher", "Cristine"]
+      >
+
+      iex> rows = [[id: 1, name: "José"], [id: 2, name: "Christopher"], [id: 3, name: "Cristine"]]
+      iex> Explorer.DataFrame.from_rows(rows)
+      #Explorer.DataFrame<
+        [rows: 3, columns: 2]
+        id integer [1, 2, 3]
+        name string ["José", "Christopher", "Cristine"]
+      >
+
+    With a list of maps, missing keys will yield a null value.
+
+      iex> rows = [%{id: 1, name: "José", date: ~D[2001-01-01]}, %{id: 2, date: ~D[1993-01-01]}, %{id: 3, name: "Cristine"}]
+      iex> Explorer.DataFrame.from_rows(rows)
+      #Explorer.DataFrame<
+        [rows: 3, columns: 3]
+        date date [2001-01-01, 1993-01-01, nil]
+        id integer [1, 2, 3]
+        name string ["José", nil, "Cristine"]
+      >
+  """
+  @spec from_rows(rows :: list(map()) | Keyword.t(), opts :: Keyword.t()) :: DataFrame.t()
+  def from_rows(rows, opts \\ []) do
+    backend = backend_from_options!(opts)
+    backend.from_rows(rows)
+  end
+
+  @doc """
   Converts a dataframe to a map.
 
   By default, the constituent series of the dataframe are converted to Elixir lists.

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -113,6 +113,21 @@ defmodule Explorer.PolarsBackend.DataFrame do
     end
   end
 
+  @impl true
+  def from_rows([h | _] = rows) when is_map(h) do
+    case Native.df_from_map_rows(rows) do
+      {:ok, df} -> Shared.to_dataframe(df)
+      {:error, reason} -> raise "#{inspect(reason)}"
+    end
+  end
+
+  def from_rows([h | _] = rows) when is_list(h) do
+    case Native.df_from_keyword_rows(rows) do
+      {:ok, df} -> Shared.to_dataframe(df)
+      {:error, reason} -> raise "#{inspect(reason)}"
+    end
+  end
+
   # Conversion
 
   @impl true

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -59,6 +59,8 @@ defmodule Explorer.PolarsBackend.Native do
   def df_filter(_df, _mask), do: err()
   def df_find_idx_by_name(_df, _name), do: err()
   def df_frame_equal(_df, _other, _null_equal), do: err()
+  def df_from_map_rows(_rows), do: err()
+  def df_from_keyword_rows(_rows), do: err()
   def df_get_columns(_df), do: err()
   def df_groups(_df, _colnames), do: err()
   def df_groupby_agg(_df, _groups, _aggs), do: err()

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -1,5 +1,7 @@
 use polars::prelude::*;
+use rustler::{Term, TermType};
 
+use std::collections::HashMap;
 use std::fs::File;
 use std::result::Result;
 
@@ -7,7 +9,7 @@ use crate::series::{
     cast, parse_quantile_interpol_options, to_ex_series_collection, to_series_collection,
 };
 
-use crate::{ExDataFrame, ExSeries, ExplorerError};
+use crate::{ExAnyValue, ExDataFrame, ExSeries, ExplorerError};
 
 macro_rules! df_read {
     ($data: ident, $df: ident, $body: block) => {
@@ -149,6 +151,102 @@ pub fn df_to_csv_file(
 #[rustler::nif]
 pub fn df_as_str(data: ExDataFrame) -> Result<String, ExplorerError> {
     df_read!(data, df, { Ok(format!("{:?}", df)) })
+}
+
+#[rustler::nif]
+pub fn df_from_map_rows(
+    rows: Vec<HashMap<Term, Option<ExAnyValue>>>,
+) -> Result<ExDataFrame, ExplorerError> {
+    // Coerce the keys from `Term` (atom or binary) to `String`
+    let rows: Vec<HashMap<String, &Option<ExAnyValue>>> = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .map(|(key, val)| (atom_or_binary_to_string(key), val))
+                .collect()
+        })
+        .collect();
+
+    // Get the map keys and sort them
+    let mut keys = rows
+        .first()
+        .unwrap()
+        .keys()
+        .cloned()
+        .collect::<Vec<String>>();
+
+    case_insensitive_sort(&mut keys);
+
+    // Coerce the vec of hashmaps to polars Rows
+    let rows = rows
+        .iter()
+        .map(|row| row::Row::new(get_vals_in_order(row, &keys)))
+        .collect::<Vec<row::Row>>();
+
+    // Create the dataframe and assign the column names
+    let mut df = DataFrame::from_rows(&rows)?;
+    df.set_column_names(&keys)?;
+    Ok(ExDataFrame::new(df))
+}
+
+fn atom_or_binary_to_string(val: &Term) -> String {
+    match val.get_type() {
+        TermType::Atom => val.atom_to_string().unwrap(),
+        TermType::Binary => {
+            String::from_utf8_lossy(val.into_binary().unwrap().as_slice()).to_string()
+        }
+        _ => panic!("Unsupported key value"),
+    }
+}
+
+fn get_vals_in_order<'a>(
+    map: &'a HashMap<String, &Option<ExAnyValue>>,
+    keys: &'a [String],
+) -> Vec<AnyValue<'a>> {
+    keys.iter()
+        .map(|key| match map.get(key) {
+            None => AnyValue::Null,
+            Some(None) => AnyValue::Null,
+            Some(Some(val)) => val.to_polars(),
+        })
+        .collect()
+}
+
+fn case_insensitive_sort(strings: &mut Vec<String>) {
+    strings.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()))
+}
+
+#[rustler::nif]
+pub fn df_from_keyword_rows(
+    rows: Vec<Vec<(Term, Option<ExAnyValue>)>>,
+) -> Result<ExDataFrame, ExplorerError> {
+    // Get the keys and coerce them from `Term` (atom or binary) to `String`
+    let keys = rows
+        .first()
+        .unwrap()
+        .iter()
+        .map(|(key, _)| atom_or_binary_to_string(key))
+        .collect::<Vec<String>>();
+
+    // Coerce the vec of tuples to polars Rows
+    let rows = rows
+        .iter()
+        .map(|row| {
+            let row = row
+                .iter()
+                .map(|(_, val)| match val {
+                    Some(val) => val.to_polars(),
+                    None => AnyValue::Null,
+                })
+                .collect();
+            row::Row::new(row)
+        })
+        .collect::<Vec<row::Row>>();
+
+    // Create the dataframe and assign the column names
+    let mut df = DataFrame::from_rows(&rows)?;
+    df.set_column_names(&keys)?;
+    Ok(ExDataFrame::new(df))
 }
 
 #[rustler::nif]

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -13,7 +13,7 @@ mod error;
 mod series;
 
 use dataframe::*;
-pub use datatypes::{ExDataFrame, ExDataFrameRef, ExSeries, ExSeriesRef};
+pub use datatypes::{ExAnyValue, ExDataFrame, ExDataFrameRef, ExSeries, ExSeriesRef};
 pub use error::ExplorerError;
 use series::*;
 
@@ -48,6 +48,8 @@ rustler::init!(
         df_filter,
         df_find_idx_by_name,
         df_frame_equal,
+        df_from_map_rows,
+        df_from_keyword_rows,
         df_get_columns,
         df_groups,
         df_groupby_agg,


### PR DESCRIPTION
WIP. ~Last hurdle is figuring out how to coerce atom keys to string keys without iterating over the whole list of rows Elixir-side. @philss any ideas?~ Figured it out! I'm able to pass a term and then match on the TermType. A bit convoluted, but it works!

I also think the `ExAnyValue` approach may permit us to have a single `s_from_list` without the macro implementation. And I think remove the iteration over the full list Elixir-side. @jonatanklosko @josevalim I believe that came up during our call.

Closes #59.

cc @kimjoaoun 