### PR TITLE
Change `DF.to_map/2` to use string keys by default

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -46,7 +46,7 @@ defmodule Explorer.Backend.DataFrame do
 
   @callback from_columns(map() | Keyword.t()) :: df
   @callback from_rows(list(map() | Keyword.t())) :: df
-  @callback to_map(df, convert_series? :: boolean()) :: map()
+  @callback to_map(df, convert_series? :: boolean(), atom_keys? :: boolean()) :: map()
   @callback to_binary(df, header? :: boolean(), delimiter :: String.t()) :: String.t()
 
   # Introspection

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -300,14 +300,27 @@ defmodule Explorer.DataFrame do
 
   By default, the constituent series of the dataframe are converted to Elixir lists.
 
+  ## Options
+
+    * `:convert_series` - Should the series should be converted to a list? (default: `true`)
+    * `:atom_keys` - Configure if the resultant map should have atom keys. (default: `false`)
+
   ## Examples
 
       iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, nil])
       iex> Explorer.DataFrame.to_map(df)
+      %{"floats" => [1.0, 2.0], "ints" => [1, nil]}
+
+      iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, nil])
+      iex> Explorer.DataFrame.to_map(df, atom_keys: true)
       %{floats: [1.0, 2.0], ints: [1, nil]}
   """
-  @spec to_map(df :: DataFrame.t(), convert_series? :: boolean()) :: map()
-  def to_map(df, convert_series? \\ true), do: apply_impl(df, :to_map, [convert_series?])
+  @spec to_map(df :: DataFrame.t(), Keyword.t()) :: map()
+  def to_map(df, opts \\ []) do
+    opts = keyword!(opts, convert_series: true, atom_keys: false)
+
+    apply_impl(df, :to_map, [opts[:convert_series], opts[:atom_keys]])
+  end
 
   @doc """
   Writes a dataframe to a binary representation of a delimited file.

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -302,7 +302,7 @@ defmodule Explorer.DataFrame do
 
   ## Options
 
-    * `:convert_series` - Should the series should be converted to a list? (default: `true`)
+    * `:convert_series` - Convert the series to lists (default: `true`)
     * `:atom_keys` - Configure if the resultant map should have atom keys. (default: `false`)
 
   ## Examples

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -198,16 +198,20 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def to_map(%DataFrame{data: df}, convert_series?) do
-    Enum.reduce(df, %{}, &to_map_reducer(&1, &2, convert_series?))
+  def to_map(%DataFrame{data: df}, convert_series?, atom_keys?) do
+    Enum.reduce(df, %{}, &to_map_reducer(&1, &2, convert_series?, atom_keys?))
   end
 
-  defp to_map_reducer(series, acc, convert_series?) do
+  defp to_map_reducer(series, acc, convert_series?, atom_keys?) do
     series_name =
       series
       |> Native.s_name()
       |> then(fn {:ok, name} ->
-        String.to_atom(name)
+        if atom_keys? do
+          String.to_atom(name)
+        else
+          name
+        end
       end)
 
     series = Shared.to_series(series)

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -81,7 +81,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, delimiter: "*")
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                a: ["c", "e"],
                b: ["d", "f"]
              }
@@ -98,7 +98,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, dtypes: [{"a", :string}])
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                a: ["1", "3"],
                b: [2, 4]
              }
@@ -116,7 +116,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.read_csv!(csv, parse_dates: true)
       assert [:datetime] = DF.select(df, ["c"]) |> Explorer.DataFrame.dtypes()
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                a: [1, 3],
                b: [2, 4],
                c: [~N[2020-10-15 00:00:01.000], ~N[2020-10-15 00:00:18.000]]
@@ -135,7 +135,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.read_csv!(csv, parse_dates: false)
       assert [:string] = DF.select(df, ["c"]) |> Explorer.DataFrame.dtypes()
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                a: [1, 3],
                b: [2, 4],
                c: ["2020-10-15 00:00:01", "2020-10-15 00:00:18"]
