### PR TITLE
Normalize dtype handling and CSV options

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -14,14 +14,13 @@ defmodule Explorer.Backend.DataFrame do
 
   @callback from_csv(
               filename :: String.t(),
-              names :: list(String.t()) | nil,
-              dtypes :: list({String.t(), atom()}) | nil,
+              dtypes :: list({String.t(), atom()}),
               delimiter :: String.t(),
               null_character :: String.t(),
               skip_rows :: integer(),
               header? :: boolean(),
               encoding :: String.t(),
-              max_rows :: integer() | Inf,
+              max_rows :: integer() | nil,
               columns :: list(String.t()) | list(Atom.t()) | list(integer()) | nil,
               infer_schema_length :: integer() | nil,
               parse_dates :: boolean()

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -111,5 +111,5 @@ defmodule Explorer.Backend.Series do
 
   # Escape hatch
 
-  @callback transform(s, fun) :: s
+  @callback transform(s, fun) :: s | list()
 end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -20,7 +20,6 @@ defmodule Explorer.PolarsBackend.DataFrame do
   @impl true
   def from_csv(
         filename,
-        names,
         dtypes,
         delimiter,
         null_character,
@@ -32,19 +31,15 @@ defmodule Explorer.PolarsBackend.DataFrame do
         infer_schema_length,
         parse_dates
       ) do
-    max_rows = if max_rows == Inf, do: nil, else: max_rows
-
     infer_schema_length =
       if infer_schema_length == nil,
         do: max_rows || @default_infer_schema_length,
         else: infer_schema_length
 
     dtypes =
-      if dtypes do
-        Enum.map(dtypes, fn {column_name, dtype} ->
-          {column_name, Shared.internal_from_dtype(dtype)}
-        end)
-      end
+      Enum.map(dtypes, fn {column_name, dtype} ->
+        {column_name, Shared.internal_from_dtype(dtype)}
+      end)
 
     {columns, with_projection} = column_list_check(columns)
 
@@ -65,10 +60,9 @@ defmodule Explorer.PolarsBackend.DataFrame do
         parse_dates
       )
 
-    case {df, names} do
-      {{:ok, df}, nil} -> {:ok, Shared.to_dataframe(df)}
-      {{:ok, df}, names} -> checked_rename(Shared.to_dataframe(df), names)
-      {{:error, error}, _} -> {:error, error}
+    case df do
+      {:ok, df} -> {:ok, Shared.to_dataframe(df)}
+      {:error, error} -> {:error, error}
     end
   end
 
@@ -91,17 +85,6 @@ defmodule Explorer.PolarsBackend.DataFrame do
               "expected :columns to be a list of only integers, only atoms, or only binaries, " <>
                 "got: #{inspect(list)}"
     end
-  end
-
-  defp checked_rename(df, names) do
-    if n_columns(df) != length(names) do
-      raise(
-        ArgumentError,
-        "Expected length of provided names (#{length(names)}) to match number of columns in dataframe (#{n_columns(df)})."
-      )
-    end
-
-    {:ok, rename(df, names)}
   end
 
   @impl true
@@ -212,15 +195,12 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   # Like `Explorer.Series.from_list/2`, but gives a better error message with the series name.
   defp series_from_list!(name, list) do
-    case Explorer.Shared.check_types(list) do
-      {:ok, type} ->
-        {list, type} = Explorer.Shared.cast_numerics(list, type)
-        PolarsSeries.from_list(list, type, name)
-
-      {:error, error} ->
-        message = "cannot create series #{inspect(name)}: " <> error
-        raise ArgumentError, message
-    end
+    type = Explorer.Shared.check_types!(list)
+    {list, type} = Explorer.Shared.cast_numerics(list, type)
+    PolarsSeries.from_list(list, type, name)
+  rescue
+    e ->
+      raise ArgumentError, "cannot create series #{inspect(name)}: " <> Exception.message(e)
   end
 
   @impl true

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -2,7 +2,6 @@ defmodule Explorer.PolarsBackend.Series do
   @moduledoc false
 
   import Kernel, except: [length: 1]
-  import Explorer.Shared, only: [cast_numerics: 2]
 
   alias Explorer.DataFrame
   alias Explorer.PolarsBackend.Native

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -2,7 +2,7 @@ defmodule Explorer.PolarsBackend.Series do
   @moduledoc false
 
   import Kernel, except: [length: 1]
-  import Explorer.Shared, only: [check_types!: 1, cast_numerics: 2]
+  import Explorer.Shared, only: [cast_numerics: 2]
 
   alias Explorer.DataFrame
   alias Explorer.PolarsBackend.Native
@@ -328,13 +328,7 @@ defmodule Explorer.PolarsBackend.Series do
 
   # Escape hatch
   @impl true
-  def transform(series, fun) do
-    list = series |> Series.to_list() |> Enum.map(fun)
-    type = check_types!(list)
-    {list, type} = cast_numerics(list, type)
-
-    from_list(list, type)
-  end
+  def transform(series, fun), do: series |> Series.to_list() |> Enum.map(fun)
 
   # Polars specific functions
 

--- a/notebooks/exploring_explorer.livemd
+++ b/notebooks/exploring_explorer.livemd
@@ -30,7 +30,7 @@ For CSV, your 'usual suspects' of options are available:
 
 * `delimiter` - A single character used to separate fields within a record. (default: `","`)
 * `dtypes` - A keyword list of `[column_name: dtype]`. If `nil`, dtypes are imputed from the first 1000 rows. (default: `nil`)
-* `header?` - Does the file have a header of column names as the first row or not? (default: `true`)
+* `header` - Does the file have a header of column names as the first row or not? (default: `true`)
 * `max_rows` - Maximum number of lines to read. (default: `Inf`)
 * `names` - A list of column names. Must match the width of the dataframe. (default: nil)
 * `null_character` - The string that should be interpreted as a nil value. (default: `"NA"`)
