### PR TITLE
Compose dataframe inspecting

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -110,6 +110,8 @@ defmodule Explorer.Backend.DataFrame do
   @callback ungroup(df, columns :: [column_name]) :: df
   @callback summarise(df, aggregations :: map()) :: df
 
+  # Functions
+
   @default_limit 5
   import Inspect.Algebra
   alias Explorer.{DataFrame, Series}

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2327,14 +2327,20 @@ defmodule Explorer.DataFrame do
   end
 
   defimpl Inspect do
-    alias Explorer.DataFrame
-    alias Explorer.Series
-
-    @default_limit 5
+    import Inspect.Algebra
 
     def inspect(df, opts) do
-      opts = Map.put(opts, :limit, @default_limit)
-      Shared.apply_impl(df, :inspect, [opts])
+      force_unfit(
+        concat([
+          color("#Explorer.DataFrame<", :map, opts),
+          nest(
+            concat([line(), Shared.apply_impl(df, :inspect, [opts])]),
+            2
+          ),
+          line(),
+          color(">", :map, opts)
+        ])
+      )
     end
   end
 end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -11,8 +11,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   defstruct resource: nil, reference: nil
 
-  use Explorer.Backend.DataFrame, backend: "Polars"
-
+  @behaviour Explorer.Backend.DataFrame
   @default_infer_schema_length 1000
 
   # IO
@@ -463,6 +462,14 @@ defmodule Explorer.PolarsBackend.DataFrame do
     |> ungroup([])
     |> DataFrame.arrange(groups)
   end
+
+  # Inspect
+
+  @impl true
+  def inspect(df, opts) do
+    {n_rows, _} = shape(df)
+    Explorer.Backend.DataFrame.inspect(df, "Polars", n_rows, opts)
+  end
 end
 
 defimpl Enumerable, for: Explorer.PolarsBackend.DataFrame do
@@ -505,15 +512,4 @@ defimpl Enumerable, for: Explorer.PolarsBackend.DataFrame do
   end
 
   def member?(_, _), do: {:error, __MODULE__}
-end
-
-defimpl Inspect, for: Explorer.PolarsBackend.DataFrame do
-  alias Explorer.PolarsBackend.Native
-
-  def inspect(df, _opts) do
-    case Native.df_as_str(df) do
-      {:ok, str} -> str
-      {:error, error} -> raise "#{error}"
-    end
-  end
 end

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -58,7 +58,6 @@ defmodule Explorer.PolarsBackend.Native do
       ),
       do: err()
 
-  def df_as_str(_df), do: err()
   def df_column(_df, _name), do: err()
   def df_columns(_def), do: err()
   def df_drop(_df, _name), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -13,7 +13,7 @@ defmodule Explorer.PolarsBackend.Series do
 
   defstruct resource: nil, reference: nil
 
-  use Explorer.Backend.Series
+  @behaviour Explorer.Backend.Series
 
   # Conversion
 
@@ -325,6 +325,11 @@ defmodule Explorer.PolarsBackend.Series do
   # Escape hatch
   @impl true
   def transform(series, fun), do: series |> Series.to_list() |> Enum.map(fun)
+
+  @impl true
+  def inspect(series, opts) do
+    Explorer.Backend.Series.inspect(series, "Polars", Series.size(series), opts)
+  end
 
   # Polars specific functions
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2048,10 +2048,20 @@ defmodule Explorer.Series do
       )
 
   defimpl Inspect do
-    alias Explorer.Shared
+    import Inspect.Algebra
 
-    def inspect(series, opts) do
-      Shared.apply_impl(series, :inspect, [opts])
+    def inspect(df, opts) do
+      force_unfit(
+        concat([
+          color("#Explorer.Series<", :map, opts),
+          nest(
+            concat([line(), Shared.apply_impl(df, :inspect, [opts])]),
+            2
+          ),
+          line(),
+          color(">", :map, opts)
+        ])
+      )
     end
   end
 end

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -180,11 +180,6 @@ pub fn df_write_ndjson(data: ExDataFrame, filename: &str) -> Result<(), Explorer
     Ok(())
 }
 
-#[rustler::nif(schedule = "DirtyIo")]
-pub fn df_as_str(data: ExDataFrame) -> Result<String, ExplorerError> {
-    Ok(format!("{:?}", data.resource.0))
-}
-
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_join(
     data: ExDataFrame,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -32,7 +32,6 @@ mod atoms {
 rustler::init!(
     "Elixir.Explorer.PolarsBackend.Native",
     [
-        df_as_str,
         df_column,
         df_columns,
         df_drop,


### PR DESCRIPTION
The idea is to keep the "shell" of the inspect representation
constant but delegate the remaining to a shared implementation.

df_as_str was removed because we are missing the polars flag
to make it work, so I thought we could skip it too.