### PR TITLE
remove unnecessary `RwLock`

### DIFF
--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -3,13 +3,12 @@ use polars::prelude::*;
 use rustler::resource::ResourceArc;
 use rustler::{Atom, Encoder, Env, NifStruct, NifUntaggedEnum, Term};
 use std::convert::TryInto;
-use std::sync::RwLock;
 
 use std::result::Result;
 
 use crate::atoms;
 
-pub struct ExDataFrameRef(pub RwLock<DataFrame>);
+pub struct ExDataFrameRef(pub DataFrame);
 pub struct ExSeriesRef(pub Series);
 
 #[derive(NifStruct)]
@@ -26,7 +25,7 @@ pub struct ExSeries {
 
 impl ExDataFrameRef {
     pub fn new(df: DataFrame) -> Self {
-        Self(RwLock::new(df))
+        Self(df)
     }
 }
 


### PR DESCRIPTION
The `RwLock` around `ExDataFrame` was a holdover from `ex_polars`, which mutated the underlying dataframe. We don't do that, so we don't need a RwLock. I also think that if we did, it would likely be more reasonable to use a Mutex.