### PR TITLE
Implement the Table.Reader protocol

### DIFF
--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -13,6 +13,7 @@ defmodule Explorer.Backend.Series do
 
   @callback from_list(list(), dtype()) :: s
   @callback to_list(s) :: list()
+  @callback to_enum(s) :: Enumerable.t()
   @callback cast(s, dtype) :: s
 
   # Introspection

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2152,3 +2152,18 @@ defmodule Explorer.DataFrame do
   defp column_index_map(names),
     do: for({name, idx} <- Enum.with_index(names), into: %{}, do: {idx, name})
 end
+
+defimpl Table.Reader, for: Explorer.DataFrame do
+  def init(df) do
+    columns = Explorer.DataFrame.names(df)
+
+    data =
+      Enum.map(columns, fn column ->
+        df
+        |> Explorer.DataFrame.pull(column)
+        |> Explorer.Series.to_enum()
+      end)
+
+    {:columns, %{columns: columns}, data}
+  end
+end

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -42,6 +42,11 @@ defmodule Explorer.PolarsBackend.Series do
   end
 
   @impl true
+  def to_enum(series) do
+    Explorer.PolarsBackend.Series.Iterator.new(series)
+  end
+
+  @impl true
   def cast(series, dtype), do: Shared.apply_native(series, :s_cast, [Atom.to_string(dtype)])
 
   # Introspection

