### PR TITLE
[WIP] Better error messages

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2013,9 +2013,9 @@ defmodule Explorer.Series do
   end
 
   defp dtype_length_error(function, left, right, :length_mismatch) do
-    raise(
-      ArgumentError,
-      "Explorer.Series.#{function} could not compare. One of the series must be length 1 or length of left argument (#{length(left)}) must match the length of right argument (#{length(right)})"
-    )
+    raise ArgumentError,
+          "Explorer.Series.#{function} could not compare. " <>
+            "One of the series must be length 1 or the length of both series should match, "
+            "got #{length(left)} and #{length(right)}"
   end
 end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1214,6 +1214,20 @@ defmodule Explorer.Series do
         [true, true, false]
       >
 
+      iex> s1 = Explorer.Series.from_list([1, 2, 3])
+      iex> s2 = Explorer.Series.from_list([1])
+      iex> Explorer.Series.equal(s1, s2)
+      #Explorer.Series<
+        boolean[3]
+        [true, false, false]
+      >
+
+      iex> s1 = Explorer.Series.from_list([1, 2, 3])
+      iex> s2 = Explorer.Series.from_list([1,2])
+      iex> Explorer.Series.equal(s1, s2)
+      ** (ArgumentError) Explorer.Series.equal/2 could not compare. One of the series must be length 1 or length of left argument (3) must match the length of right argument (2)
+
+
       iex> s = Explorer.Series.from_list([1, 2, 3])
       iex> Explorer.Series.equal(s, 1)
       #Explorer.Series<
@@ -1253,8 +1267,17 @@ defmodule Explorer.Series do
           left :: Series.t(),
           right :: Series.t() | number() | Date.t() | NaiveDateTime.t() | boolean() | String.t()
         ) :: Series.t()
-  def equal(%Series{dtype: dtype} = left, %Series{dtype: dtype} = right),
-    do: apply_impl(left, :eq, [right])
+
+  def equal(%Series{dtype: _left_dtype} = left, %Series{dtype: _right_dtype} = right) do
+    case is_valid_length(left, right) do
+      {false, nil} -> dtype_length_error("equal/2", left, right, nil)
+      false -> dtype_length_error("equal/2", left, right)
+      true -> apply_impl(left, :eq, [right])
+    end
+  end
+
+  # def equal(%Series{dtype: dtype} = left, %Series{dtype: dtype} = right),
+  #   do: apply_impl(left, :eq, [right])
 
   def equal(%Series{dtype: dtype} = left, right)
       when K.and(dtype in [:integer, :float], is_number(right)),
@@ -1271,6 +1294,15 @@ defmodule Explorer.Series do
 
   def equal(%Series{dtype: :boolean} = left, right) when is_boolean(right),
     do: apply_impl(left, :eq, [right])