@@ -54,7 +54,7 @@ Explorer.DataFrame.table(df)
 
 Writing files is very similar to reading them. The options are a little more limited:
 
-* `header?` - Should the column names be written as the first line of the file? (default: `true`)
+* `header` - Should the column names be written as the first line of the file? (default: `true`)
 * `delimiter` - A single character used to separate fields within a record. (default: `","`)
 
 First, let's add some useful aliases:

--- a/notebooks/exploring_explorer.livemd
+++ b/notebooks/exploring_explorer.livemd
@@ -24,19 +24,17 @@ Mix.install([
 
 ## Reading and writing data
 
-Data can be read from delimited files (like CSV), Parquet, and the Arrow IPC (feather) format. You can also load in data from a map or keyword list of columns with `Explorer.DataFrame.new/1`.
+Data can be read from delimited files (like CSV), NDJSon, Parquet, and the Arrow IPC (feather) format. You can also load in data from a map or keyword list of columns with `Explorer.DataFrame.new/1`.
 
 For CSV, your 'usual suspects' of options are available:
 
 * `delimiter` - A single character used to separate fields within a record. (default: `","`)
-* `dtypes` - A keyword list of `[column_name: dtype]`. If `nil`, dtypes are imputed from the first 1000 rows. (default: `nil`)
+* `dtypes` - A keyword list of `[column_name: dtype]`. If a type is not specified for a column, it is imputed from the first 1000 rows. (default: `[]`)
 * `header` - Does the file have a header of column names as the first row or not? (default: `true`)
-* `max_rows` - Maximum number of lines to read. (default: `Inf`)
-* `names` - A list of column names. Must match the width of the dataframe. (default: nil)
+* `max_rows` - Maximum number of lines to read. (default: `nil`)
 * `null_character` - The string that should be interpreted as a nil value. (default: `"NA"`)
 * `skip_rows` - The number of lines to skip at the beginning of the file. (default: `0`)
-* `columns` - A list of column names to keep. If present, only these columns are read
-* into the dataframe. (default: `nil`)
+* `columns` - A list of column names to keep. If present, only these columns are read into the dataframe. (default: `nil`)
 
 `Explorer` also has multiple example datasets built in, which you can load from the `Explorer.Datasets` module like so:
 

--- a/notebooks/exploring_explorer.livemd
+++ b/notebooks/exploring_explorer.livemd
@@ -24,7 +24,7 @@ Mix.install([
 
 ## Reading and writing data
 
-Data can be read from delimited files (like CSV), NDJSon, Parquet, and the Arrow IPC (feather) format. You can also load in data from a map or keyword list of columns with `Explorer.DataFrame.new/1`.
+Data can be read from delimited files (like CSV), NDJSON, Parquet, and the Arrow IPC (feather) format. You can also load in data from a map or keyword list of columns with `Explorer.DataFrame.new/1`.
 
 For CSV, your 'usual suspects' of options are available:
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -102,6 +102,13 @@ defmodule Explorer.DataFrameTest do
                a: ["1", "3"],
                b: [2, 4]
              }
+
+      df = DF.from_csv!(csv, dtypes: %{a: :string})
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               a: ["1", "3"],
+               b: [2, 4]
+             }
     end
 
     @tag :tmp_dir
@@ -143,7 +150,7 @@ defmodule Explorer.DataFrameTest do
     end
 
     @tag :tmp_dir
-    test "header?", config do
+    test "header", config do
       csv =
         tmp_csv(config.tmp_dir, """
         a,b
@@ -151,7 +158,7 @@ defmodule Explorer.DataFrameTest do
         e,f
         """)
 
-      df = DF.from_csv!(csv, header?: false)
+      df = DF.from_csv!(csv, header: false)
 
       assert DF.to_columns(df, atom_keys: true) == %{
                column_1: ["a", "c", "e"],
@@ -256,55 +263,6 @@ defmodule Explorer.DataFrameTest do
 
       assert DF.to_columns(df, atom_keys: true) == %{
                b: ["d", "f"]
-             }
-    end
-
-    @tag :tmp_dir
-    test "names", config do
-      csv =
-        tmp_csv(config.tmp_dir, """
-        a,b
-        c,d
-        e,f
-        """)
-
-      df = DF.from_csv!(csv, names: ["a2", "b2"])
-
-      assert DF.to_columns(df, atom_keys: true) == %{
-               a2: ["c", "e"],
-               b2: ["d", "f"]
-             }
-    end
-
-    @tag :tmp_dir
-    test "names raises exception on invalid length", config do
-      csv =
-        tmp_csv(config.tmp_dir, """
-        a,b
-        c,d
-        """)
-
-      assert_raise(
-        ArgumentError,
-        "Expected length of provided names (1) to match number of columns in dataframe (2).",
-        fn -> DF.from_csv(csv, names: ["a2"]) end
-      )
-    end
-
-    @tag :tmp_dir
-    test "names and dtypes options work together", config do
-      csv =
-        tmp_csv(config.tmp_dir, """
-        a,b
-        1,2
-        3,4
-        """)
-
-      df = DF.from_csv!(csv, dtypes: [{"a", :string}], names: ["a2", "b2"])
-
-      assert DF.to_columns(df, atom_keys: true) == %{
-               a2: ["1", "3"],
-               b2: [2, 4]
              }
     end
 


### PR DESCRIPTION
  * Remove `names` option in `from_csv` to remove ambiguity
    (users can call rename afterwards)

  * Normalizea and validate `dtypes` in `from_csv`

  * Remove `Inf` which is not a common Elixir value

  * Support returning a list from `Series.transform` to
    unify `dtypes` handling