### PR TITLE
Allow a series of `nils` to be created

### DIFF
--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -68,7 +68,7 @@ defmodule Explorer.Shared do
       end)
 
     case type do
-      nil -> {:error, "cannot make a series from a list of all nils"}
+      nil -> {:ok, :float}
       {:error, _} = error -> error
       valid -> {:ok, valid}
     end


### PR DESCRIPTION
This makes the behavior similar to what we see in `py-polars` and
`nodejs-polars`, where a series with only `nil` values can be created
with the dtype of `float`.

This closes https://github.com/elixir-nx/explorer/issues/150