@@ -153,7 +153,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, header?: false)
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                column_1: ["a", "c", "e"],
                column_2: ["b", "d", "f"]
              }
@@ -170,7 +170,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, max_rows: 1)
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                a: ["c"],
                b: ["d"]
              }
@@ -188,7 +188,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, null_character: "n/a")
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                a: [nil, "nil", "c"],
                b: ["NA", nil, "d"]
              }
@@ -205,7 +205,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, skip_rows: 1)
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                c: ["e"],
                d: ["f"]
              }
@@ -222,7 +222,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, with_columns: ["b"])
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                b: ["d", "f"]
              }
     end
@@ -238,7 +238,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, names: ["a2", "b2"])
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                a2: ["c", "e"],
                b2: ["d", "f"]
              }
@@ -270,7 +270,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, dtypes: [{"a", :string}], names: ["a2", "b2"])
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                a2: ["1", "3"],
                b2: [2, 4]
              }
@@ -292,7 +292,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv)
 
-      assert DF.to_map(df) == %{
+      assert DF.to_map(df, atom_keys: true) == %{
                a: [1, 3],
                b: [2, 4]
              }
@@ -419,7 +419,7 @@ defmodule Explorer.DataFrameTest do
   test "fetch/2" do
     df = DF.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
     assert Series.to_list(df["a"]) == [1, 2, 3]
-    assert DF.to_map(df[["a"]]) == %{a: [1, 2, 3]}
+    assert DF.to_map(df[["a"]]) == %{"a" => [1, 2, 3]}
   end
 
   test "pop/2" do
@@ -427,11 +427,11 @@ defmodule Explorer.DataFrameTest do
 
     {s1, df2} = Access.pop(df1, "a")
     assert Series.to_list(s1) == [1, 2, 3]
-    assert DF.to_map(df2) == %{b: ["a", "b", "c"]}
+    assert DF.to_map(df2) == %{"b" => ["a", "b", "c"]}
 
     {df3, df4} = Access.pop(df1, ["a"])
-    assert DF.to_map(df3) == %{a: [1, 2, 3]}
-    assert DF.to_map(df4) == %{b: ["a", "b", "c"]}
+    assert DF.to_map(df3) == %{"a" => [1, 2, 3]}
+    assert DF.to_map(df4) == %{"b" => ["a", "b", "c"]}
   end
 
   test "get_and_update/3" do
@@ -443,12 +443,17 @@ defmodule Explorer.DataFrameTest do
       end)
 
     assert Series.to_list(s) == [1, 2, 3]
-    assert DF.to_map(df2) == %{a: [0, 0, 0], b: ["a", "b", "c"]}
+    assert DF.to_map(df2, atom_keys: true) == %{a: [0, 0, 0], b: ["a", "b", "c"]}
   end
 
   test "pivot_wider/2" do
     df1 = DF.from_columns(id: [1, 1], variable: ["a", "b"], value: [1, 2])
-    assert DF.to_map(DF.pivot_wider(df1, "variable", "value")) == %{id: [1], a: [1], b: [2]}
+
+    assert DF.to_map(DF.pivot_wider(df1, "variable", "value"), atom_keys: true) == %{
+             id: [1],
+             a: [1],
+             b: [2]
+           }
 
     df2 = DF.from_columns(id: [1, 1], variable: ["a", "b"], value: [1.0, 2.0])
 
@@ -456,7 +461,8 @@ defmodule Explorer.DataFrameTest do
              DF.pivot_wider(df2, "variable", "value",
                id_cols: ["id"],
                names_prefix: "col"
-             )
+             ),
+             atom_keys: true
            ) == %{id: [1], cola: [1.0], colb: [2.0]}
   end
 


### PR DESCRIPTION
We want to avoid the inconsistency of having the columns of our
dataframes as strings and the map keys as atoms. This way we always have
column names as strings, and if the user wants he/she can configure to
use atoms.