### PR TITLE
Add DataFrame.new/2

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -48,9 +48,8 @@ defmodule Explorer.Backend.DataFrame do
 
   # Conversion
 
-  @callback new(Table.Reader.t()) :: df
-  @callback from_columns(map() | Keyword.t()) :: df
-  @callback from_rows(list(map() | Keyword.t())) :: df
+  @callback from_tabular(Table.Reader.t()) :: df
+  @callback from_series(map() | Keyword.t()) :: df
   @callback to_columns(df, convert_series? :: boolean(), atom_keys? :: boolean()) :: map()
   @callback to_rows(df, atom_keys? :: boolean()) :: [map()]
   @callback dump_csv(df, header? :: boolean(), delimiter :: String.t()) :: String.t()

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -48,6 +48,7 @@ defmodule Explorer.Backend.DataFrame do
 
   # Conversion
 
+  @callback new(Table.Reader.t()) :: df
   @callback from_columns(map() | Keyword.t()) :: df
   @callback from_rows(list(map() | Keyword.t())) :: df
   @callback to_columns(df, convert_series? :: boolean(), atom_keys? :: boolean()) :: map()

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -30,7 +30,7 @@ defmodule Explorer.DataFrame do
   Dataframes can be created from normal Elixir objects. The main ways you might do this are
   `from_columns/1` and `from_rows/1`. For example:
 
-      iex> Explorer.DataFrame.from_columns(a: ["a", "b"], b: [1, 2])
+      iex> Explorer.DataFrame.new(a: ["a", "b"], b: [1, 2])
       #Explorer.DataFrame<
         [rows: 2, columns: 2]
         a string ["a", "b"]
@@ -487,7 +487,16 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-  Columnar data:
+  From series:
+
+      iex> Explorer.DataFrame.new(%{floats: Explorer.Series.from_list([1.0, 2.0]), ints: Explorer.Series.from_list([1, nil])})
+      #Explorer.DataFrame<
+        [rows: 2, columns: 2]
+        floats float [1.0, 2.0]
+        ints integer [1, nil]
+      >
+
+  From columnar data:
 
       iex> Explorer.DataFrame.new(%{floats: [1.0, 2.0], ints: [1, nil]})
       #Explorer.DataFrame<
@@ -506,7 +515,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.new(%{floats: [1.0, 2.0], ints: [1, "wrong"]})
       ** (ArgumentError) cannot create series "ints": cannot make a series from mismatched types - the value "wrong" does not match inferred dtype integer
 
-  Row data:
+  From row data:
 
       iex> rows = [%{id: 1, name: "José"}, %{id: 2, name: "Christopher"}, %{id: 3, name: "Cristine"}]
       iex> Explorer.DataFrame.new(rows)
@@ -525,106 +534,36 @@ defmodule Explorer.DataFrame do
       >
   """
   @doc type: :single
-  @spec new(Table.Reader.t(), opts :: Keyword.t()) :: DataFrame.t()
-  def new(tabular, opts \\ []) do
+  @spec new(
+          Table.Reader.t() | series_pairs,
+          opts :: Keyword.t()
+        ) :: DataFrame.t()
+        when series_pairs: %{column_name() => Series.t()} | [{column_name(), Series.t()}]
+  def new(data, opts \\ []) do
     backend = backend_from_options!(opts)
 
-    case tabular do
-      %DataFrame{data: %^backend{}} -> tabular
-      tabular -> backend.new(tabular)
+    case data do
+      %DataFrame{data: %^backend{}} ->
+        data
+
+      data ->
+        case classify_data(data) do
+          {:series, series} -> backend.from_series(series)
+          {:other, tabular} -> backend.from_tabular(tabular)
+        end
     end
   end
 
-  @doc """
-  Creates a new dataframe from a map or keyword of lists or series.
+  defp classify_data([{_, %Series{}} | _] = data), do: {:series, data}
 
