### PR TITLE
Optimize backend lookup

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2197,7 +2197,7 @@ defmodule Explorer.DataFrame do
 
   defp backend_from_options!(opts) do
     backend = Explorer.Shared.backend_from_options!(opts) || Explorer.Backend.get()
-    Module.concat(backend, "DataFrame")
+    :"#{backend}.DataFrame"
   end
 
   defp apply_impl(df, fun, args \\ []) do

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2018,7 +2018,7 @@ defmodule Explorer.Series do
 
   defp backend_from_options!(opts) do
     backend = Explorer.Shared.backend_from_options!(opts) || Explorer.Backend.get()
-    Module.concat(backend, "Series")
+    :"#{backend}.Series"
   end
 
   defp apply_impl(series, fun, args \\ []) do


### PR DESCRIPTION
It is a hack but one that is safe for us to perform.

This avoid the process of splitting the module name into parts and joining them together.