### PR TITLE
Remove "with" prefix from options of some functions

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -42,7 +42,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback from_ndjson(
               filename :: String.t(),
               infer_schema_length :: integer(),
-              with_batch_size :: integer()
+              batch_size :: integer()
             ) :: result(df)
   @callback to_ndjson(df, filename :: String.t()) :: result(String.t())
 
@@ -68,12 +68,12 @@ defmodule Explorer.Backend.DataFrame do
   @callback tail(df, rows :: integer()) :: df
   @callback select(df, columns :: [colname], :keep | :drop) :: df
   @callback filter(df, mask :: series) :: df
-  @callback mutate(df, with_columns :: map()) :: df
+  @callback mutate(df, columns :: map()) :: df
   @callback arrange(df, columns :: [colname | {:asc | :desc, colname}]) :: df
   @callback distinct(df, columns :: [colname], keep_all? :: boolean()) :: df
   @callback rename(df, [colname]) :: df
   @callback dummies(df, columns :: [colname]) :: df
-  @callback sample(df, n :: integer(), with_replacement? :: boolean(), seed :: integer()) :: df
+  @callback sample(df, n :: integer(), replacement :: boolean(), seed :: integer()) :: df
   @callback pull(df, column :: String.t()) :: series
   @callback slice(df, offset :: integer(), length :: integer()) :: df
   @callback take(df, indices :: list(integer())) :: df

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -25,7 +25,7 @@ defmodule Explorer.Backend.Series do
 
   @callback head(s, n :: integer()) :: s
   @callback tail(s, n :: integer()) :: s
-  @callback sample(s, n :: integer(), with_replacement :: boolean(), seed :: integer()) :: s
+  @callback sample(s, n :: integer(), replacement :: boolean(), seed :: integer()) :: s
   @callback take_every(s, integer()) :: s
   @callback filter(s, mask :: s) :: s
   @callback filter(s, function()) :: s

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -420,7 +420,7 @@ defmodule Explorer.DataFrame do
 
   ## Options
 
-    * `with_batch_size` - Sets the batch size for reading rows.
+    * `batch_size` - Sets the batch size for reading rows.
     This value may have significant impact in performance, so adjust it for your needs (default: `1000`).
 
     * `infer_schema_length` - Maximum number of rows read for schema inference.
@@ -432,7 +432,7 @@ defmodule Explorer.DataFrame do
   def from_ndjson(filename, opts \\ []) do
     opts =
       Keyword.validate!(opts,
-        with_batch_size: 1000,
+        batch_size: 1000,
         infer_schema_length: @default_infer_schema_length
       )
 
@@ -441,7 +441,7 @@ defmodule Explorer.DataFrame do
     backend.from_ndjson(
       filename,
       opts[:infer_schema_length],
-      opts[:with_batch_size]
+      opts[:batch_size]
     )
   end
 
@@ -1531,7 +1531,8 @@ defmodule Explorer.DataFrame do
 
   ## Options
 
-    * `with_replacement?` - If set to `true`, each sample will be independent and therefore values may repeat. Required to be `true` for `n` greater then the number of rows in the dataframe or `frac` > 1.0. (default: `false`)
+    * `replacement` - If set to `true`, each sample will be independent and therefore values may repeat.
+      Required to be `true` for `n` greater then the number of rows in the dataframe or `frac` > 1.0. (default: `false`)
     * `seed` - An integer to be used as a random seed. If nil, a random value between 1 and 1e12 will be used. (default: nil)
 
   ## Examples
@@ -1578,22 +1579,21 @@ defmodule Explorer.DataFrame do
   def sample(df, n_or_frac, opts \\ [])
 
   def sample(df, n, opts) when is_integer(n) do
-    opts =
-      Keyword.validate!(opts, with_replacement?: false, seed: Enum.random(1..1_000_000_000_000))
+    opts = Keyword.validate!(opts, replacement: false, seed: Enum.random(1..1_000_000_000_000))
 
     n_rows = n_rows(df)
 
-    case {n > n_rows, opts[:with_replacement?]} do
+    case {n > n_rows, opts[:replacement]} do
       {true, false} ->
         raise ArgumentError,
               "in order to sample more rows than are in the dataframe (#{n_rows}), sampling " <>
-                "`with_replacement?` must be true"
+                "`replacement` must be true"
 
       _ ->
         :ok
     end
 
-    apply_impl(df, :sample, [n, opts[:with_replacement?], opts[:seed]])
+    apply_impl(df, :sample, [n, opts[:replacement], opts[:seed]])
   end
 
   def sample(df, frac, opts) when is_float(frac) do

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -22,7 +22,7 @@ defmodule Explorer.PolarsBackend.Native do
         _projection,
         _sep,
         _rechunk,
-        _with_columns,
+        _columns,
         _dtypes,
         _encoding,
         _null_char,
@@ -48,7 +48,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_read_ndjson(
         _filename,
         _infer_schema_length,
-        _with_batch_size
+        _batch_size
       ),
       do: err()
 
@@ -148,7 +148,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_rolling_mean(_s, _window_size, _weight, _ignore_null, _min_periods), do: err()
   def s_rolling_min(_s, _window_size, _weight, _ignore_null, _min_periods), do: err()
   def s_rolling_sum(_s, _window_size, _weight, _ignore_null, _min_periods), do: err()
-  def s_seedable_random_indices(_length, _n_samples, _with_replacement, _seed), do: err()
+  def s_seedable_random_indices(_length, _n_samples, _replacement, _seed), do: err()
   def s_series_equal(_s, _other, _null_equal), do: err()
   def s_slice(_s, _offset, _length), do: err()
   def s_sort(_s, _reverse), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -66,11 +66,11 @@ defmodule Explorer.PolarsBackend.Series do
   def tail(series, n_elements), do: Shared.apply_native(series, :s_tail, [n_elements])
 
   @impl true
