### PR TITLE
Run formatter before running tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,20 @@ env:
   MIX_ENV: test
 
 jobs:
+  format:
+    runs-on: ubuntu-latest
+    name: mix format
+    steps:
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "${{ env.OTP_VERSION }}"
+          elixir-version: "${{ env.ELIXIR_VERSION }}"
+      - run: mix format --check-formatted
   test:
     runs-on: ubuntu-latest
     name: test
+    needs: [format]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
@@ -46,13 +57,3 @@ jobs:
       - run: mix deps.get
       - run: mix compile --warnings-as-errors
       - run: mix test --warnings-as-errors
-  format:
-    runs-on: ubuntu-latest
-    name: mix format
-    steps:
-      - uses: actions/checkout@v2
-      - uses: erlef/setup-beam@v1
-        with:
-          otp-version: "${{ env.OTP_VERSION }}"
-          elixir-version: "${{ env.ELIXIR_VERSION }}"
-      - run: mix format --check-formatted


### PR DESCRIPTION
This ensure that we fail fast if any formatting issue is found.

Reference: https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#defining-prerequisite-jobs