### PR TITLE
Use microseconds instead of milliseconds

### DIFF
--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -55,6 +55,7 @@ defmodule Explorer.PolarsBackend.Shared do
   def normalise_dtype("date"), do: :date
   def normalise_dtype("datetime"), do: :datetime
   def normalise_dtype("datetime[ms]"), do: :datetime
+  def normalise_dtype("datetime[μs]"), do: :datetime
   def normalise_dtype("list [u32]"), do: :list
 
   def internal_from_dtype(:integer), do: "i64"
@@ -62,5 +63,5 @@ defmodule Explorer.PolarsBackend.Shared do
   def internal_from_dtype(:boolean), do: "bool"
   def internal_from_dtype(:string), do: "str"
   def internal_from_dtype(:date), do: "date"
-  def internal_from_dtype(:datetime), do: "datetime[ms]"
+  def internal_from_dtype(:datetime), do: "datetime[μs]"
 end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -134,6 +134,14 @@ defmodule Explorer.Series do
         ["1", nil]
       >
 
+  It is possible to create a series of `:datetime` from a list of microseconds since Unix Epoch.
+
+      iex> Explorer.Series.from_list([1649883642 * 1_000 * 1_000], dtype: :datetime)
+      #Explorer.Series<
+        datetime[1]
+        [2022-04-13 21:00:42.000000]
+      >
+
   Mixing non-numeric data types will raise an ArgumentError.
 
       iex> Explorer.Series.from_list([1, "a"])
@@ -245,6 +253,36 @@ defmodule Explorer.Series do
       #Explorer.Series<
         string[3]
         ["1", "2", "3"]
+      >
+
+      iex> s = Explorer.Series.from_list([1, 2, 3])
+      iex> Explorer.Series.cast(s, :float)
+      #Explorer.Series<
+        float[3]
+        [1.0, 2.0, 3.0]
+      >
+
+      iex> s = Explorer.Series.from_list([1, 2, 3])
+      iex> Explorer.Series.cast(s, :date)
+      #Explorer.Series<
+        date[3]
+        [1970-01-02, 1970-01-03, 1970-01-04]
+      >
+
+  Note that `datetime` is represented as an integer of microseconds since Unix Epoch (1970-01-01 00:00:00).
+
+      iex> s = Explorer.Series.from_list([1, 2, 3])
+      iex> Explorer.Series.cast(s, :datetime)
+      #Explorer.Series<
+        datetime[3]
+        [1970-01-01 00:00:00.000001, 1970-01-01 00:00:00.000002, 1970-01-01 00:00:00.000003]
+      >
+
+      iex> s = Explorer.Series.from_list([1649883642 * 1_000 * 1_000])
+      iex> Explorer.Series.cast(s, :datetime)
+      #Explorer.Series<
+        datetime[1]
+        [2022-04-13 21:00:42.000000]
       >
 
   `cast/2` will return the series as a no-op if you try to cast to the same dtype.
@@ -640,7 +678,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~N[2021-01-01 00:00:00], ~N[1999-12-31 00:00:00]])
       iex> Explorer.Series.min(s)
-      ~N[1999-12-31 00:00:00.000]
+      ~N[1999-12-31 00:00:00.000000]
 
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.min(s)
@@ -679,7 +717,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~N[2021-01-01 00:00:00], ~N[1999-12-31 00:00:00]])
       iex> Explorer.Series.max(s)
-      ~N[2021-01-01 00:00:00.000]
+      ~N[2021-01-01 00:00:00.000000]
 
       iex> s = Explorer.Series.from_list(["a", "b", "c"])
       iex> Explorer.Series.max(s)
@@ -830,7 +868,7 @@ defmodule Explorer.Series do
 
       iex> s = Explorer.Series.from_list([~N[2021-01-01 00:00:00], ~N[1999-12-31 00:00:00]])
       iex> Explorer.Series.quantile(s, 0.5)
-      ~N[2021-01-01 00:00:00.000]
+      ~N[2021-01-01 00:00:00.000000]
 
       iex> s = Explorer.Series.from_list([true, false, true])
       iex> Explorer.Series.quantile(s, 0.5)

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -83,7 +83,6 @@ pub fn df_read_csv(
     Ok(ExDataFrame::new(df))
 }
 
-// TODO: consider adding "datetime[ns]"
 fn dtype_from_str(dtype: &str) -> Result<DataType, ExplorerError> {
     match dtype {
         "str" => Ok(DataType::Utf8),
@@ -91,6 +90,7 @@ fn dtype_from_str(dtype: &str) -> Result<DataType, ExplorerError> {
         "i64" => Ok(DataType::Int64),
         "bool" => Ok(DataType::Boolean),
         "date" => Ok(DataType::Date),
+        "datetime[μs]" => Ok(DataType::Datetime(TimeUnit::Microseconds, None)),
         "datetime[ms]" => Ok(DataType::Datetime(TimeUnit::Milliseconds, None)),
         _ => Err(ExplorerError::Internal("Unrecognised datatype".into())),
     }

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -66,7 +66,7 @@ pub fn s_new_date64(name: &str, val: Vec<Option<ExDateTime>>) -> ExSeries {
                 .map(|dt| dt.map(|dt| dt.into()))
                 .collect::<Vec<Option<i64>>>(),
         )
-        .cast(&DataType::Datetime(TimeUnit::Milliseconds, None))
+        .cast(&DataType::Datetime(TimeUnit::Microseconds, None))
         .unwrap(),
     )
 }