-  def sample(series, n, with_replacement?, seed) when is_integer(n) do
+  def sample(series, n, replacement, seed) when is_integer(n) do
     indices =
       series
       |> size()
-      |> Native.s_seedable_random_indices(n, with_replacement?, seed)
+      |> Native.s_seedable_random_indices(n, replacement, seed)
 
     take(series, indices)
   end

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -422,6 +422,12 @@ defmodule Explorer.Series do
 
   Can sample with or without replacement.
 
+  ## Options
+
+    * `replacement` - If set to `true`, each sample will be independent and therefore values may repeat.
+      Required to be `true` for `n` greater then the number of rows in the dataframe or `frac` > 1.0. (default: `false`)
+    * `seed` - An integer to be used as a random seed. If nil, a random value between 1 and 1e12 will be used. (default: nil)
+
   ## Examples
 
       iex> s = 1..100 |> Enum.to_list() |> Explorer.Series.from_list()
@@ -443,22 +449,21 @@ defmodule Explorer.Series do
   def sample(series, n_or_frac, opts \\ [])
 
   def sample(series, n, opts) when is_integer(n) do
-    opts =
-      Keyword.validate!(opts, with_replacement?: false, seed: Enum.random(1..1_000_000_000_000))
+    opts = Keyword.validate!(opts, replacement: false, seed: Enum.random(1..1_000_000_000_000))
 
     size = size(series)
 
-    case {n > size, opts[:with_replacement?]} do
+    case {n > size, opts[:replacement]} do
       {true, false} ->
         raise ArgumentError,
               "in order to sample more elements than are in the series (#{size}), sampling " <>
-                "`with_replacement?` must be true"
+                "`replacement` must be true"
 
       _ ->
         :ok
     end
 
-    apply_impl(series, :sample, [n, opts[:with_replacement?], opts[:seed]])
+    apply_impl(series, :sample, [n, opts[:replacement], opts[:seed]])
   end
 
   def sample(series, frac, opts) when is_float(frac) do

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -425,7 +425,7 @@ defmodule Explorer.Series do
   ## Options
 
     * `replacement` - If set to `true`, each sample will be independent and therefore values may repeat.
-      Required to be `true` for `n` greater then the number of rows in the dataframe or `frac` > 1.0. (default: `false`)
+      Required to be `true` for `n` greater then the number of rows in the series or `frac` > 1.0. (default: `false`)
     * `seed` - An integer to be used as a random seed. If nil, a random value between 1 and 1e12 will be used. (default: nil)
 
   ## Examples

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -161,13 +161,13 @@ pub fn df_write_ipc(
 pub fn df_read_ndjson(
     filename: &str,
     infer_schema_length: Option<usize>,
-    with_batch_size: usize,
+    batch_size: usize,
 ) -> Result<ExDataFrame, ExplorerError> {
     let file = File::open(filename)?;
     let buf_reader = BufReader::new(file);
     let df = JsonReader::new(buf_reader)
         .with_json_format(JsonFormat::JsonLines)
-        .with_batch_size(with_batch_size)
+        .with_batch_size(batch_size)
         .infer_schema_len(infer_schema_length)
         .finish()?;
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -661,12 +661,12 @@ pub fn cast(s: &Series, to_type: &str) -> Result<Series, ExplorerError> {
 pub fn s_seedable_random_indices(
     length: usize,
     n_samples: usize,
-    with_replacement: bool,
+    replacement: bool,
     seed: u64,
 ) -> Vec<usize> {
     let mut rng: Pcg64 = SeedableRng::seed_from_u64(seed);
     let range: Vec<usize> = (0..length).collect();
-    if with_replacement {
+    if replacement {
         (0..n_samples).map(|_| rng.gen_range(0..length)).collect()
     } else {
         range

--- a/notebooks/exploring_explorer.livemd
+++ b/notebooks/exploring_explorer.livemd
@@ -35,7 +35,7 @@ For CSV, your 'usual suspects' of options are available:
 * `names` - A list of column names. Must match the width of the dataframe. (default: nil)
 * `null_character` - The string that should be interpreted as a nil value. (default: `"NA"`)
 * `skip_rows` - The number of lines to skip at the beginning of the file. (default: `0`)
-* `with_columns` - A list of column names to keep. If present, only these columns are read
+* `columns` - A list of column names to keep. If present, only these columns are read
 * into the dataframe. (default: `nil`)
 
 `Explorer` also has multiple example datasets built in, which you can load from the `Explorer.Datasets` module like so:
@@ -481,7 +481,7 @@ DataFrame.sample(df, 10000)
 ```
 
 ```elixir
-DataFrame.sample(df, 10000, with_replacement?: true)
+DataFrame.sample(df, 10000, replacement: true)
 ```
 
 ### Pull/slice/take

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -367,7 +367,7 @@ defmodule Explorer.DataFrameTest do
     test "reads from file with options", %{tmp_dir: tmp_dir} do
       ndjson_path = to_ndjson(tmp_dir)
 
-      assert {:ok, df} = DF.from_ndjson(ndjson_path, infer_schema_length: 3, with_batch_size: 3)
+      assert {:ok, df} = DF.from_ndjson(ndjson_path, infer_schema_length: 3, batch_size: 3)
 
       assert DF.names(df) == ~w[a b c d]
       assert DF.dtypes(df) == [:integer, :float, :boolean, :string]


### PR DESCRIPTION
The "with" prefix is a thing from Polars. We don't need to follow the
same style.

This is related to #206 