-  Lists and series must be the same size. This function has the same validations from
-  `Explorer.Series.from_list/2` for lists, so they must conform to the requirements for making a series.
-
-  ## Options
-
-    * `backend` - The Explorer backend to use. Defaults to the value returned by `Explorer.Backend.get/0`.
-
-  ## Examples
-
-      iex> Explorer.DataFrame.from_columns(%{floats: [1.0, 2.0], ints: [1, nil]})
-      #Explorer.DataFrame<
-        [rows: 2, columns: 2]
-        floats float [1.0, 2.0]
-        ints integer [1, nil]
-      >
-
-      iex> Explorer.DataFrame.from_columns([floats: [1.0, 2.0], ints: [1, nil]])
-      #Explorer.DataFrame<
-        [rows: 2, columns: 2]
-        floats float [1.0, 2.0]
-        ints integer [1, nil]
-      >
-
-      iex> Explorer.DataFrame.from_columns(floats: Explorer.Series.from_list([1.0, 2.0]), ints: Explorer.Series.from_list([1, nil]))
-      #Explorer.DataFrame<
-        [rows: 2, columns: 2]
-        floats float [1.0, 2.0]
-        ints integer [1, nil]
-      >
-
-      iex> Explorer.DataFrame.from_columns(%{floats: [1.0, 2.0], ints: [1, "wrong"]})
-      ** (ArgumentError) cannot create series "ints": cannot make a series from mismatched types - the value "wrong" does not match inferred dtype integer
-  """
-  @doc type: :single
-  @spec from_columns(series :: column_pairs(list()), opts :: Keyword.t()) :: DataFrame.t()
-  def from_columns(series, opts \\ []) do
-    backend = backend_from_options!(opts)
-    backend.from_columns(series)
+  defp classify_data(data) when map_size(data) > 0 do
+    case Enum.fetch!(data, 0) do
+      {_, %Series{}} -> {:series, data}
+      _ -> {:other, data}
+    end
   end
 
-  @doc """
-  Creates a new dataframe from a list of maps or keyword lists.
-
-  Each map in the list should have the same keys, but missing keys will yield a null value for
-  that row. All values for a given key should be of the same dtype.
-
-  Keyword lists should all be in the same order.
-
-  ## Options
-
-    * `backend` - The Explorer backend to use. Defaults to the value returned by `Explorer.default_backend/0`.
-
-  ## Examples
-
-      iex> rows = [%{id: 1, name: "José"}, %{id: 2, name: "Christopher"}, %{id: 3, name: "Cristine"}]
-      iex> Explorer.DataFrame.from_rows(rows)
-      #Explorer.DataFrame<
-        [rows: 3, columns: 2]
-        id integer [1, 2, 3]
-        name string ["José", "Christopher", "Cristine"]
-      >
-
-      iex> rows = [[id: 1, name: "José"], [id: 2, name: "Christopher"], [id: 3, name: "Cristine"]]
-      iex> Explorer.DataFrame.from_rows(rows)
-      #Explorer.DataFrame<
-        [rows: 3, columns: 2]
-        id integer [1, 2, 3]
-        name string ["José", "Christopher", "Cristine"]
-      >
-
-  With a list of maps, missing keys will yield a null value.
-
-      iex> rows = [%{id: 1, name: "José", date: ~D[2001-01-01]}, %{id: 2, date: ~D[1993-01-01]}, %{id: 3, name: "Cristine"}]
-      iex> Explorer.DataFrame.from_rows(rows)
-      #Explorer.DataFrame<
-        [rows: 3, columns: 3]
-        date date [2001-01-01, 1993-01-01, nil]
-        id integer [1, 2, 3]
-        name string ["José", nil, "Cristine"]
-      >
-  """
-  @doc type: :single
-  @spec from_rows(rows :: list(column_pairs(any())), opts :: Keyword.t()) :: DataFrame.t()
-  def from_rows(rows, opts \\ []) do
-    backend = backend_from_options!(opts)
-    backend.from_rows(rows)
-  end
+  defp classify_data(data), do: {:other, data}
 
   @doc """
   Converts a dataframe to a map of columns.
@@ -638,11 +577,11 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-      iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, nil])
+      iex> df = Explorer.DataFrame.new(floats: [1.0, 2.0], ints: [1, nil])
       iex> Explorer.DataFrame.to_columns(df)
       %{"floats" => [1.0, 2.0], "ints" => [1, nil]}
 
-      iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, nil])
+      iex> df = Explorer.DataFrame.new(floats: [1.0, 2.0], ints: [1, nil])
       iex> Explorer.DataFrame.to_columns(df, atom_keys: true)
       %{floats: [1.0, 2.0], ints: [1, nil]}
   """
@@ -667,11 +606,11 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-      iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, nil])
+      iex> df = Explorer.DataFrame.new(floats: [1.0, 2.0], ints: [1, nil])
       iex> Explorer.DataFrame.to_rows(df)
       [%{"floats" => 1.0, "ints" => 1}, %{"floats" => 2.0 ,"ints" => nil}]
 
-      iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, nil])
+      iex> df = Explorer.DataFrame.new(floats: [1.0, 2.0], ints: [1, nil])
       iex> Explorer.DataFrame.to_rows(df, atom_keys: true)
       [%{floats: 1.0, ints: 1}, %{floats: 2.0, ints: nil}]
   """
@@ -690,7 +629,7 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-      iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, 2])
+      iex> df = Explorer.DataFrame.new(floats: [1.0, 2.0], ints: [1, 2])
       iex> Explorer.DataFrame.names(df)
       ["floats", "ints"]
   """
@@ -703,7 +642,7 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-      iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0], ints: [1, 2])
+      iex> df = Explorer.DataFrame.new(floats: [1.0, 2.0], ints: [1, 2])
       iex> Explorer.DataFrame.dtypes(df)
       [:float, :integer]
   """
