### PR TITLE
Do not add special meaning to empty lists

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1197,15 +1197,15 @@ defmodule Explorer.DataFrame do
         callback when is_function(callback) ->
           Enum.filter(names(df), callback)
 
-        [] ->
-          raise ArgumentError,
-                "you must provide at least one column or omit the column option to select all columns"
-
         columns ->
           to_existing_columns(df, columns)
       end
 
-    apply_impl(df, :distinct, [columns, opts[:keep_all?]])
+    if columns != [] do
+      apply_impl(df, :distinct, [columns, opts[:keep_all?]])
+    else
+      df
+    end
   end
 
   @doc """
@@ -1421,7 +1421,7 @@ defmodule Explorer.DataFrame do
         rename_with(df, callback, columns)
 
       [] ->
-        raise ArgumentError, "function to select column names did not return any names"
+        df
     end
   end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -626,6 +626,25 @@ defmodule Explorer.DataFrameTest do
     assert df5 == df
   end
 
+  test "pivot_wider/4" do
+    df = DF.new(id: [1, 1], variable: ["a", "b"], value: [1, 2], other: [4, 5])
+    df1 = DF.pivot_wider(df, "variable", "value")
+
+    assert DF.names(df1) == ["id", "other", "a", "b"]
+
+    df2 = DF.pivot_wider(df, "variable", "value", id_columns: [:id])
+    assert DF.names(df2) == ["id", "a", "b"]
+
+    df2 = DF.pivot_wider(df, "variable", "value", id_columns: [0])
+    assert DF.names(df2) == ["id", "a", "b"]
+
+    assert_raise ArgumentError,
+                 "id_columns must select at least one existing column, but [] selects none",
+                 fn ->
+                   DF.pivot_wider(df, "variable", "value", id_columns: [])
+                 end
+  end
+
   test "table reader integration" do
     df = DF.new(x: [1, 2, 3], y: ["a", "b", "c"])
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -660,6 +660,13 @@ defmodule Explorer.DataFrameTest do
       assert DF.names(df2) == ["id", "a", "b"]
     end
 
+    test "with a filter function" do
+      df = DF.new(id: [1, 1], variable: ["a", "b"], value: [1, 2], other: [4, 5])
+
+      df1 = DF.pivot_wider(df, "variable", "value", id_columns: &String.starts_with?(&1, "id"))
+      assert DF.names(df1) == ["id", "a", "b"]
+    end
+
     test "without an id column" do
       df = DF.new(id: [1, 1], variable: ["a", "b"], value: [1, 2], other_id: [4, 5])
 
@@ -667,6 +674,12 @@ defmodule Explorer.DataFrameTest do
                    "id_columns must select at least one existing column, but [] selects none",
                    fn ->
                      DF.pivot_wider(df, "variable", "value", id_columns: [])
+                   end
+
+      assert_raise ArgumentError,
+                   ~r/id_columns must select at least one existing column, but/,
+                   fn ->
+                     DF.pivot_wider(df, "variable", "value", id_columns: &String.starts_with?(&1, "none"))
                    end
     end
   end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -679,7 +679,9 @@ defmodule Explorer.DataFrameTest do
       assert_raise ArgumentError,
                    ~r/id_columns must select at least one existing column, but/,
                    fn ->
-                     DF.pivot_wider(df, "variable", "value", id_columns: &String.starts_with?(&1, "none"))
+                     DF.pivot_wider(df, "variable", "value",
+                       id_columns: &String.starts_with?(&1, "none")
+                     )
                    end
     end
   end


### PR DESCRIPTION
This changes the behaviour of functions that are treating empty lists as
exceptions. Now we return the original data frame untouched instead of
raising error.

Closes https://github.com/elixir-nx/explorer/issues/205