+
+  defp is_valid_length(left, right) do
+    case {Series.length(left), Series.length(right)} do
+      {l, r} when K.or(l == 0, r == 0) -> {false, nil}
+      {l, r} when K.or(l == 1, r == 1) -> true
+      {l, r} when l != r -> false
+      {_, _} -> true
+    end
+  end
 
   @doc """
   Returns boolean mask of `left != right`, element-wise.
@@ -1974,4 +2006,20 @@ defmodule Explorer.Series do
         "cannot invoke Explorer.Series.#{function} with mismatched dtypes: #{left_dtype} and " <>
           "#{right_dtype}."
       )
+
+  defp dtype_length_error(function, left, right, zero_length \\ "")
+
+  defp dtype_length_error(function, _left, _right, nil) do
+    raise(
+      ArgumentError,
+      "Explorer.Series.#{function} cannot compare zero length series"
+    )
+  end
+
+  defp dtype_length_error(function, left, right, _zero_length) do
+    raise(
+      ArgumentError,
+      "Explorer.Series.#{function} could not compare. One of the series must be length 1 or length of left argument (#{length(left)}) must match the length of right argument (#{length(right)})"
+    )
+  end
 end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2008,10 +2008,8 @@ defmodule Explorer.Series do
       )
 
   defp dtype_length_error(function, _left, _right, :zero_length) do
-    raise(
-      ArgumentError,
-      "Explorer.Series.#{function} cannot compare with zero length series"
-    )
+    raise ArgumentError,
+          "Explorer.Series.#{function} cannot compare non-empty series with zero length series"
   end
 
   defp dtype_length_error(function, left, right, :length_mismatch) do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -50,41 +50,38 @@ defmodule Explorer.SeriesTest do
   end
 
   describe "equal/2" do
-    test "raises error when both of the arguments are empty Series" do
-      assert_raise ArgumentError,
-                   "Explorer.Series.equal/2 cannot compare zero length series",
-                   fn ->
-                     left = Series.from_list([])
-                     right = Series.from_list([])
-                     Series.equal(left, right)
-                   end
-    end
-
-    test "raises error when RHS is an empty Series" do
-      assert_raise ArgumentError,
-                   "Explorer.Series.equal/2 cannot compare zero length series",
-                   fn ->
-                     left = Series.from_list([1, 2, 3])
-                     right = Series.from_list([])
-                     Series.equal(left, right)
-                   end
-    end
-
-    test "raises error when LHS is an empty Series" do
-      assert_raise ArgumentError,
-                   "Explorer.Series.equal/2 cannot compare zero length series",
-                   fn ->
-                     left = Series.from_list([])
-                     right = Series.from_list([1, 2, 3])
-                     Series.equal(left, right)
-                   end
-    end
-
-    test "do not raise any error if LHS is length 1" do
-      left = Series.from_list([1])
-      right = Series.from_list([1, 2, 3])
+    test "returns an empty series if both are empty" do
+      left = Series.from_list([])
+      right = Series.from_list([])
       s = Series.equal(left, right)
-      assert Series.to_list(s) == [true, false, false]
+      assert Series.to_list(s) == []
     end
+  end
+
+  test "raises error when RHS is an empty Series" do
+    assert_raise ArgumentError,
+                 "Explorer.Series.equal/2 cannot compare with zero length series",
+                 fn ->
+                   left = Series.from_list([1, 2, 3])
+                   right = Series.from_list([])
+                   Series.equal(left, right)
+                 end
+  end
+
+  test "raises error when LHS is an empty Series" do
+    assert_raise ArgumentError,
+                 "Explorer.Series.equal/2 cannot compare with zero length series",
+                 fn ->
+                   left = Series.from_list([])
+                   right = Series.from_list([1, 2, 3])
+                   Series.equal(left, right)
+                 end
+  end
+
+  test "do not raise any error if LHS is length 1" do
+    left = Series.from_list([1])
+    right = Series.from_list([1, 2, 3])
+    s = Series.equal(left, right)
+    assert Series.to_list(s) == [true, false, false]
   end
 end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -48,4 +48,49 @@ defmodule Explorer.SeriesTest do
 
     assert Series.to_list(s2) == [1, 4, 3]
   end
+
+  describe "equal/2" do
+    test "raises error when both of the arguments are empty Series" do
+      assert_raise ArgumentError,
+                   "Explorer.Series.equal/2 cannot compare zero length series",
+                   fn ->
+                     left = Series.from_list([])
+                     right = Series.from_list([])
+                     Series.equal(left, right)
+                   end
+    end
+
+    test "raises error when RHS is an empty Series" do
+      assert_raise ArgumentError,
+                   "Explorer.Series.equal/2 cannot compare zero length series",
+                   fn ->
+                     left = Series.from_list([1, 2, 3])
+                     right = Series.from_list([])
+                     Series.equal(left, right)
+                   end
+    end
+
+    test "raises error when LHS is an empty Series" do
+      assert_raise ArgumentError,
+                   "Explorer.Series.equal/2 cannot compare zero length series",
+                   fn ->
+                     left = Series.from_list([])
+                     right = Series.from_list([1, 2, 3])
+                     Series.equal(left, right)
+                   end
+    end
+
+    test "do not raise any error if LHS is length 1" do
+      left = Series.from_list([1])
+      right = Series.from_list([1, 2, 3])
+      s = Series.equal(left, right)
+      assert Series.to_list(s) == [true, false, false]
+    end
+  end
+
+  # test "equal/2" do
+  #  s = Series.from_list([1,2,3])
+
+  #  assert
+  # end
 end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -87,10 +87,4 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(s) == [true, false, false]
     end
   end
-
-  # test "equal/2" do
-  #  s = Series.from_list([1,2,3])
-
-  #  assert
-  # end
 end


### PR DESCRIPTION
> This is a first approach to handle error messages raised by comparison functions. I've made a first attempt only with `Series.equal/2` because I realized that the job may be much more complex than I've pictured it in the start. So I'll submit for some code review before applying the approach to the other functions.

## What?

As discussed in #158, we need better error messages for comparison functions when applied to Series of some specific lengths.

## Why?

**Developer Experience:** current error messages raised are not clear enough on what's really wrong. Changes proposed here will give a better overview on what's happening when:
1. One of the Series is empty
2. Length of the Series do not match each other

## How?

I've tried to match (as most as I could) the coding style already present in the surrounding functions, so my approach was:
1. To create a new helper function (`dtype_length_error`) to raise the error, which deals with the function that was called and the arguments (it solves the discussion about showing both LHS and RHS in the error message). This function has a clause to deal with empty Series and mismatches
2. To create another helper function (`is_valid_length`) to check the length of the arguments and, by adding it to the first clause, making sure that all the other clauses will never have to deal with empty or mismatched Series. 
3. To add a bunch of new tests to `series_test.exs` to check if all of the above would work (I've added two more examples to the doctest session, but some other cases didn't make much sense as docs, so I opted to add them directly to the dedicated file)

- - - 

**Next steps:**

If the approach is correct, the plan would be to create more tests to check **all** of the element-wise functions and apply the lenght-check + error-raising  to all of those that breaks when there is an empty or mismatched pair. 

When completed it closes #158 and a lot of related similar issues.