### PR TITLE
rename to_map to to_columns and add to_rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `DataFrame.to_rows/2` converts a `DataFrame` to a list of maps
+
 ### Changed
 
 - `Series.length/1` is now `Series.size/` in keeping with Elixir idioms
 - `Nx` is now an optional dependency
 - Minimum Elixir version is now 1.13
+- `DataFrame.to_map/2` is now `DataFrame.to_columns/2`
+- `Rustler` is now an optional dependency
 
 ## [v0.1.1] - 2022-04-27
 

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -51,7 +51,7 @@ defmodule Explorer.Backend.DataFrame do
 
   @callback from_columns(map() | Keyword.t()) :: df
   @callback from_rows(list(map() | Keyword.t())) :: df
-  @callback to_map(df, convert_series? :: boolean(), atom_keys? :: boolean()) :: map()
+  @callback to_columns(df, convert_series? :: boolean(), atom_keys? :: boolean()) :: map()
   @callback to_binary(df, header? :: boolean(), delimiter :: String.t()) :: String.t()
 
   # Introspection

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -52,6 +52,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback from_columns(map() | Keyword.t()) :: df
   @callback from_rows(list(map() | Keyword.t())) :: df
   @callback to_columns(df, convert_series? :: boolean(), atom_keys? :: boolean()) :: map()
+  @callback to_rows(df, atom_keys? :: boolean()) :: [map()]
   @callback to_binary(df, header? :: boolean(), delimiter :: String.t()) :: String.t()
 
   # Introspection

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -456,6 +456,30 @@ defmodule Explorer.DataFrame do
   end
 
   @doc """
+  Converts a dataframe to a list of maps (rows).
+
+  ## Options
+
+    * `:atom_keys` - Configure if the resultant maps should have atom keys. (default: `false`)
+
+  ## Examples
+
+      iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, nil])
+      iex> Explorer.DataFrame.to_rows(df)
+      [%{"floats" => 1.0, "ints" => 1}, %{"floats" => 2.0 ,"ints" => nil}]
+
+      iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, nil])
+      iex> Explorer.DataFrame.to_rows(df, atom_keys: true)
+      [%{floats: 1.0, ints: 1}, %{floats: 2.0, ints: nil}]
+  """
+  @spec to_rows(df :: DataFrame.t(), Keyword.t()) :: [map()]
+  def to_rows(df, opts \\ []) do
+    opts = Keyword.validate!(opts, atom_keys: false)
+
+    apply_impl(df, :to_rows, [opts[:atom_keys]])
+  end
+
+  @doc """
   Writes a dataframe to a binary representation of a delimited file.
 
   ## Options

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -458,6 +458,10 @@ defmodule Explorer.DataFrame do
   @doc """
   Converts a dataframe to a list of maps (rows).
 
+  > #### Warning {: .warning}
+  >
+  > This may be an expensive operation because `polars` stores data in columnar format.
+
   ## Options
 
     * `:atom_keys` - Configure if the resultant maps should have atom keys. (default: `false`)

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -429,7 +429,7 @@ defmodule Explorer.DataFrame do
   end
 
   @doc """
-  Converts a dataframe to a map.
+  Converts a dataframe to a map of columns.
 
   By default, the constituent series of the dataframe are converted to Elixir lists.
 
@@ -441,18 +441,18 @@ defmodule Explorer.DataFrame do
   ## Examples
 
       iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, nil])
-      iex> Explorer.DataFrame.to_map(df)
+      iex> Explorer.DataFrame.to_columns(df)
       %{"floats" => [1.0, 2.0], "ints" => [1, nil]}
 
       iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, nil])
-      iex> Explorer.DataFrame.to_map(df, atom_keys: true)
+      iex> Explorer.DataFrame.to_columns(df, atom_keys: true)
       %{floats: [1.0, 2.0], ints: [1, nil]}
   """
-  @spec to_map(df :: DataFrame.t(), Keyword.t()) :: map()
-  def to_map(df, opts \\ []) do
+  @spec to_columns(df :: DataFrame.t(), Keyword.t()) :: map()
+  def to_columns(df, opts \\ []) do
     opts = Keyword.validate!(opts, convert_series: true, atom_keys: false)
 