@@ -716,7 +655,7 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-      iex> df = Explorer.DataFrame.from_columns(floats: [1.0, 2.0, 3.0], ints: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(floats: [1.0, 2.0, 3.0], ints: [1, 2, 3])
       iex> Explorer.DataFrame.shape(df)
       {3, 2}
   """
@@ -825,7 +764,7 @@ defmodule Explorer.DataFrame do
 
   You can select columns with a list of names:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.select(df, ["a"])
       #Explorer.DataFrame<
         [rows: 3, columns: 1]
@@ -835,7 +774,7 @@ defmodule Explorer.DataFrame do
 
   You can also use a range or a list of integers:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3], c: [4, 5, 6])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3], c: [4, 5, 6])
       iex> Explorer.DataFrame.select(df, [0, 1])
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -843,7 +782,7 @@ defmodule Explorer.DataFrame do
         b integer [1, 2, 3]
       >
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3], c: [4, 5, 6])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3], c: [4, 5, 6])
       iex> Explorer.DataFrame.select(df, 0..1)
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -853,7 +792,7 @@ defmodule Explorer.DataFrame do
 
   Or you can use a callback function that takes the dataframe's names as its first argument:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.select(df, &String.starts_with?(&1, "b"))
       #Explorer.DataFrame<
         [rows: 3, columns: 1]
@@ -862,14 +801,14 @@ defmodule Explorer.DataFrame do
 
   If you pass `:drop` as the third argument, it will return all but the named columns:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.select(df, ["b"], :drop)
       #Explorer.DataFrame<
         [rows: 3, columns: 1]
         a string ["a", "b", "c"]
       >
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3], c: [4, 5, 6])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3], c: [4, 5, 6])
       iex> Explorer.DataFrame.select(df, ["a", "b"], :drop)
       #Explorer.DataFrame<
         [rows: 3, columns: 1]
@@ -914,7 +853,7 @@ defmodule Explorer.DataFrame do
 
   You can pass a mask directly:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.filter(df, Explorer.Series.greater(df["b"], 1))
       #Explorer.DataFrame<
         [rows: 2, columns: 2]
@@ -924,7 +863,7 @@ defmodule Explorer.DataFrame do
 
   You can combine masks using `Explorer.Series.and/2` or `Explorer.Series.or/2`:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> b_gt = Explorer.Series.greater(df["b"], 1)
       iex> a_eq = Explorer.Series.equal(df["a"], "b")
       iex> Explorer.DataFrame.filter(df, Explorer.Series.and(a_eq, b_gt))
@@ -936,7 +875,7 @@ defmodule Explorer.DataFrame do
 
   Including a list:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.filter(df, [false, true, false])
       #Explorer.DataFrame<
         [rows: 1, columns: 2]
@@ -946,7 +885,7 @@ defmodule Explorer.DataFrame do
 
   Or you can invoke a callback on the dataframe:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.filter(df, &Explorer.Series.greater(&1["b"], 1))
       #Explorer.DataFrame<
         [rows: 2, columns: 2]
@@ -996,7 +935,7 @@ defmodule Explorer.DataFrame do
 
   You can pass in a list directly as a new column:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.mutate(df, c: [4, 5, 6])
       #Explorer.DataFrame<
         [rows: 3, columns: 3]
@@ -1007,7 +946,7 @@ defmodule Explorer.DataFrame do
 
   Or you can pass in a series:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> s = Explorer.Series.from_list([4, 5, 6])
       iex> Explorer.DataFrame.mutate(df, c: s)
       #Explorer.DataFrame<
@@ -1019,7 +958,7 @@ defmodule Explorer.DataFrame do
 
   Or you can invoke a callback on the dataframe:
 
-      iex> df = Explorer.DataFrame.from_columns(a: [4, 5, 6], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: [4, 5, 6], b: [1, 2, 3])
       iex> Explorer.DataFrame.mutate(df, c: &Explorer.Series.add(&1["a"], &1["b"]))
       #Explorer.DataFrame<
         [rows: 3, columns: 3]
@@ -1030,7 +969,7 @@ defmodule Explorer.DataFrame do
 
   You can overwrite existing columns:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.mutate(df, a: [4, 5, 6])
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -1040,7 +979,7 @@ defmodule Explorer.DataFrame do
 
   Scalar values are repeated to fill the series:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.mutate(df, a: 4)
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -1050,7 +989,7 @@ defmodule Explorer.DataFrame do
 
   Including when a callback returns a scalar:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.mutate(df, a: &Explorer.Series.max(&1["b"]))
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -1060,7 +999,7 @@ defmodule Explorer.DataFrame do
 
   Alternatively, all of the above works with a map instead of a keyword list:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "c"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "c"], b: [1, 2, 3])
       iex> Explorer.DataFrame.mutate(df, %{"c" => [4, 5, 6]})
       #Explorer.DataFrame<
         [rows: 3, columns: 3]
@@ -1085,7 +1024,7 @@ defmodule Explorer.DataFrame do
 
   A single column name will sort ascending by that column:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["b", "c", "a"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["b", "c", "a"], b: [1, 2, 3])
       iex> Explorer.DataFrame.arrange(df, "a")
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -1095,7 +1034,7 @@ defmodule Explorer.DataFrame do
 
   You can also sort descending:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["b", "c", "a"], b: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(a: ["b", "c", "a"], b: [1, 2, 3])
       iex> Explorer.DataFrame.arrange(df, desc: "a")
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -1184,7 +1123,7 @@ defmodule Explorer.DataFrame do
 
   A callback on the dataframe's names can be passed instead of a list (like `select/3`):
 
-      iex> df = Explorer.DataFrame.from_columns(x1: [1, 3, 3], x2: ["a", "c", "c"], y1: [1, 2, 3])
+      iex> df = Explorer.DataFrame.new(x1: [1, 3, 3], x2: ["a", "c", "c"], y1: [1, 2, 3])
       iex> Explorer.DataFrame.distinct(df, columns: &String.starts_with?(&1, "x"))
       #Explorer.DataFrame<
         [rows: 2, columns: 2]
@@ -1225,7 +1164,7 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-      iex> df = Explorer.DataFrame.from_columns(a: [1, 2, nil], b: [1, nil, 3])
+      iex> df = Explorer.DataFrame.new(a: [1, 2, nil], b: [1, nil, 3])
       iex> Explorer.DataFrame.drop_nil(df)
       #Explorer.DataFrame<
         [rows: 1, columns: 2]
@@ -1233,7 +1172,7 @@ defmodule Explorer.DataFrame do
         b integer [1]
       >
 
-      iex> df = Explorer.DataFrame.from_columns(a: [1, 2, nil], b: [1, nil, 3], c: [nil, 5, 6])
+      iex> df = Explorer.DataFrame.new(a: [1, 2, nil], b: [1, nil, 3], c: [nil, 5, 6])
       iex> Explorer.DataFrame.drop_nil(df, [:a, :c])
       #Explorer.DataFrame<
         [rows: 1, columns: 3]
@@ -1242,7 +1181,7 @@ defmodule Explorer.DataFrame do
         c integer [5]
       >
 
-      iex> df = Explorer.DataFrame.from_columns(a: [1, 2, nil], b: [1, nil, 3], c: [nil, 5, 6])
+      iex> df = Explorer.DataFrame.new(a: [1, 2, nil], b: [1, nil, 3], c: [nil, 5, 6])
       iex> Explorer.DataFrame.drop_nil(df, 0..1)
       #Explorer.DataFrame<
         [rows: 1, columns: 3]
@@ -1275,7 +1214,7 @@ defmodule Explorer.DataFrame do
 
   You can pass in a list of new names:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "a"], b: [1, 3, 1])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "a"], b: [1, 3, 1])
       iex> Explorer.DataFrame.rename(df, ["c", "d"])
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -1285,7 +1224,7 @@ defmodule Explorer.DataFrame do
 
   Or you can rename individual columns using keyword args:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "a"], b: [1, 3, 1])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "a"], b: [1, 3, 1])
       iex> Explorer.DataFrame.rename(df, a: "first")
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -1295,7 +1234,7 @@ defmodule Explorer.DataFrame do
 
   Or you can rename individual columns using a map:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "a"], b: [1, 3, 1])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "a"], b: [1, 3, 1])
       iex> Explorer.DataFrame.rename(df, %{"a" => "first"})
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -1305,7 +1244,7 @@ defmodule Explorer.DataFrame do
 
   Or if you want to use a function:
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "a"], b: [1, 3, 1])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "a"], b: [1, 3, 1])
       iex> Explorer.DataFrame.rename(df, &(&1 <> "_test"))
       #Explorer.DataFrame<
         [rows: 3, columns: 2]
@@ -1455,7 +1394,7 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "a", "c"], b: ["b", "a", "b", "d"])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "a", "c"], b: ["b", "a", "b", "d"])
       iex> Explorer.DataFrame.dummies(df, ["a"])
       #Explorer.DataFrame<
         [rows: 4, columns: 3]
@@ -1464,7 +1403,7 @@ defmodule Explorer.DataFrame do
         a_c integer [0, 0, 0, 1]
       >
 
-      iex> df = Explorer.DataFrame.from_columns(a: ["a", "b", "a", "c"], b: ["b", "a", "b", "d"])
+      iex> df = Explorer.DataFrame.new(a: ["a", "b", "a", "c"], b: ["b", "a", "b", "d"])
       iex> Explorer.DataFrame.dummies(df, ["a", "b"])
       #Explorer.DataFrame<
         [rows: 4, columns: 6]
@@ -1572,7 +1511,7 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-      iex> df = Explorer.DataFrame.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
+      iex> df = Explorer.DataFrame.new(a: [1, 2, 3], b: ["a", "b", "c"])
       iex> Explorer.DataFrame.take(df, [0, 2])
       #Explorer.DataFrame<
         [rows: 2, columns: 2]
@@ -1795,7 +1734,7 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-      iex> df = Explorer.DataFrame.from_columns(id: [1, 1], variable: ["a", "b"], value: [1, 2])
+      iex> df = Explorer.DataFrame.new(id: [1, 1], variable: ["a", "b"], value: [1, 2])
       iex> Explorer.DataFrame.pivot_wider(df, "variable", "value")
       #Explorer.DataFrame<
         [rows: 1, columns: 3]
@@ -1866,8 +1805,8 @@ defmodule Explorer.DataFrame do
 
   Inner join:
 
-      iex> left = Explorer.DataFrame.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
-      iex> right = Explorer.DataFrame.from_columns(a: [1, 2, 2], c: ["d", "e", "f"])
+      iex> left = Explorer.DataFrame.new(a: [1, 2, 3], b: ["a", "b", "c"])
+      iex> right = Explorer.DataFrame.new(a: [1, 2, 2], c: ["d", "e", "f"])
       iex> Explorer.DataFrame.join(left, right)
       #Explorer.DataFrame<
         [rows: 3, columns: 3]
@@ -1878,8 +1817,8 @@ defmodule Explorer.DataFrame do
 
   Left join:
 
-      iex> left = Explorer.DataFrame.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
-      iex> right = Explorer.DataFrame.from_columns(a: [1, 2, 2], c: ["d", "e", "f"])
+      iex> left = Explorer.DataFrame.new(a: [1, 2, 3], b: ["a", "b", "c"])
+      iex> right = Explorer.DataFrame.new(a: [1, 2, 2], c: ["d", "e", "f"])
       iex> Explorer.DataFrame.join(left, right, how: :left)
       #Explorer.DataFrame<
         [rows: 4, columns: 3]
@@ -1890,8 +1829,8 @@ defmodule Explorer.DataFrame do
 
   Right join:
 
-      iex> left = Explorer.DataFrame.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
-      iex> right = Explorer.DataFrame.from_columns(a: [1, 2, 4], c: ["d", "e", "f"])
+      iex> left = Explorer.DataFrame.new(a: [1, 2, 3], b: ["a", "b", "c"])
+      iex> right = Explorer.DataFrame.new(a: [1, 2, 4], c: ["d", "e", "f"])
       iex> Explorer.DataFrame.join(left, right, how: :right)
       #Explorer.DataFrame<
         [rows: 3, columns: 3]
@@ -1902,8 +1841,8 @@ defmodule Explorer.DataFrame do
 
   Outer join:
 
-      iex> left = Explorer.DataFrame.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
-      iex> right = Explorer.DataFrame.from_columns(a: [1, 2, 4], c: ["d", "e", "f"])
+      iex> left = Explorer.DataFrame.new(a: [1, 2, 3], b: ["a", "b", "c"])
+      iex> right = Explorer.DataFrame.new(a: [1, 2, 4], c: ["d", "e", "f"])
       iex> Explorer.DataFrame.join(left, right, how: :outer)
       #Explorer.DataFrame<
         [rows: 4, columns: 3]
@@ -1914,8 +1853,8 @@ defmodule Explorer.DataFrame do
 
   Cross join:
 
-      iex> left = Explorer.DataFrame.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
-      iex> right = Explorer.DataFrame.from_columns(a: [1, 2, 4], c: ["d", "e", "f"])
+      iex> left = Explorer.DataFrame.new(a: [1, 2, 3], b: ["a", "b", "c"])
+      iex> right = Explorer.DataFrame.new(a: [1, 2, 4], c: ["d", "e", "f"])
       iex> Explorer.DataFrame.join(left, right, how: :cross)
       #Explorer.DataFrame<
         [rows: 9, columns: 4]
@@ -1927,8 +1866,8 @@ defmodule Explorer.DataFrame do
 
   Inner join with different names:
 
-      iex> left = Explorer.DataFrame.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
-      iex> right = Explorer.DataFrame.from_columns(d: [1, 2, 2], c: ["d", "e", "f"])
+      iex> left = Explorer.DataFrame.new(a: [1, 2, 3], b: ["a", "b", "c"])
+      iex> right = Explorer.DataFrame.new(d: [1, 2, 2], c: ["d", "e", "f"])
       iex> Explorer.DataFrame.join(left, right, on: [{"a", "d"}])
       #Explorer.DataFrame<
         [rows: 3, columns: 3]
@@ -1998,8 +1937,8 @@ defmodule Explorer.DataFrame do
 
   ## Examples
 
-      iex> df1 = Explorer.DataFrame.from_columns(x: [1, 2, 3], y: ["a", "b", "c"])
-      iex> df2 = Explorer.DataFrame.from_columns(x: [4, 5, 6], y: ["d", "e", "f"])
+      iex> df1 = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+      iex> df2 = Explorer.DataFrame.new(x: [4, 5, 6], y: ["d", "e", "f"])
       iex> Explorer.DataFrame.concat_rows([df1, df2])
       #Explorer.DataFrame<
         [rows: 6, columns: 2]
@@ -2007,8 +1946,8 @@ defmodule Explorer.DataFrame do
         y string ["a", "b", "c", "d", "e", ...]
       >
 
-      iex> df1 = Explorer.DataFrame.from_columns(x: [1, 2, 3], y: ["a", "b", "c"])
-      iex> df2 = Explorer.DataFrame.from_columns(x: [4.2, 5.3, 6.4], y: ["d", "e", "f"])
+      iex> df1 = Explorer.DataFrame.new(x: [1, 2, 3], y: ["a", "b", "c"])
+      iex> df2 = Explorer.DataFrame.new(x: [4.2, 5.3, 6.4], y: ["d", "e", "f"])
       iex> Explorer.DataFrame.concat_rows([df1, df2])
       #Explorer.DataFrame<
         [rows: 6, columns: 2]

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -479,7 +479,7 @@ defmodule Explorer.DataFrame do
   @doc """
   Creates a new dataframe.
 
-  Any tabular data is accepted, as long as it adheres to the `Table.Reader` protocol.
+  Accepts any tabular data adhering to the `Table.Reader` protocol, as well as a map or a keyword list with series.
 
   ## Options
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -66,8 +66,6 @@ defmodule Explorer.PolarsBackend.Native do
   def df_drop_nulls(_df, _subset), do: err()
   def df_dtypes(_df), do: err()
   def df_filter(_df, _mask), do: err()
-  def df_from_map_rows(_rows), do: err()
-  def df_from_keyword_rows(_rows), do: err()
   def df_get_columns(_df), do: err()
   def df_groups(_df, _colnames), do: err()
   def df_groupby_agg(_df, _groups, _aggs), do: err()

--- a/mix.lock
+++ b/mix.lock
@@ -10,7 +10,7 @@
   "nx": {:hex, :nx, "0.1.0", "8f8a047dc0fd2b1798406edf828b43c46cca648b13c58fd5abd52285316b3d86", [:mix], [], "hexpm", "24ce6e184dc9c7b7c6c247923bfbe994101a7fe049bd3fd376b5b0512f787256"},
   "rustler": {:hex, :rustler, "0.25.0", "32526b51af7e58a740f61941bf923486ce6415a91c3934cc16c281aa201a2240", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}, {:toml, "~> 0.6", [hex: :toml, repo: "hexpm", optional: false]}], "hexpm", "6b43a11a37fe79c6234d88c4102ab5dfede7a6a764dc5c7b539956cfa02f3cf4"},
   "rustler_precompiled": {:hex, :rustler_precompiled, "0.4.1", "61398740d9d184f7e7d6bba48f6a57523a7d4497e3cc212c9a0090deffea78cb", [:mix], [{:castore, "~> 0.1", [hex: :castore, repo: "hexpm", optional: false]}, {:rustler, "~> 0.23", [hex: :rustler, repo: "hexpm", optional: true]}], "hexpm", "99c000412ed0aae96a52aa9a4d1abc0d3a3ec1c6b2e12c0d8376d09109465e6d"},