--- a/lib/explorer/polars_backend/series/iterator.ex
+++ b/lib/explorer/polars_backend/series/iterator.ex
@@ -1,0 +1,48 @@
+defmodule Explorer.PolarsBackend.Series.Iterator do
+  @moduledoc false
+
+  defstruct [:series, :offset, :size]
+
+  alias Explorer.PolarsBackend.Series
+
+  def new(series) do
+    %__MODULE__{series: series, offset: 0, size: Series.length(series)}
+  end
+
+  defimpl Enumerable do
+    alias Explorer.PolarsBackend.Series
+
+    def count(iterator), do: {:ok, iterator.size}
+
+    def member?(_iterator, _value), do: {:error, __MODULE__}
+
+    def slice(iterator) do
+      {:ok, iterator.size,
+       fn start, length ->
+         iterator.series
+         |> Series.slice(start, length)
+         |> Series.to_list()
+       end}
+    end
+
+    def reduce(_iterator, {:halt, acc}, _fun), do: {:halted, acc}
+
+    def reduce(iterator, {:suspend, acc}, fun) do
+      {:suspended, acc, &reduce(iterator, &1, fun)}
+    end
+
+    def reduce(iterator, {:cont, acc}, fun) do
+      case next(iterator) do
+        :done -> {:done, acc}
+        {value, iterator} -> reduce(iterator, fun.(value, acc), fun)
+      end
+    end
+
+    defp next(%{offset: size, size: size}), do: :done
+
+    defp next(iterator) do
+      value = Series.get(iterator.series, iterator.offset)
+      {value, update_in(iterator.offset, &(&1 + 1))}
+    end
+  end
+end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -181,6 +181,18 @@ defmodule Explorer.Series do
   def to_list(series), do: apply_impl(series, :to_list)
 
   @doc """
+  Converts a series to an enumerable.
+
+  ## Examples
+
+      iex> series = Explorer.Series.from_list([1, 2, 3])
+      iex> series |> Explorer.Series.to_enum() |> Enum.to_list()
+      [1, 2, 3]
+  """
+  @spec to_enum(series :: Series.t()) :: Enumerable.t()
+  def to_enum(series), do: apply_impl(series, :to_enum)
+
+  @doc """
   Converts a `t:Nx.Tensor.t/0` to a series.
 
   ## Examples

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule Explorer.MixProject do
       {:ex_doc, "~> 0.24", only: :docs, runtime: false},
       {:nx, "~> 0.1.0"},
       {:rustler_precompiled, "~> 0.3"},
+      {:table, "~> 0.1.0"},
       {:table_rex, "~> 3.1.1"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -10,6 +10,7 @@
   "nx": {:hex, :nx, "0.1.0", "8f8a047dc0fd2b1798406edf828b43c46cca648b13c58fd5abd52285316b3d86", [:mix], [], "hexpm", "24ce6e184dc9c7b7c6c247923bfbe994101a7fe049bd3fd376b5b0512f787256"},
   "rustler": {:hex, :rustler, "0.25.0", "32526b51af7e58a740f61941bf923486ce6415a91c3934cc16c281aa201a2240", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:toml, "~> 0.6", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "6b43a11a37fe79c6234d88c4102ab5dfede7a6a764dc5c7b539956cfa02f3cf4"},
   "rustler_precompiled": {:hex, :rustler_precompiled, "0.3.0", "47517912d12ccd9e5e950e2ae11c67842261a811233514a60351c560436ea309", [:mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:rustler, "~> 0.23", [hex: :rustler, repo: "hexpm", optional: false]}], "hexpm", "836dbaaf5bea2538c30a06f89ac1961b6fbfb1eff2dba71fc30b1eecb4a0546e"},
+  "table": {:hex, :table, "0.1.0", "f16104d717f960a623afb134a91339d40d8e11e0c96cfce54fee086b333e43f0", [:mix], [], "hexpm", "bf533d3606823ad8a7ee16f41941e5e6e0e42a20c4504cdf4cfabaaed1c8acb9"},
   "table_rex": {:hex, :table_rex, "3.1.1", "0c67164d1714b5e806d5067c1e96ff098ba7ae79413cc075973e17c38a587caa", [:mix], [], "hexpm", "678a23aba4d670419c23c17790f9dcd635a4a89022040df7d5d772cb21012490"},
   "toml": {:hex, :toml, "0.6.2", "38f445df384a17e5d382befe30e3489112a48d3ba4c459e543f748c2f25dd4d1", [:mix], [], "hexpm", "d013e45126d74c0c26a38d31f5e8e9b83ea19fc752470feb9a86071ca5a672fa"},
 }

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -502,4 +502,18 @@ defmodule Explorer.DataFrameTest do
                  "columns and dtypes must be identical for all dataframes",
                  fn -> DF.concat_rows(df1, DF.from_columns(x: [7, 8, 9], y: [10, 11, 12])) end
   end
+
+  test "table reader integration" do
+    df = DF.from_columns(x: [1, 2, 3], y: ["a", "b", "c"])
+
+    assert df |> Table.to_rows() |> Enum.to_list() == [
+             %{"x" => 1, "y" => "a"},
+             %{"x" => 2, "y" => "b"},
+             %{"x" => 3, "y" => "c"}
+           ]
+
+    columns = Table.to_columns(df)
+    assert Enum.to_list(columns["x"]) == [1, 2, 3]
+    assert Enum.to_list(columns["y"]) == ["a", "b", "c"]
+  end
 end

--- a/test/explorer/polars_backend/series_test.exs
+++ b/test/explorer/polars_backend/series_test.exs
@@ -50,4 +50,27 @@ defmodule Explorer.PolarsBackend.SeriesTest do
 
     assert Series.from_list(dates, :datetime) |> Series.to_list() == dates
   end
+
+  test "to_enum/1 returns a valid enumerable" do
+    enum1 =
+      [1, 2, 3, 4]
+      |> Explorer.Series.from_list(backend: Explorer.PolarsBackend)
+      |> Explorer.Series.to_enum()
+
+    enum2 =
+      ["a", "b", "c"]
+      |> Explorer.Series.from_list(backend: Explorer.PolarsBackend)
+      |> Explorer.Series.to_enum()
+
+    assert Enum.zip(enum1, enum2) == [{1, "a"}, {2, "b"}, {3, "c"}]
+
+    assert Enum.reduce(enum1, 0, &+/2) == 10
+    assert Enum.reduce(enum2, "", &<>/2) == "cba"
+
+    assert Enum.count(enum1) == 4
+    assert Enum.count(enum2) == 3
+
+    assert Enum.slice(enum1, 1..2) == [2, 3]
+    assert Enum.slice(enum2, 1..2) == ["b", "c"]
+  end
 end


### PR DESCRIPTION
Closes #169.

Integrates Explorer with [`table`](https://hexdocs.pm/table/Table.html), which allows a `DataFrame` to be consumed as rows or as columns.