### PR TITLE
Move backend functions to `Explorer.Backend`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Rustler` is now an optional dependency
 - `read_` and `write_` IO functions are now `from_` and `to_`
 - `to_binary` is now `dump_csv`
+- Now uses `polars`'s "simd" feature
+- Now uses `polars`'s "performant" feature
+- `Explorer.default_backend/0` is now `Explorer.Backend.get/0`
+- `Explorer.default_backend/1` is now `Explorer.Backend.put/1`
 
 ## [v0.1.1] - 2022-04-27
 

--- a/lib/explorer.ex
+++ b/lib/explorer.ex
@@ -5,54 +5,5 @@ defmodule Explorer do
 
   Most of the functionality in `Explorer` is in `Explorer.DataFrame` and
   `Explorer.Series`. Refer to those modules for more in-depth documentation.
-
-  This module only handles the default backend for `Explorer`. The default
-  backend is read from the application environment. Currently, the only backend
-  is an in-memory, eager one based on
-  [`Polars`](https://github.com/pola-rs/polars). When alternatives are
-  available, you can use them by configuring your runtime:
-
-      # config/runtime.exs
-      import Config
-      config :explorer, default_backend: Lib.CustomBackend
   """
-
-  ## Backend API
-
-  @backend_key {Explorer, :default_backend}
-
-  @doc """
-  Sets the current process default backend to `backend`.
-
-  The default backend is stored only in the process dictionary. This means if
-  you start a separate process, such as `Task`, the default backend must be set
-  on the new process too.
-
-  ## Examples
-      iex> Explorer.default_backend(Lib.CustomBackend)
-      Explorer.PolarsBackend
-      iex> Explorer.default_backend()
-      Lib.CustomBackend
-  """
-  def default_backend(backend) do
-    Process.put(@backend_key, backend!(backend)) ||
-      backend!(Application.fetch_env!(:explorer, :default_backend))
-  end
-
-  @doc """
-  Gets the default backend for the current process.
-  """
-  def default_backend do
-    Process.get(@backend_key) || backend!(Application.fetch_env!(:explorer, :default_backend))
-  end
-
-  ## Helpers
-
-  defp backend!(backend) when is_atom(backend),
-    do: backend
-
-  defp backend!(other) do
-    raise ArgumentError,
-          "backend must be an atom, got: #{inspect(other)}"
-  end
 end

--- a/lib/explorer/backend.ex
+++ b/lib/explorer/backend.ex
@@ -1,8 +1,55 @@
 defmodule Explorer.Backend do
   @moduledoc """
-  The behaviour for Explorer backends.
+  The behaviour for Explorer backends and associated functions.
 
   Each backend is a module with `DataFrame` and `Series` submodules that match the 
   respective behaviours for each.
+
+  The default backend is read from the application environment. Currently, the only 
+  backend is an in-memory, eager one based on
+  [`Polars`](https://github.com/pola-rs/polars). When alternatives are
+  available, you can use them by configuring your runtime:
+
+      # config/runtime.exs
+      import Config
+      config :explorer, default_backend: Lib.CustomBackend
+
   """
+
+  @backend_key {Explorer, :default_backend}
+
+  @doc """
+  Sets the current process default backend to `backend`.
+
+  The default backend is stored only in the process dictionary. This means if
+  you start a separate process, such as `Task`, the default backend must be set
+  on the new process too.
+
+  ## Examples
+      iex> Explorer.Backend.put(Lib.CustomBackend)
+      Explorer.PolarsBackend
+      iex> Explorer.Backend.get()
+      Lib.CustomBackend
+  """
+  def put(backend) do
+    Process.put(@backend_key, backend!(backend)) ||
+      backend!(Application.fetch_env!(:explorer, :default_backend))
+  end
+
+  @doc """
+  Gets the default backend for the current process.
+  """
+  def get do
+    Process.get(@backend_key) || backend!(Application.fetch_env!(:explorer, :default_backend))
+  end
+
+  ## Helpers
+
+  defp backend!(backend) when is_atom(backend),
+    do: backend
+
+  defp backend!(other) do
+    raise ArgumentError,
+          "backend must be an atom, got: #{inspect(other)}"
+  end
 end

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -394,7 +394,7 @@ defmodule Explorer.DataFrame do
 
   ## Options
 
-    * `backend` - The Explorer backend to use. Defaults to the value returned by `Explorer.default_backend/0`.
+    * `backend` - The Explorer backend to use. Defaults to the value returned by `Explorer.Backend.get/0`.
 
   ## Examples
 
@@ -2199,7 +2199,7 @@ defmodule Explorer.DataFrame do
   # Helpers
 
   defp backend_from_options!(opts) do
-    backend = Explorer.Shared.backend_from_options!(opts) || Explorer.default_backend()
+    backend = Explorer.Shared.backend_from_options!(opts) || Explorer.Backend.get()
     Module.concat(backend, "DataFrame")
   end
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2011,7 +2011,7 @@ defmodule Explorer.Series do
   # Helpers
 
   defp backend_from_options!(opts) do
-    backend = Explorer.Shared.backend_from_options!(opts) || Explorer.default_backend()
+    backend = Explorer.Shared.backend_from_options!(opts) || Explorer.Backend.get()
     Module.concat(backend, "Series")
   end
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -2,6 +2,9 @@ defmodule Explorer.Shared do
   # A collection of **private** helpers shared in Explorer.
   @moduledoc false
 
+  @doc """
+  Gets the backend from a `Keyword.t()` or `nil`.
+  """
   def backend_from_options!(opts) do
     case Keyword.fetch(opts, :backend) do
       {:ok, backend} when is_atom(backend) ->


### PR DESCRIPTION
Closes #194.