### PR TITLE
`DF.concat_rows` casts numeric cols if they differ

### DIFF
--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -382,4 +382,41 @@ defmodule Explorer.DataFrameTest do
              )
            ) == %{id: [1], cola: [1.0], colb: [2.0]}
   end
+
+  test "concat_rows/2" do
+    df1 = DF.from_columns(x: [1, 2, 3], y: ["a", "b", "c"])
+    df2 = DF.from_columns(x: [4, 5, 6], y: ["d", "e", "f"])
+    df3 = DF.concat_rows(df1, df2)
+
+    assert Series.to_list(df3["x"]) == [1, 2, 3, 4, 5, 6]
+    assert Series.to_list(df3["y"]) == ~w(a b c d e f)
+
+    df2 = DF.from_columns(x: [4.0, 5.0, 6.0], y: ["d", "e", "f"])
+    df3 = DF.concat_rows(df1, df2)
+
+    assert Series.to_list(df3["x"]) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+    df4 = DF.from_columns(x: [7, 8, 9], y: ["g", "h", nil])
+    df5 = DF.concat_rows(df3, df4)
+
+    assert Series.to_list(df5["x"]) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    assert Series.to_list(df5["y"]) == ~w(a b c d e f g h) ++ [nil]
+
+    df6 = DF.concat_rows([df1, df2, df4])
+
+    assert Series.to_list(df6["x"]) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
+    assert Series.to_list(df6["y"]) == ~w(a b c d e f g h) ++ [nil]
+
+    assert_raise ArgumentError,
+                 "dataframes must have the same columns",
+                 fn -> DF.concat_rows(df1, DF.from_columns(z: [7, 8, 9])) end
+
+    assert_raise ArgumentError,
+                 "dataframes must have the same columns",
+                 fn -> DF.concat_rows(df1, DF.from_columns(x: [7, 8, 9], z: [7, 8, 9])) end
+
+    assert_raise ArgumentError,
+                 "columns and dtypes must be identical for all dataframes",
+                 fn -> DF.concat_rows(df1, DF.from_columns(x: [7, 8, 9], y: [10, 11, 12])) end
+  end
 end


### PR DESCRIPTION
This change makes the behaviour of `Dataframe.concat_rows` be similar to
the one of `Series.from_list` that accepts both integers and floats in
the same series.

Closes https://github.com/elixir-nx/explorer/issues/135.