### PR TITLE
Add `Series.coalesce`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support negative indexes throughout the columns API
 - Integrate with the `table` package
 - Add `Series.to_enum/1` for lazily traversing the series
+- Add `Series.coalesce/1` and `Series.coalesce/2` for finding the first non-null value in a list of series
 
 ### Changed
 
@@ -32,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `reverse?` is now an option instead of an argument in `Series.cumulative_*` functions
 - `DataFrame.from_columns/2` and `DataFrame.from_rows/2` is now `DataFrame.new/2`
 - Rename "col" to "column" throughout the API
-- Remove "with_" prefix in options throughout the API
+- Remove "with\_" prefix in options throughout the API
 
 ## [v0.1.1] - 2022-04-27
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -34,6 +34,7 @@ defmodule Explorer.Backend.Series do
   @callback take(s, indices :: list()) :: s
   @callback get(s, idx :: integer()) :: s
   @callback concat(s, s) :: s
+  @callback coalesce(s, s) :: s
 
   # Aggregation
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -98,6 +98,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_argsort(_s, _reverse), do: err()
   def s_as_str(_s), do: err()
   def s_cast(_s, _dtype), do: err()
+  def s_coalesce(_s, _other), do: err()
   def s_cum_max(_s, _reverse), do: err()
   def s_cum_min(_s, _reverse), do: err()
   def s_cum_sum(_s, _reverse), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -98,6 +98,9 @@ defmodule Explorer.PolarsBackend.Series do
   @impl true
   def concat(s1, s2), do: Shared.apply_native(s1, :s_append, [s2.data])
 
+  @impl true
+  def coalesce(s1, s2), do: Shared.apply_native(s1, :s_coalesce, [s2.data])
+
   # Aggregation
 
   @impl true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -647,6 +647,32 @@ defmodule Explorer.Series do
   defp concat_reducer(%Series{dtype: dtype1}, %Series{dtype: dtype2}),
     do: raise(ArgumentError, "dtypes must match, found #{dtype1} and #{dtype2}")
 
+  @doc """
+  Finds the first non-missing element at each position.
+
+  ## Examples
+
+      iex> s1 = Explorer.Series.from_list([1, 2, nil, nil])
+      iex> s2 = Explorer.Series.from_list([1, 2, nil, 4])
+      iex> s3 = Explorer.Series.from_list([nil, nil, 3, 4])
+      iex> Explorer.Series.coalesce([s1, s2, s3])
+      #Explorer.Series<
+        integer[4]
+        [1, 2, 3, 4]
+      >
+  """
+  @spec coalesce([Series.t()]) :: Series.t()
+  def coalesce([%Series{} = h | t] = _series),
+    do: Enum.reduce(t, h, &Shared.apply_impl(&2, :coalesce, [&1]))
+
+  @doc """
+  Finds the first non-missing element at each position.
+
+  `coalesce(s1, s2)` is equivalent to `coalesce([s1, s2])`.
+  """
+  @spec coalesce(s1 :: Series.t(), s2 :: Series.t()) :: Series.t()
+  def coalesce(s1, s2), do: concat([s1, s2])
+
   # Aggregation
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -616,6 +616,7 @@ defmodule Explorer.Series do
         [1.0, 2.0, 3.0, 4.0, 5.0, 6.4]
       >
   """
+  @spec concat([Series.t()]) :: Series.t()
   def concat([%Series{} = h | t] = _series) do
     Enum.reduce(t, h, &concat_reducer/2)
   end
@@ -625,6 +626,7 @@ defmodule Explorer.Series do
 
   `concat(s1, s2)` is equivalent to `concat([s1, s2])`.
   """
+  @spec concat(s1 :: Series.t(), s2 :: Series.t()) :: Series.t()
   def concat(%Series{} = s1, %Series{} = s2),
     do: concat([s1, s2])
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -77,6 +77,7 @@ rustler::init!(
         s_argsort,
         s_as_str,
         s_cast,
+        s_coalesce,
         s_cum_max,
         s_cum_min,
         s_cum_sum,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -688,3 +688,11 @@ pub fn parse_quantile_interpol_options(strategy: &str) -> QuantileInterpolOption
         _ => QuantileInterpolOptions::Nearest,
     }
 }
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_coalesce(data: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
+    let s1 = &data.resource.0;
+    let s2 = &other.resource.0;
+    let coalesced = s1.zip_with(&s1.is_not_null(), s2)?;
+    Ok(ExSeries::new(coalesced))
+}


### PR DESCRIPTION
Closes #226. Sorry @kimjoaoun I couldn't resist :).

NB: `clippy` is failing on the latest nightly rust because it adds a new check by default. I've made the necessary changes in #202 and will rebase once that's merged.