-  "table": {:hex, :table, "0.1.0", "f16104d717f960a623afb134a91339d40d8e11e0c96cfce54fee086b333e43f0", [:mix], [], "hexpm", "bf533d3606823ad8a7ee16f41941e5e6e0e42a20c4504cdf4cfabaaed1c8acb9"},
+  "table": {:hex, :table, "0.1.1", "e8d3c75bb14b8dac227e17d85a626e695d96c271569e94e4a2d15494a7cb0b49", [:mix], [], "hexpm", "6a73280b2f5ad70474594feeb8c034ad490b97dbd5adaeb678f71c250cbc928c"},
   "table_rex": {:hex, :table_rex, "3.1.1", "0c67164d1714b5e806d5067c1e96ff098ba7ae79413cc075973e17c38a587caa", [:mix], [], "hexpm", "678a23aba4d670419c23c17790f9dcd635a4a89022040df7d5d772cb21012490"},
   "toml": {:hex, :toml, "0.6.2", "38f445df384a17e5d382befe30e3489112a48d3ba4c459e543f748c2f25dd4d1", [:mix], [], "hexpm", "d013e45126d74c0c26a38d31f5e8e9b83ea19fc752470feb9a86071ca5a672fa"},
 }

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -40,8 +40,6 @@ rustler::init!(
         df_drop_nulls,
         df_dtypes,
         df_filter,
-        df_from_map_rows,
-        df_from_keyword_rows,
         df_get_columns,
         df_groups,
         df_groupby_agg,

--- a/notebooks/exploring_explorer.livemd
+++ b/notebooks/exploring_explorer.livemd
@@ -24,7 +24,7 @@ Mix.install([
 
 ## Reading and writing data
 
-Data can be read from delimited files (like CSV), Parquet, and the Arrow IPC (feather) format. You can also load in data from a map or keyword list of columns with `Explorer.DataFrame.from_columns/1`.
+Data can be read from delimited files (like CSV), Parquet, and the Arrow IPC (feather) format. You can also load in data from a map or keyword list of columns with `Explorer.DataFrame.new/1`.
 
 For CSV, your 'usual suspects' of options are available:
 
@@ -299,7 +299,7 @@ Series.count(s)
 A `DataFrame` is really just a collection of `Series` of the same size. Which is why you can create a `DataFrame` from a `Keyword` list.
 
 ```elixir
-DataFrame.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
+DataFrame.new(a: [1, 2, 3], b: ["a", "b", "c"])
 ```
 
 Similarly to `Series`, the `Inspect` implementation prints some info at the top and to the left. At the top we see the shape of the dataframe (rows and columns) and then for each column we see the name, dtype, and first five values. We can see a bit more from that built-in dataset we loaded in earlier.

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -55,15 +55,15 @@ defmodule Explorer.DataFrameTest do
       assert_raise ArgumentError,
                    "could not find any overlapping columns",
                    fn ->
-                     left = DF.from_columns(a: [1, 2, 3])
-                     right = DF.from_columns(b: [1, 2, 3])
+                     left = DF.new(a: [1, 2, 3])
+                     right = DF.new(b: [1, 2, 3])
                      DF.join(left, right)
                    end
     end
 
     test "doesn't raise if no overlapping columns on cross join" do
-      left = DF.from_columns(a: [1, 2, 3])
-      right = DF.from_columns(b: [1, 2, 3])
+      left = DF.new(a: [1, 2, 3])
+      right = DF.new(b: [1, 2, 3])
       joined = DF.join(left, right, how: :cross)
       assert %DF{} = joined
     end
@@ -404,7 +404,7 @@ defmodule Explorer.DataFrameTest do
     @tag :tmp_dir
     test "writes to a file", %{tmp_dir: tmp_dir} do
       df =
-        DF.from_columns(
+        DF.new(
           a: [1, -10, 2, 1, 7, 1, 1, 5, 1, 1, 1, 100_000_000_000_000],
           b: [2.0, -3.5, 0.6, 2.0, -3.5, 0.6, 2.0, -3.5, 0.6, 2.0, -3.5, 0.6],
           c: [false, true, false, false, true, false, false, true, false, false, true, false],
@@ -449,7 +449,7 @@ defmodule Explorer.DataFrameTest do
   end
 
   test "fetch/2" do
-    df = DF.from_columns(a: [1, 2, 3], b: ["a", "b", "c"], c: [4.0, 5.1, 6.2])
+    df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"], c: [4.0, 5.1, 6.2])
 
     assert Series.to_list(df[:a]) == [1, 2, 3]
     assert Series.to_list(df["a"]) == [1, 2, 3]
@@ -478,7 +478,7 @@ defmodule Explorer.DataFrameTest do
   end
 
   test "pop/2" do
-    df1 = DF.from_columns(a: [1, 2, 3], b: ["a", "b", "c"], c: [4.0, 5.1, 6.2])
+    df1 = DF.new(a: [1, 2, 3], b: ["a", "b", "c"], c: [4.0, 5.1, 6.2])
 
     {s1, df2} = Access.pop(df1, "a")
     assert Series.to_list(s1) == [1, 2, 3]
@@ -502,7 +502,7 @@ defmodule Explorer.DataFrameTest do
   end
 
   test "get_and_update/3" do
-    df1 = DF.from_columns(a: [1, 2, 3], b: ["a", "b", "c"])
+    df1 = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
     {s, df2} =
       Access.get_and_update(df1, "a", fn current_value ->
@@ -514,7 +514,7 @@ defmodule Explorer.DataFrameTest do
   end
 
   test "pivot_wider/2" do
-    df1 = DF.from_columns(id: [1, 1], variable: ["a", "b"], value: [1, 2])
+    df1 = DF.new(id: [1, 1], variable: ["a", "b"], value: [1, 2])
 
     assert DF.to_columns(DF.pivot_wider(df1, "variable", "value"), atom_keys: true) == %{
              id: [1],
@@ -522,7 +522,7 @@ defmodule Explorer.DataFrameTest do
              b: [2]
            }
 
-    df2 = DF.from_columns(id: [1, 1], variable: ["a", "b"], value: [1.0, 2.0])
+    df2 = DF.new(id: [1, 1], variable: ["a", "b"], value: [1.0, 2.0])
 
     assert DF.to_columns(
              DF.pivot_wider(df2, "variable", "value",
@@ -534,19 +534,19 @@ defmodule Explorer.DataFrameTest do
   end
 
   test "concat_rows/2" do
-    df1 = DF.from_columns(x: [1, 2, 3], y: ["a", "b", "c"])
-    df2 = DF.from_columns(x: [4, 5, 6], y: ["d", "e", "f"])
+    df1 = DF.new(x: [1, 2, 3], y: ["a", "b", "c"])
+    df2 = DF.new(x: [4, 5, 6], y: ["d", "e", "f"])
     df3 = DF.concat_rows(df1, df2)
 
     assert Series.to_list(df3["x"]) == [1, 2, 3, 4, 5, 6]
     assert Series.to_list(df3["y"]) == ~w(a b c d e f)
 
-    df2 = DF.from_columns(x: [4.0, 5.0, 6.0], y: ["d", "e", "f"])
+    df2 = DF.new(x: [4.0, 5.0, 6.0], y: ["d", "e", "f"])
     df3 = DF.concat_rows(df1, df2)
 
     assert Series.to_list(df3["x"]) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 
-    df4 = DF.from_columns(x: [7, 8, 9], y: ["g", "h", nil])
+    df4 = DF.new(x: [7, 8, 9], y: ["g", "h", nil])
     df5 = DF.concat_rows(df3, df4)
 
     assert Series.to_list(df5["x"]) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]
@@ -559,15 +559,15 @@ defmodule Explorer.DataFrameTest do
 
     assert_raise ArgumentError,
                  "dataframes must have the same columns",
-                 fn -> DF.concat_rows(df1, DF.from_columns(z: [7, 8, 9])) end
+                 fn -> DF.concat_rows(df1, DF.new(z: [7, 8, 9])) end
 
     assert_raise ArgumentError,
                  "dataframes must have the same columns",
-                 fn -> DF.concat_rows(df1, DF.from_columns(x: [7, 8, 9], z: [7, 8, 9])) end
+                 fn -> DF.concat_rows(df1, DF.new(x: [7, 8, 9], z: [7, 8, 9])) end
 
     assert_raise ArgumentError,
                  "columns and dtypes must be identical for all dataframes",
-                 fn -> DF.concat_rows(df1, DF.from_columns(x: [7, 8, 9], y: [10, 11, 12])) end
+                 fn -> DF.concat_rows(df1, DF.new(x: [7, 8, 9], y: [10, 11, 12])) end
   end
 
   test "distinct/2", %{df: df} do
@@ -594,7 +594,7 @@ defmodule Explorer.DataFrameTest do
   end
 
   test "drop_nil/2" do
-    df = DF.from_columns(a: [1, 2, nil], b: [1, nil, 3])
+    df = DF.new(a: [1, 2, nil], b: [1, nil, 3])
 
     df1 = DF.drop_nil(df)
     assert DF.to_columns(df1) == %{"a" => [1], "b" => [1]}
@@ -616,7 +616,7 @@ defmodule Explorer.DataFrameTest do
   end
 
   test "table reader integration" do
-    df = DF.from_columns(x: [1, 2, 3], y: ["a", "b", "c"])
+    df = DF.new(x: [1, 2, 3], y: ["a", "b", "c"])
 
     assert df |> Table.to_rows() |> Enum.to_list() == [
              %{"x" => 1, "y" => "a"},


### PR DESCRIPTION
Closes #191, fixes #175.

This implementation essentially does `Table.to_columns |> DataFrame.from_columns`, so in case of row data the conversion happens in Elixir.

## Benchmark

Note that this benchmark uses `table` patched with https://github.com/dashbitco/table/pull/6.

```
Operating System: Linux
CPU Information: Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz
Number of Available Cores: 4
Available memory: 30.79 GB
Elixir 1.13.0
Erlang 24.1.2

Name                                 ips        average  deviation         median         99th %
columns |> DF.new                   8.06      124.11 ms     ±2.52%      123.79 ms      134.60 ms
columns |> DF.from_columns          7.99      125.18 ms     ±5.42%      123.37 ms      151.22 ms
rows |> DF.new                      2.60      384.58 ms    ±15.70%      357.50 ms      495.09 ms
rows |> DF.from_rows                2.43      412.20 ms     ±2.90%      408.58 ms      441.89 ms

Comparison: 
columns |> DF.new                   8.06
columns |> DF.from_columns          7.99 - 1.01x slower +1.07 ms
rows |> DF.new                      2.60 - 3.10x slower +260.48 ms
rows |> DF.from_rows                2.43 - 3.32x slower +288.10 ms
```

<details>
<summary>Code</summary>

```elixir
defmodule Bench do
  def run do
    dataset =
      Explorer.Datasets.fossil_fuels()
      |> List.duplicate(100)
      |> Explorer.DataFrame.concat_rows()

    rows = Explorer.DataFrame.to_rows(dataset)
    columns = Explorer.DataFrame.to_columns(dataset)

    Benchee.run(%{
      "rows |> DF.from_rows" => fn ->
        Explorer.DataFrame.from_rows(rows)
      end,
      "columns |> DF.from_columns" => fn ->
        Explorer.DataFrame.from_columns(columns)
      end,
      "rows |> DF.new" => fn ->
        Explorer.DataFrame.new(rows)
      end,
      "columns |> DF.new" => fn ->
        Explorer.DataFrame.new(columns)
      end
    })
  end
end

Bench.run()
```

</details>

## Notes

From the benchmark it seems there is no performance benefit of using `DataFrame::from_rows` in Rust, as compared to conversion to columnary data on the Elixir side.

More importantly, the current version of `DataFrame.from_rows` doesn't support data with all-nil column, neither data with mixed integers and floats (while `from_columns` does normalize them to floats). Consequently, handling those cases would be an additional overhead to the current implementation.

## Discussion

With `DataFrame.new` we no longer need `DataFrame.from_rows` and `DataFrame.from_columns`, but there are two differences:

1. `DataFrame.from_rows` supports maps with missing keys and defaults to `nil`s, but `Table` raises on such. I think this restriction is fine.
2. `DataFrame.from_columns` supports a map with series, like `%{floats: Series.from_list([1.0, 2.0]), ints: Series.from_list([1, nil])}`. `Table` doesn't recognize this as tabular, because `Series` doesn't implement the `Enumerable` protocol. One option would be to have a specialized `DataFrame.from_series` function for this case.