-    apply_impl(df, :to_map, [opts[:convert_series], opts[:atom_keys]])
+    apply_impl(df, :to_columns, [opts[:convert_series], opts[:atom_keys]])
   end
 
   @doc """

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -219,6 +219,15 @@ defmodule Explorer.PolarsBackend.DataFrame do
     Map.put(acc, series_name, series)
   end
 
+  @impl true
+  def to_rows(%DataFrame{data: polars_df} = df, atom_keys?) do
+    names = if atom_keys?, do: df |> names() |> Enum.map(&String.to_atom/1), else: names(df)
+
+    polars_df
+    |> Enum.map(fn s -> s |> Shared.to_series() |> PolarsSeries.to_list() end)
+    |> Enum.zip_with(fn row -> names |> Enum.zip(row) |> Map.new() end)
+  end
+
   # Introspection
 
   @impl true

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -198,11 +198,11 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def to_map(%DataFrame{data: df}, convert_series?, atom_keys?) do
-    Enum.reduce(df, %{}, &to_map_reducer(&1, &2, convert_series?, atom_keys?))
+  def to_columns(%DataFrame{data: df}, convert_series?, atom_keys?) do
+    Enum.reduce(df, %{}, &to_columns_reducer(&1, &2, convert_series?, atom_keys?))
   end
 
-  defp to_map_reducer(series, acc, convert_series?, atom_keys?) do
+  defp to_columns_reducer(series, acc, convert_series?, atom_keys?) do
     series_name =
       series
       |> Native.s_name()

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -81,7 +81,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, delimiter: "*")
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                a: ["c", "e"],
                b: ["d", "f"]
              }
@@ -98,7 +98,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, dtypes: [{"a", :string}])
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                a: ["1", "3"],
                b: [2, 4]
              }
@@ -116,7 +116,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.read_csv!(csv, parse_dates: true)
       assert [:datetime] = DF.select(df, ["c"]) |> Explorer.DataFrame.dtypes()
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                a: [1, 3],
                b: [2, 4],
                c: [~N[2020-10-15 00:00:01.000000], ~N[2020-10-15 00:00:18.000000]]
@@ -135,7 +135,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.read_csv!(csv, parse_dates: false)
       assert [:string] = DF.select(df, ["c"]) |> Explorer.DataFrame.dtypes()
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                a: [1, 3],
                b: [2, 4],
                c: ["2020-10-15 00:00:01", "2020-10-15 00:00:18"]
@@ -153,7 +153,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, header?: false)
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                column_1: ["a", "c", "e"],
                column_2: ["b", "d", "f"]
              }
@@ -170,7 +170,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, max_rows: 1)
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                a: ["c"],
                b: ["d"]
              }
@@ -188,7 +188,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, null_character: "n/a")
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                a: [nil, "nil", "c"],
                b: ["NA", nil, "d"]
              }
@@ -205,7 +205,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, skip_rows: 1)
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                c: ["e"],
                d: ["f"]
              }
@@ -222,7 +222,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, with_columns: ["b"])
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                b: ["d", "f"]
              }
     end
@@ -238,7 +238,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, names: ["a2", "b2"])
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                a2: ["c", "e"],
                b2: ["d", "f"]
              }
@@ -270,7 +270,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv, dtypes: [{"a", :string}], names: ["a2", "b2"])
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                a2: ["1", "3"],
                b2: [2, 4]
              }
@@ -292,7 +292,7 @@ defmodule Explorer.DataFrameTest do
 
       df = DF.read_csv!(csv)
 
-      assert DF.to_map(df, atom_keys: true) == %{
+      assert DF.to_columns(df, atom_keys: true) == %{
                a: [1, 3],
                b: [2, 4]
              }
@@ -309,7 +309,7 @@ defmodule Explorer.DataFrameTest do
 
       assert DF.names(df) == DF.names(parquet_df)
       assert DF.dtypes(df) == DF.dtypes(parquet_df)
-      assert DF.to_map(df) == DF.to_map(parquet_df)
+      assert DF.to_columns(df) == DF.to_columns(parquet_df)
     end
   end
 
@@ -386,7 +386,7 @@ defmodule Explorer.DataFrameTest do
 
       assert DF.names(df) == DF.names(ndjson_df)
       assert DF.dtypes(df) == DF.dtypes(ndjson_df)
-      assert DF.to_map(df) == DF.to_map(ndjson_df)
+      assert DF.to_columns(df) == DF.to_columns(ndjson_df)
     end
   end
 
@@ -419,7 +419,7 @@ defmodule Explorer.DataFrameTest do
   test "fetch/2" do
     df = DF.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
     assert Series.to_list(df["a"]) == [1, 2, 3]
-    assert DF.to_map(df[["a"]]) == %{"a" => [1, 2, 3]}
+    assert DF.to_columns(df[["a"]]) == %{"a" => [1, 2, 3]}
   end
 
   test "pop/2" do
@@ -427,11 +427,11 @@ defmodule Explorer.DataFrameTest do
 
     {s1, df2} = Access.pop(df1, "a")
     assert Series.to_list(s1) == [1, 2, 3]
-    assert DF.to_map(df2) == %{"b" => ["a", "b", "c"]}
+    assert DF.to_columns(df2) == %{"b" => ["a", "b", "c"]}
 
     {df3, df4} = Access.pop(df1, ["a"])
-    assert DF.to_map(df3) == %{"a" => [1, 2, 3]}
-    assert DF.to_map(df4) == %{"b" => ["a", "b", "c"]}
+    assert DF.to_columns(df3) == %{"a" => [1, 2, 3]}
+    assert DF.to_columns(df4) == %{"b" => ["a", "b", "c"]}
   end
 
   test "get_and_update/3" do
@@ -443,13 +443,13 @@ defmodule Explorer.DataFrameTest do
       end)
 
     assert Series.to_list(s) == [1, 2, 3]
-    assert DF.to_map(df2, atom_keys: true) == %{a: [0, 0, 0], b: ["a", "b", "c"]}
+    assert DF.to_columns(df2, atom_keys: true) == %{a: [0, 0, 0], b: ["a", "b", "c"]}
   end
 
   test "pivot_wider/2" do
     df1 = DF.from_columns(id: [1, 1], variable: ["a", "b"], value: [1, 2])
 
-    assert DF.to_map(DF.pivot_wider(df1, "variable", "value"), atom_keys: true) == %{
+    assert DF.to_columns(DF.pivot_wider(df1, "variable", "value"), atom_keys: true) == %{
              id: [1],
              a: [1],
              b: [2]
@@ -457,7 +457,7 @@ defmodule Explorer.DataFrameTest do
 
     df2 = DF.from_columns(id: [1, 1], variable: ["a", "b"], value: [1.0, 2.0])
 
-    assert DF.to_map(
+    assert DF.to_columns(
              DF.pivot_wider(df2, "variable", "value",
                id_cols: ["id"],
                names_prefix: "col"


### PR DESCRIPTION
Closes #169. I'm not sure if `to_rows` is the most efficient possible implementation, but row-wise access or iteration is discouraged in `polars` and presents a challenge for types so I went with this.