@@ -467,7 +467,7 @@ pub fn s_min(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
         DataType::Int64 => Ok(s.min::<i64>().encode(env)),
         DataType::Float64 => Ok(s.min::<f64>().encode(env)),
         DataType::Date => Ok(s.min::<i32>().map(ExDate::from).encode(env)),
-        DataType::Datetime(TimeUnit::Milliseconds, None) => {
+        DataType::Datetime(TimeUnit::Microseconds, None) => {
             Ok(s.min::<i64>().map(ExDateTime::from).encode(env))
         }
         dt => panic!("min/1 not implemented for {:?}", dt),
@@ -481,7 +481,7 @@ pub fn s_max(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
         DataType::Int64 => Ok(s.max::<i64>().encode(env)),
         DataType::Float64 => Ok(s.max::<f64>().encode(env)),
         DataType::Date => Ok(s.max::<i32>().map(ExDate::from).encode(env)),
-        DataType::Datetime(TimeUnit::Milliseconds, None) => {
+        DataType::Datetime(TimeUnit::Microseconds, None) => {
             Ok(s.max::<i64>().map(ExDateTime::from).encode(env))
         }
         dt => panic!("max/1 not implemented for {:?}", dt),
@@ -543,7 +543,7 @@ fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Term<'b> {
         AnyValue::Int64(v) => Some(v).encode(env),
         AnyValue::Float64(v) => Some(v).encode(env),
         AnyValue::Date(v) => Some(ExDate::from(v)).encode(env),
-        AnyValue::Datetime(v, TimeUnit::Milliseconds, None) => {
+        AnyValue::Datetime(v, TimeUnit::Microseconds, None) => {
             Some(ExDateTime::from(v)).encode(env)
         }
         dt => panic!("get/2 not implemented for {:?}", dt),
@@ -583,10 +583,10 @@ pub fn s_quantile<'a>(
             None => Ok(None::<ExDate>.encode(env)),
             Some(days) => Ok(ExDate::from(days as i32).encode(env)),
         },
-        DataType::Datetime(TimeUnit::Milliseconds, None) => {
+        DataType::Datetime(TimeUnit::Microseconds, None) => {
             match s.datetime()?.quantile(quantile, strategy)? {
                 None => Ok(None::<ExDateTime>.encode(env)),
-                Some(ms) => Ok(ExDateTime::from(ms as i64).encode(env)),
+                Some(microseconds) => Ok(ExDateTime::from(microseconds as i64).encode(env)),
             }
         }
         _ => Ok(term_from_value(
@@ -650,7 +650,7 @@ pub fn cast(s: &Series, to_type: &str) -> Result<Series, ExplorerError> {
         "float" => Ok(s.cast(&DataType::Float64)?),
         "integer" => Ok(s.cast(&DataType::Int64)?),
         "date" => Ok(s.cast(&DataType::Date)?),
-        "datetime" => Ok(s.cast(&DataType::Datetime(TimeUnit::Milliseconds, None))?),
+        "datetime" => Ok(s.cast(&DataType::Datetime(TimeUnit::Microseconds, None))?),
         "boolean" => Ok(s.cast(&DataType::Boolean)?),
         "string" => Ok(s.cast(&DataType::Utf8)?),
         _ => Err(ExplorerError::Other(String::from("Cannot cast to type"))),

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -119,7 +119,7 @@ defmodule Explorer.DataFrameTest do
       assert DF.to_map(df, atom_keys: true) == %{
                a: [1, 3],
                b: [2, 4],
-               c: [~N[2020-10-15 00:00:01.000], ~N[2020-10-15 00:00:18.000]]
+               c: [~N[2020-10-15 00:00:01.000000], ~N[2020-10-15 00:00:18.000000]]
              }
     end
 

--- a/test/explorer/polars_backend/series_test.exs
+++ b/test/explorer/polars_backend/series_test.exs
@@ -24,9 +24,10 @@ defmodule Explorer.PolarsBackend.SeriesTest do
 
   test "from_list/2 of naive datetime" do
     dates = [
-      ~N[1022-01-04 21:18:31.224],
-      ~N[1988-11-23 06:36:16.158],
-      ~N[2353-03-07 00:39:35.702]
+      ~N[2022-04-13 15:44:31.560227],
+      ~N[1022-01-04 21:18:31.224123],
+      ~N[1988-11-23 06:36:16.158432],
+      ~N[2353-03-07 00:39:35.702789]
     ]
 
     assert Series.from_list(dates, :datetime) |> Series.to_list() == dates
@@ -38,9 +39,10 @@ defmodule Explorer.PolarsBackend.SeriesTest do
       for _i <- 0..:rand.uniform(100) do
         days = :rand.uniform(today_in_days)
         seconds = days * day_in_seconds
+        microseconds = {:rand.uniform(999_999), 6}
 
         seconds
-        |> NaiveDateTime.from_gregorian_seconds({:rand.uniform(100) * 1_000, 3})
+        |> NaiveDateTime.from_gregorian_seconds(microseconds)
         |> NaiveDateTime.add(:rand.uniform(24) * 60 * 60, :second)
         |> NaiveDateTime.add(:rand.uniform(60) * 60, :second)
         |> NaiveDateTime.add(:rand.uniform(60), :second)


### PR DESCRIPTION
This change introduces the usage of microseconds for datetime series in order
to preserve more precision.

Closes https://github.com/elixir-nx/explorer/issues/156