### PR TITLE
Keep track of names & dtypes and introduce a "virtual" out DF

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -114,10 +114,17 @@ defmodule Explorer.Backend.DataFrame do
   @callback summarise(df, aggregations :: map()) :: df
 
   # Functions
+  alias Explorer.{DataFrame, Series}
+
+  @doc """
+  Creates a new DataFrame for a given backend.
+  """
+  def new(data, names, dtypes) do
+    %DataFrame{data: data, names: names, dtypes: dtypes, groups: []}
+  end
 
   @default_limit 5
   import Inspect.Algebra
-  alias Explorer.{DataFrame, Series}
 
   @doc """
   Default inspect implementation for backends.

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -84,8 +84,8 @@ defmodule Explorer.Backend.DataFrame do
   @callback pivot_wider(
               df,
               id_columns :: [column_name()],
-              names_from :: [column_name()],
-              values_from :: [column_name()],
+              names_from :: column_name(),
+              values_from :: column_name(),
               names_prefix :: String.t()
             ) :: df
   @callback pivot_longer(

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -75,7 +75,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback filter(df, mask :: series) :: df
   @callback mutate(df, out_df :: df(), columns :: %{column_name() => mutate_value()}) :: df
   @callback arrange(df, columns :: [column_name() | {:asc | :desc, column_name()}]) :: df
-  @callback distinct(df, columns :: [column_name()], keep_all? :: boolean()) :: df
+  @callback distinct(df, out_df :: df(), columns :: [column_name()], keep_all? :: boolean()) :: df
   @callback rename(df, out_df :: df()) :: df
   @callback dummies(df, columns :: [column_name()]) :: df
   @callback sample(df, n :: integer(), replacement :: boolean(), seed :: integer()) :: df

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -110,7 +110,7 @@ defmodule Explorer.Backend.DataFrame do
   # Groups
 
   @callback group_by(df, out_df :: df()) :: df
-  @callback ungroup(df, columns :: [column_name()]) :: df
+  @callback ungroup(df, out_df :: df()) :: df
   @callback summarise(df, aggregations :: map()) :: df
 
   # Functions

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -11,7 +11,12 @@ defmodule Explorer.Backend.DataFrame do
   @type column_name :: String.t()
   @type dtype :: Explorer.Series.dtype()
 
-  @type mutate_value :: series() | float() | integer() | String.t() | (df() -> series())
+  @typep basic_types :: float() | integer() | String.t() | Date.t() | DateTime.t()
+  @type mutate_value ::
+          series()
+          | basic_types()
+          | [basic_types()]
+          | (df() -> series() | basic_types() | [basic_types()])
 
   # IO
 
@@ -73,7 +78,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback tail(df, rows :: integer()) :: df
   @callback select(df, out_df :: df()) :: df
   @callback filter(df, mask :: series) :: df
-  @callback mutate(df, out_df :: df(), columns :: %{column_name() => mutate_value()}) :: df
+  @callback mutate(df, out_df :: df(), mutations :: [{column_name(), mutate_value()}]) :: df
   @callback arrange(df, columns :: [column_name() | {:asc | :desc, column_name()}]) :: df
   @callback distinct(df, out_df :: df(), columns :: [column_name()], keep_all? :: boolean()) :: df
   @callback rename(df, out_df :: df()) :: df

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -109,7 +109,7 @@ defmodule Explorer.Backend.DataFrame do
 
   # Groups
 
-  @callback group_by(df, columns :: [column_name()]) :: df
+  @callback group_by(df, out_df :: df()) :: df
   @callback ungroup(df, columns :: [column_name()]) :: df
   @callback summarise(df, aggregations :: map()) :: df
 

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -90,10 +90,8 @@ defmodule Explorer.Backend.DataFrame do
             ) :: df
   @callback pivot_longer(
               df,
-              id_columns :: [column_name()],
-              value_columns :: [column_name()],
-              names_to :: column_name(),
-              values_to :: column_name()
+              out_df :: df(),
+              value_columns :: [column_name()]
             ) :: df
 
   # Two or more table verbs

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -74,7 +74,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback mutate(df, columns :: map()) :: df
   @callback arrange(df, columns :: [column_name() | {:asc | :desc, column_name()}]) :: df
   @callback distinct(df, columns :: [column_name()], keep_all? :: boolean()) :: df
-  @callback rename(df, [column_name()]) :: df
+  @callback rename(df, out_df :: df()) :: df
   @callback dummies(df, columns :: [column_name()]) :: df
   @callback sample(df, n :: integer(), replacement :: boolean(), seed :: integer()) :: df
   @callback pull(df, column :: column_name()) :: series

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -101,7 +101,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback join(
               left :: df,
               right :: df,
-              on :: list(column_name() | {column_name(), column_name()}),
+              on :: list({column_name(), column_name()}),
               how :: :left | :inner | :outer | :right | :cross
             ) :: df
 

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -99,8 +99,9 @@ defmodule Explorer.Backend.DataFrame do
   # Two or more table verbs
 
   @callback join(
-              left :: df,
-              right :: df,
+              left :: df(),
+              right :: df(),
+              out_df :: df(),
               on :: list({column_name(), column_name()}),
               how :: :left | :inner | :outer | :right | :cross
             ) :: df

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -69,7 +69,7 @@ defmodule Explorer.Backend.DataFrame do
 
   @callback head(df, rows :: integer()) :: df
   @callback tail(df, rows :: integer()) :: df
-  @callback select(df, columns :: [column_name()], :keep | :drop) :: df
+  @callback select(df, out_df :: df()) :: df
   @callback filter(df, mask :: series) :: df
   @callback mutate(df, columns :: map()) :: df
   @callback arrange(df, columns :: [column_name() | {:asc | :desc, column_name()}]) :: df
@@ -120,7 +120,8 @@ defmodule Explorer.Backend.DataFrame do
   Creates a new DataFrame for a given backend.
   """
   def new(data, names, dtypes) do
-    %DataFrame{data: data, names: names, dtypes: dtypes, groups: []}
+    dtypes_pairs = Enum.zip(names, dtypes)
+    %DataFrame{data: data, names: names, dtypes: Map.new(dtypes_pairs), groups: []}
   end
 
   @default_limit 5

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -111,7 +111,7 @@ defmodule Explorer.Backend.DataFrame do
 
   @callback group_by(df, out_df :: df()) :: df
   @callback ungroup(df, out_df :: df()) :: df
-  @callback summarise(df, out_df :: df(), aggregations :: %{column_name() => atom()}) :: df
+  @callback summarise(df, out_df :: df(), aggregations :: %{column_name() => [atom()]}) :: df
 
   # Functions
   alias Explorer.{DataFrame, Series}

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -11,6 +11,8 @@ defmodule Explorer.Backend.DataFrame do
   @type column_name :: String.t()
   @type dtype :: Explorer.Series.dtype()
 
+  @type mutate_value :: series() | float() | integer() | String.t() | (df() -> series())
+
   # IO
 
   @callback from_csv(
@@ -71,7 +73,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback tail(df, rows :: integer()) :: df
   @callback select(df, out_df :: df()) :: df
   @callback filter(df, mask :: series) :: df
-  @callback mutate(df, columns :: map()) :: df
+  @callback mutate(df, out_df :: df(), columns :: %{column_name() => mutate_value()}) :: df
   @callback arrange(df, columns :: [column_name() | {:asc | :desc, column_name()}]) :: df
   @callback distinct(df, columns :: [column_name()], keep_all? :: boolean()) :: df
   @callback rename(df, out_df :: df()) :: df

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -111,7 +111,7 @@ defmodule Explorer.Backend.DataFrame do
 
   @callback group_by(df, out_df :: df()) :: df
   @callback ungroup(df, out_df :: df()) :: df
-  @callback summarise(df, aggregations :: map()) :: df
+  @callback summarise(df, out_df :: df(), aggregations :: %{column_name() => atom()}) :: df
 
   # Functions
   alias Explorer.{DataFrame, Series}

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1333,7 +1333,9 @@ defmodule Explorer.DataFrame do
     new_names = to_column_names(names)
     check_new_names_length!(df, new_names)
 
-    Shared.apply_impl(df, :rename, [new_names])
+    out_df = %{df | names: new_names}
+
+    Shared.apply_impl(df, :rename, [out_df])
   end
 
   def rename(df, names) when is_column_pairs(names) do

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1833,10 +1833,7 @@ defmodule Explorer.DataFrame do
 
     out_df = %{df | names: columns ++ [names_to, values_to], dtypes: new_dtypes}
 
-    Shared.apply_impl(df, :pivot_longer, [
-      out_df,
-      value_columns
-    ])
+    Shared.apply_impl(df, :pivot_longer, [out_df, value_columns])
   end
 
   @doc """
@@ -2404,25 +2401,23 @@ defmodule Explorer.DataFrame do
     groups = for group <- df.groups, do: {group, df.dtypes[group]}
 
     agg_pairs =
-      Enum.flat_map(column_pairs, fn {column_name, aggregations} ->
-        for agg <- aggregations do
-          name = "#{column_name}_#{agg}"
+      for {column_name, aggregations} <- column_pairs, agg <- aggregations do
+        name = "#{column_name}_#{agg}"
 
-          dtype =
-            case agg do
-              :median ->
-                :float
+        dtype =
+          case agg do
+            :median ->
+              :float
 
-              :mean ->
-                :float
+            :mean ->
+              :float
 
-              _other ->
-                df.dtypes[column_name]
-            end
+            _other ->
+              df.dtypes[column_name]
+          end
 
-          {name, dtype}
-        end
-      end)
+        {name, dtype}
+      end
 
     groups ++ agg_pairs
   end

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2262,9 +2262,11 @@ defmodule Explorer.DataFrame do
       >
   """
   @doc type: :single
-  @spec ungroup(df :: DataFrame.t(), groups_or_group :: column_names() | column_name()) ::
+  @spec ungroup(df :: DataFrame.t(), groups_or_group :: column_names() | column_name() | :all) ::
           DataFrame.t()
-  def ungroup(df, groups \\ [])
+  def ungroup(df, groups \\ :all)
+
+  def ungroup(df, :all), do: Shared.apply_impl(df, :ungroup, [%{df | groups: []}])
 
   def ungroup(df, groups) when is_list(groups) do
     current_groups = groups(df)
@@ -2279,7 +2281,9 @@ defmodule Explorer.DataFrame do
           )
     end)
 
-    Shared.apply_impl(df, :ungroup, [groups])
+    out_df = %{df | groups: current_groups -- groups}
+
+    Shared.apply_impl(df, :ungroup, [out_df])
   end
 
   def ungroup(df, group) when is_column_name(group), do: ungroup(df, [group])

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -101,15 +101,22 @@ defmodule Explorer.DataFrame do
   @valid_dtypes Explorer.Shared.dtypes()
 
   @type data :: Explorer.Backend.DataFrame.t()
-  @type t :: %DataFrame{data: data, groups: [String.t()]}
+  # TODO: enforce names and dtypes
   @enforce_keys [:data, :groups]
-  defstruct [:data, :groups]
+  defstruct [:data, :groups, :names, :dtypes]
 
   @type column_name :: atom() | String.t()
   @type column :: column_name() | non_neg_integer()
   @type columns :: [column] | Range.t()
   @type column_names :: [column_name]
   @type column_pairs(other) :: [{column(), other}] | %{column() => other}
+
+  @type t :: %DataFrame{
+          data: data,
+          groups: [String.t()],
+          names: [Explorer.Backend.DataFrame.column_name()],
+          dtypes: [Explorer.Backend.Series.dtype()]
+        }
 
   @default_infer_schema_length 1000
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1926,6 +1926,8 @@ defmodule Explorer.DataFrame do
 
   # Two table verbs
 
+  @valid_join_types [:inner, :left, :right, :outer, :cross]
+
   @doc """
   Join two tables.
 
@@ -2029,6 +2031,12 @@ defmodule Explorer.DataFrame do
         on: find_overlapping_columns(left_columns, right_columns),
         how: :inner
       )
+
+    unless opts[:how] in @valid_join_types do
+      raise ArgumentError,
+            "join type is not valid: #{inspect(opts[:how])}. " <>
+              "Valid options are: #{Enum.map_join(@valid_join_types, ", ", &inspect/1)}"
+    end
 
     {on, how} =
       case {opts[:on], opts[:how]} do

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1012,7 +1012,7 @@ defmodule Explorer.DataFrame do
   Columns are added with keyword list or maps. New variables overwrite existing variables of the
   same name. Column names are coerced from atoms to strings.
 
-  Be aware that mutating grouped dataframes will cause them to lost ordering.
+  Be aware that mutating grouped dataframes will cause them to lose ordering.
 
   ## Examples
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2241,6 +2241,9 @@ defmodule Explorer.DataFrame do
   @doc """
   Removes grouping variables.
 
+  Accepts a list of group names. If groups is not specified, then all groups are
+  removed.
+
   ## Examples
 
       iex> df = Explorer.Datasets.fossil_fuels()
@@ -2249,6 +2252,23 @@ defmodule Explorer.DataFrame do
       #Explorer.DataFrame<
         Polars[1094 x 10]
         Groups: ["year"]
+        year integer [2010, 2010, 2010, 2010, 2010, ...]
+        country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
+        total integer [2308, 1254, 32500, 141, 7924, ...]
+        solid_fuel integer [627, 117, 332, 0, 0, ...]
+        liquid_fuel integer [1601, 953, 12381, 141, 3649, ...]
+        gas_fuel integer [74, 7, 14565, 0, 374, ...]
+        cement integer [5, 177, 2598, 0, 204, ...]
+        gas_flaring integer [0, 0, 2623, 0, 3697, ...]
+        per_capita float [0.08, 0.43, 0.9, 1.68, 0.37, ...]
+        bunker_fuels integer [9, 7, 663, 0, 321, ...]
+      >
+
+      iex> df = Explorer.Datasets.fossil_fuels()
+      iex> df = Explorer.DataFrame.group_by(df, ["country", "year"])
+      iex> Explorer.DataFrame.ungroup(df)
+      #Explorer.DataFrame<
+        Polars[1094 x 10]
         year integer [2010, 2010, 2010, 2010, 2010, ...]
         country string ["AFGHANISTAN", "ALBANIA", "ALGERIA", "ANDORRA", "ANGOLA", ...]
         total integer [2308, 1254, 32500, 141, 7924, ...]

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2224,7 +2224,12 @@ defmodule Explorer.DataFrame do
           DataFrame.t()
   def group_by(df, groups) when is_list(groups) do
     groups = to_existing_columns(df, groups)
-    all_groups = MapSet.union(MapSet.new(df.groups), MapSet.new(groups)) |> MapSet.to_list()
+
+    all_groups =
+      df.groups
+      |> MapSet.new()
+      |> MapSet.union(MapSet.new(groups))
+      |> MapSet.to_list()
 
     out_df = %{df | groups: all_groups}
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1012,8 +1012,6 @@ defmodule Explorer.DataFrame do
   Columns are added with keyword list or maps. New variables overwrite existing variables of the
   same name. Column names are coerced from atoms to strings.
 
-  Be aware that mutating grouped dataframes will cause them to lose ordering.
-
   ## Examples
 
   You can pass in a list directly as a new column:

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1851,12 +1851,9 @@ defmodule Explorer.DataFrame do
     names = names(df)
     dtypes = names |> Enum.zip(dtypes(df)) |> Enum.into(%{})
 
-    case Map.get(dtypes, values_from) do
-      dtype when dtype in [:integer, :float, :date, :datetime] ->
-        :ok
-
-      dtype ->
-        raise ArgumentError, "the values_from column must be numeric, but found #{dtype}"
+    unless dtypes[values_from] in [:integer, :float, :date, :datetime] do
+      raise ArgumentError,
+            "the values_from column must be numeric, but found #{dtypes[values_from]}"
     end
 
     id_columns =

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1282,7 +1282,14 @@ defmodule Explorer.DataFrame do
       end
 
     if columns != [] do
-      Shared.apply_impl(df, :distinct, [columns, opts[:keep_all?]])
+      out_df =
+        if opts[:keep_all?] do
+          df
+        else
+          %{df | names: columns, dtypes: Map.take(df.dtypes, columns)}
+        end
+
+      Shared.apply_impl(df, :distinct, [out_df, columns, opts[:keep_all?]])
     else
       df
     end

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2252,11 +2252,7 @@ defmodule Explorer.DataFrame do
   def group_by(df, groups) when is_list(groups) do
     groups = to_existing_columns(df, groups)
 
-    all_groups =
-      df.groups
-      |> MapSet.new()
-      |> MapSet.union(MapSet.new(groups))
-      |> MapSet.to_list()
+    all_groups = Enum.uniq(df.groups ++ groups)
 
     out_df = %{df | groups: all_groups}
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2171,7 +2171,7 @@ defmodule Explorer.DataFrame do
       >
   """
   @doc type: :single
-  @spec group_by(df :: DataFrame.t(), groups_or_group :: [String.t()] | String.t()) ::
+  @spec group_by(df :: DataFrame.t(), groups_or_group :: column_names() | column_name()) ::
           DataFrame.t()
   def group_by(df, groups) when is_list(groups) do
     groups = to_existing_columns(df, groups)
@@ -2205,12 +2205,13 @@ defmodule Explorer.DataFrame do
       >
   """
   @doc type: :single
-  @spec ungroup(df :: DataFrame.t(), groups_or_group :: [String.t()] | String.t()) ::
+  @spec ungroup(df :: DataFrame.t(), groups_or_group :: column_names() | column_name()) ::
           DataFrame.t()
   def ungroup(df, groups \\ [])
 
   def ungroup(df, groups) when is_list(groups) do
     current_groups = groups(df)
+    groups = to_existing_columns(df, groups)
 
     Enum.each(groups, fn group ->
       if group not in current_groups,
@@ -2224,7 +2225,7 @@ defmodule Explorer.DataFrame do
     Shared.apply_impl(df, :ungroup, [groups])
   end
 
-  def ungroup(df, group) when is_binary(group), do: ungroup(df, [group])
+  def ungroup(df, group) when is_column_name(group), do: ungroup(df, [group])
 
   @supported_aggs ~w[min max sum mean median first last count n_unique]a
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2224,8 +2224,11 @@ defmodule Explorer.DataFrame do
           DataFrame.t()
   def group_by(df, groups) when is_list(groups) do
     groups = to_existing_columns(df, groups)
+    all_groups = MapSet.union(MapSet.new(df.groups), MapSet.new(groups)) |> MapSet.to_list()
 
-    Shared.apply_impl(df, :group_by, [groups])
+    out_df = %{df | groups: all_groups}
+
+    Shared.apply_impl(df, :group_by, [out_df])
   end
 
   def group_by(df, group) when is_column_name(group), do: group_by(df, [group])

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -923,7 +923,7 @@ defmodule Explorer.DataFrame do
         :drop -> names(df) -- columns
       end
 
-    out_df = Shared.update_names_and_dtypes(df, columns_to_keep)
+    out_df = %{df | names: columns_to_keep, dtypes: Map.take(df.dtypes, columns_to_keep)}
 
     Shared.apply_impl(df, :select, [out_df])
   end

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2174,13 +2174,12 @@ defmodule Explorer.DataFrame do
   @spec group_by(df :: DataFrame.t(), groups_or_group :: [String.t()] | String.t()) ::
           DataFrame.t()
   def group_by(df, groups) when is_list(groups) do
-    names = names(df)
-    Enum.each(groups, fn name -> maybe_raise_column_not_found(names, name) end)
+    groups = to_existing_columns(df, groups)
 
     Shared.apply_impl(df, :group_by, [groups])
   end
 
-  def group_by(df, group) when is_binary(group), do: group_by(df, [group])
+  def group_by(df, group) when is_column_name(group), do: group_by(df, [group])
 
   @doc """
   Removes grouping variables.

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1975,14 +1975,14 @@ defmodule Explorer.DataFrame do
 
     {on, how} =
       case {opts[:on], opts[:how]} do
-        {on, :cross} ->
-          {on, :cross}
+        {[], :cross} ->
+          {[], :cross}
 
         {[], _} ->
           raise(ArgumentError, "could not find any overlapping columns")
 
         {[_ | _] = on, how} ->
-          on =
+          normalized_on =
             Enum.map(on, fn
               {l_name, r_name} ->
                 [l_column] = to_existing_columns(left, [l_name])
@@ -1999,13 +1999,10 @@ defmodule Explorer.DataFrame do
                         "the column given to option `:on` is not the same for both dataframes"
                 end
 
-                l_column
+                {l_column, r_column}
             end)
 
-          {on, how}
-
-        other ->
-          other
+          {normalized_on, how}
       end
 
     Shared.apply_impl(left, :join, [right, on, how])

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -244,7 +244,6 @@ defmodule Explorer.PolarsBackend.DataFrame do
       |> Series.to_list()
       |> Enum.map(fn indices -> df |> DataFrame.ungroup() |> take(indices) |> n_rows() end)
 
-    # TODO: change "mutate" with out_df when available
     groupby
     |> DataFrame.select(["groups"], :drop)
     |> mutate(df, n: n)

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -394,24 +394,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
     [names_to, values_to] = not_ids = Enum.slice(out_df.names, -2, 2)
     id_columns = out_df.names -- not_ids
 
-    provisional_out = Shared.apply_dataframe(df, out_df, :df_melt, [id_columns, value_columns])
-    maybe_rename_variable_and_value_columns(provisional_out, names_to, values_to)
-  end
-
-  defp maybe_rename_variable_and_value_columns(out_df, "variable", "value"), do: out_df
-
-  defp maybe_rename_variable_and_value_columns(out_df, names_to, values_to) do
-    # Note that here we need to ask Polars for the names
-    new_names =
-      out_df
-      |> names()
-      |> Enum.map(fn
-        "variable" -> names_to
-        "value" -> values_to
-        name -> name
-      end)
-
-    rename(out_df, %{out_df | names: new_names})
+    Shared.apply_dataframe(df, out_df, :df_melt, [id_columns, value_columns, names_to, values_to])
   end
 
   @impl true

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -423,7 +423,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   # Two or more table verbs
 
   @impl true
-  def join(left, right, on, :right) do
+  def join(left, right, out_df, on, :right) do
     # Join right is just the "join left" with inverted DFs and swapped "on" instructions.
     # If columns on left have the same names from right, and they are not in "on" instructions,
     # then we add a suffix "_left".
@@ -433,14 +433,20 @@ defmodule Explorer.PolarsBackend.DataFrame do
       |> Enum.map(fn {left, right} -> {right, left} end)
       |> Enum.unzip()
 
-    Shared.apply_dataframe(right, :df_join, [left.data, left_on, right_on, "left", "_left"])
+    Shared.apply_dataframe(right, out_df, :df_join, [
+      left.data,
+      left_on,
+      right_on,
+      "left",
+      "_left"
+    ])
   end
 
-  def join(left, right, on, how) do
+  def join(left, right, out_df, on, how) do
     how = Atom.to_string(how)
     {left_on, right_on} = Enum.unzip(on)
 
-    Shared.apply_dataframe(left, :df_join, [right.data, left_on, right_on, how, "_right"])
+    Shared.apply_dataframe(left, out_df, :df_join, [right.data, left_on, right_on, how, "_right"])
   end
 
   @impl true

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -245,7 +245,10 @@ defmodule Explorer.PolarsBackend.DataFrame do
       |> Enum.map(fn indices -> df |> ungroup([]) |> take(indices) |> n_rows() end)
 
     # TODO: change "mutate" with out_df when available
-    groupby |> DataFrame.select(["groups"], :drop) |> mutate(df, n: n) |> group_by(groups)
+    groupby
+    |> DataFrame.select(["groups"], :drop)
+    |> mutate(df, n: n)
+    |> DataFrame.group_by(groups)
   end
 
   @impl true
@@ -289,7 +292,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
     |> Enum.reduce(fn df, acc ->
       Shared.apply_dataframe(acc, ungrouped_out, :df_vstack, [df.data])
     end)
-    |> group_by(groups)
+    |> DataFrame.group_by(groups)
   end
 
   defp to_series(df, name, value) do
@@ -341,7 +344,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
     |> indexes_by_groups()
     |> Enum.map(fn indices -> df |> ungroup([]) |> take(indices) |> arrange(columns) end)
     |> Enum.reduce(fn df, acc -> Shared.apply_dataframe(acc, :df_vstack, [df.data]) end)
-    |> group_by(groups)
+    |> DataFrame.group_by(groups)
   end
 
   @impl true
@@ -361,7 +364,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
       df |> ungroup([]) |> take(indices) |> distinct(columns, keep_all?)
     end)
     |> Enum.reduce(fn df, acc -> Shared.apply_dataframe(acc, :df_vstack, [df.data]) end)
-    |> group_by(groups)
+    |> DataFrame.group_by(groups)
   end
 
   @impl true
@@ -448,8 +451,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
   # Groups
 
   @impl true
-  def group_by(%DataFrame{groups: groups} = df, new_groups),
-    do: %DataFrame{df | groups: groups ++ new_groups}
+  def group_by(%DataFrame{}, %DataFrame{} = out_df),
+    do: out_df
 
   @impl true
   def ungroup(df, []), do: %DataFrame{df | groups: []}

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -353,8 +353,12 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def rename(df, names) when is_list(names),
-    do: Shared.apply_dataframe(df, :df_set_column_names, [names])
+  def rename(%DataFrame{} = df, %DataFrame{} = out_df),
+    do: Shared.apply_dataframe(df, out_df, :df_set_column_names, [out_df.names])
+
+  # TODO: remove after implementing `out_df` for all functions related
+  defp do_rename(%DataFrame{} = df, new_names) when is_list(new_names),
+    do: Shared.apply_dataframe(df, :df_set_column_names, [new_names])
 
   @impl true
   def dummies(df, names),
@@ -396,7 +400,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
       "value" -> values_to
       name -> name
     end)
-    |> then(&rename(df, &1))
+    |> then(&do_rename(df, &1))
   end
 
   @impl true
@@ -409,7 +413,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
       |> Enum.map(fn name ->
         if name in id_columns, do: name, else: names_prefix <> name
       end)
-      |> then(&rename(df, &1))
+      |> then(&do_rename(df, &1))
 
     df
   end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -272,6 +272,14 @@ defmodule Explorer.PolarsBackend.DataFrame do
     Enum.reduce(columns, df, &mutate_reducer/2)
   end
 
+  # So for groups we need to:
+  # - fetch groups from DF
+  # - map them, taking the indexes
+  # - for each group of indexes, we ungroup the group and take the registries from that
+  # - we then mutate that ungrouped group
+  # - after mutating we "join" each DF (for each given group)
+  # - then we apply the groups again
+  # BUT: if groups are "virtual", why we need to group and ungroup to mutate the DF?
   def mutate(%DataFrame{groups: groups} = df, columns) do
     df
     |> Shared.apply_dataframe(:df_groups, [groups])

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -421,16 +421,10 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   def join(left, right, on, how) do
     how = Atom.to_string(how)
-    {left_on, right_on} = Enum.reduce(on, {[], []}, &join_on_reducer/2)
+    {left_on, right_on} = Enum.unzip(on)
 
     Shared.apply_dataframe(left, :df_join, [right.data, left_on, right_on, how])
   end
-
-  defp join_on_reducer(column_name, {left, right}) when is_binary(column_name),
-    do: {[column_name | left], [column_name | right]}
-
-  defp join_on_reducer({new_left, new_right}, {left, right}),
-    do: {[new_left | left], [new_right | right]}
 
   @impl true
   def concat_rows(dfs) do

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -453,13 +453,12 @@ defmodule Explorer.PolarsBackend.DataFrame do
     do: %DataFrame{df | groups: Enum.filter(df.groups, &(&1 not in groups))}
 
   @impl true
-  def summarise(%DataFrame{groups: groups} = df, columns) do
+  def summarise(%DataFrame{groups: groups} = df, %DataFrame{} = out_df, columns) do
     columns =
       Enum.map(columns, fn {key, values} -> {key, Enum.map(values, &Atom.to_string/1)} end)
 
     df
-    |> Shared.apply_dataframe(:df_groupby_agg, [groups, columns])
-    |> DataFrame.ungroup()
+    |> Shared.apply_dataframe(out_df, :df_groupby_agg, [groups, columns])
     |> DataFrame.arrange(groups)
   end
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -282,17 +282,10 @@ defmodule Explorer.PolarsBackend.DataFrame do
     end)
   end
 
-  def mutate(%DataFrame{groups: groups} = df, out_df, columns) do
-    ungrouped_df = DataFrame.ungroup(df)
+  def mutate(%DataFrame{groups: [_ | _]} = df, out_df, columns) do
     ungrouped_out = DataFrame.ungroup(out_df)
 
-    df
-    |> indexes_by_groups()
-    |> Enum.map(fn indices -> ungrouped_df |> take(indices) |> mutate(ungrouped_out, columns) end)
-    |> Enum.reduce(fn df, acc ->
-      Shared.apply_dataframe(acc, ungrouped_out, :df_vstack, [df.data])
-    end)
-    |> DataFrame.group_by(groups)
+    apply_on_groups(df, fn group -> mutate(group, ungrouped_out, columns) end)
   end
 
   defp to_series(df, name, value) do
@@ -309,14 +302,6 @@ defmodule Explorer.PolarsBackend.DataFrame do
       any ->
         to_series(df, name, List.duplicate(any, n_rows(df)))
     end
-  end
-
-  # Returns a list of lists, where each list is a group of row indexes.
-  defp indexes_by_groups(%DataFrame{groups: [_ | _]} = df) do
-    df
-    |> Shared.apply_dataframe(:df_groups, [df.groups])
-    |> pull("groups")
-    |> Series.to_list()
   end
 
   defp check_series_size!(df, series, column_name) do
@@ -339,12 +324,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
         Shared.apply_dataframe(df, :df_sort, [column, direction == :desc])
       end)
 
-  def arrange(%DataFrame{groups: groups} = df, columns) do
-    df
-    |> indexes_by_groups()
-    |> Enum.map(fn indices -> df |> DataFrame.ungroup() |> take(indices) |> arrange(columns) end)
-    |> Enum.reduce(fn df, acc -> Shared.apply_dataframe(acc, :df_vstack, [df.data]) end)
-    |> DataFrame.group_by(groups)
+  def arrange(%DataFrame{groups: [_ | _]} = df, columns) do
+    apply_on_groups(df, fn group -> arrange(group, columns) end)
   end
 
   @impl true
@@ -357,16 +338,28 @@ defmodule Explorer.PolarsBackend.DataFrame do
       |> Shared.apply_dataframe(:df_drop_duplicates, [true, columns])
       |> DataFrame.select(columns)
 
-  def distinct(%DataFrame{groups: groups} = df, columns, keep_all?) do
+  def distinct(%DataFrame{groups: [_ | _]} = df, columns, keep_all?) do
+    apply_on_groups(df, fn group -> distinct(group, columns, keep_all?) end)
+  end
+
+  defp apply_on_groups(%DataFrame{} = df, callback) when is_function(callback, 1) do
     ungrouped_df = DataFrame.ungroup(df)
 
     df
     |> indexes_by_groups()
     |> Enum.map(fn indices ->
-      ungrouped_df |> take(indices) |> distinct(columns, keep_all?)
+      ungrouped_df |> take(indices) |> then(callback)
     end)
     |> Enum.reduce(fn df, acc -> Shared.apply_dataframe(acc, :df_vstack, [df.data]) end)
-    |> DataFrame.group_by(groups)
+    |> DataFrame.group_by(df.groups)
+  end
+
+  # Returns a list of lists, where each list is a group of row indexes.
+  defp indexes_by_groups(%DataFrame{groups: [_ | _]} = df) do
+    df
+    |> Shared.apply_dataframe(:df_groups, [df.groups])
+    |> pull("groups")
+    |> Series.to_list()
   end
 
   @impl true

--- a/lib/explorer/polars_backend/lazy_data_frame.ex
+++ b/lib/explorer/polars_backend/lazy_data_frame.ex
@@ -51,11 +51,7 @@ defmodule Explorer.PolarsBackend.LazyDataFrame do
   def tail(ldf, rows), do: Shared.apply_dataframe(ldf, :lf_tail, [rows])
 
   @impl true
-  def select(ldf, columns, :keep) when is_list(columns),
-    do: Shared.apply_dataframe(ldf, :lf_select, [columns])
-
-  def select(ldf, columns, :drop) when is_list(columns),
-    do: Shared.apply_dataframe(ldf, :lf_drop, [columns])
+  def select(ldf, out_ldf), do: Shared.apply_dataframe(ldf, out_ldf, :lf_select, [out_ldf.names])
 
   # Groups
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -71,7 +71,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_head(_df, _length), do: err()
   def df_height(_df), do: err()
   def df_join(_df, _other, _left_on, _right_on, _how), do: err()
-  def df_melt(_df, _id_vars, _value_vars), do: err()
+  def df_melt(_df, _id_vars, _value_vars, _names_to, _values_to), do: err()
   def df_new(_columns), do: err()
   def df_pivot_wider(_df, _id_columns, _pivot_column, _values_columns), do: err()
   def df_read_ipc(_filename, _columns, _projection), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -70,7 +70,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_groupby_agg(_df, _groups, _aggs), do: err()
   def df_head(_df, _length), do: err()
   def df_height(_df), do: err()
-  def df_join(_df, _other, _left_on, _right_on, _how), do: err()
+  def df_join(_df, _other, _left_on, _right_on, _how, _suffix), do: err()
   def df_melt(_df, _id_vars, _value_vars, _names_to, _values_to), do: err()
   def df_new(_columns), do: err()
   def df_pivot_wider(_df, _id_columns, _pivot_column, _values_column), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -73,7 +73,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_join(_df, _other, _left_on, _right_on, _how), do: err()
   def df_melt(_df, _id_vars, _value_vars, _names_to, _values_to), do: err()
   def df_new(_columns), do: err()
-  def df_pivot_wider(_df, _id_columns, _pivot_column, _values_columns), do: err()
+  def df_pivot_wider(_df, _id_columns, _pivot_column, _values_column), do: err()
   def df_read_ipc(_filename, _columns, _projection), do: err()
   def df_read_parquet(_filename), do: err()
   def df_select(_df, _selection), do: err()

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -35,7 +35,7 @@ defmodule Explorer.PolarsBackend.Shared do
 
   def apply_dataframe(%DataFrame{} = df, %DataFrame{} = out_df, fun, args) do
     case apply(Native, fun, [df.data | args]) do
-      {:ok, %module{} = new_df} when module in @polars_df -> update_dataframe(new_df, out_df)
+      {:ok, %module{} = new_df} when module in @polars_df -> %{out_df | data: new_df}
       {:ok, %PolarsSeries{} = new_series} -> create_series(new_series)
       {:ok, value} -> value
       {:error, error} -> raise "#{error}"

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -44,14 +44,18 @@ defmodule Explorer.PolarsBackend.Shared do
 
   # TODO: consider accepting lazy df in the future
   def create_dataframe(%PolarsDataFrame{} = polars_df) do
-    {:ok, {names, dtypes}} =
-      with {:ok, names} <- Native.df_columns(polars_df),
-           {:ok, dtypes} <- Native.df_dtypes(polars_df),
-           do: {:ok, {names, dtypes}}
+    {:ok, names} = Native.df_columns(polars_df)
+    {:ok, dtypes} = Native.df_dtypes(polars_df)
 
     dtypes = Enum.map(dtypes, &normalise_dtype/1)
 
     Explorer.Backend.DataFrame.new(polars_df, names, dtypes)
+  end
+
+  def update_dataframe(%PolarsDataFrame{} = polars_df, %DataFrame{} = df) do
+    new_df = create_dataframe(polars_df)
+
+    %{new_df | groups: df.groups}
   end
 
   # TODO: consider reflecting/checking names and dtypes

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -35,8 +35,8 @@ defmodule Explorer.PolarsBackend.Shared do
 
   def apply_dataframe(%DataFrame{} = df, %DataFrame{} = out_df, fun, args) do
     case apply(Native, fun, [df.data | args]) do
-      {:ok, new_df} when is_polars_df(new_df) -> update_dataframe(new_df, out_df)
-      {:ok, new_series} when is_polars_series(new_series) -> create_series(new_series)
+      {:ok, %module{} = new_df} when module in @polars_df -> update_dataframe(new_df, out_df)
+      {:ok, %PolarsSeries{} = new_series} -> create_series(new_series)
       {:ok, value} -> value
       {:error, error} -> raise "#{error}"
     end
@@ -62,8 +62,8 @@ defmodule Explorer.PolarsBackend.Shared do
   end
 
   # TODO: reflect names and dtypes
-  def update_dataframe(polars_df, %DataFrame{} = df)
-      when is_polars_df(polars_df),
+  def update_dataframe(%module{} = polars_df, %DataFrame{} = df)
+      when module in @polars_df,
       do: %DataFrame{df | data: polars_df}
 
   def create_series(%PolarsSeries{} = polars_series) do

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -74,6 +74,7 @@ defmodule Explorer.PolarsBackend.Shared do
   def normalise_dtype("datetime"), do: :datetime
   def normalise_dtype("datetime[ms]"), do: :datetime
   def normalise_dtype("datetime[μs]"), do: :datetime
+  def normalise_dtype("list [u32]"), do: :list
 
   def internal_from_dtype(:integer), do: "i64"
   def internal_from_dtype(:float), do: "f64"

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -33,9 +33,26 @@ defmodule Explorer.PolarsBackend.Shared do
     end
   end
 
-  def create_dataframe(%module{} = polars_df) when module in @polars_df,
-    do: %DataFrame{data: polars_df, groups: []}
+  def create_dataframe(%module{} = polars_df) when module in @polars_df do
+    {names, dtypes} =
+      case polars_df do
+        %PolarsLazyFrame{} ->
+          with {:ok, names} <- Native.lf_names(polars_df),
+               {:ok, dtypes} <- Native.lf_dtypes(polars_df),
+               do: {names, dtypes}
 
+        %PolarsDataFrame{} ->
+          with {:ok, names} <- Native.df_columns(polars_df),
+               {:ok, dtypes} <- Native.df_dtypes(polars_df),
+               do: {names, dtypes}
+      end
+
+    dtypes = Enum.map(dtypes, &normalise_dtype/1)
+
+    Explorer.Backend.DataFrame.new(polars_df, names, dtypes)
+  end
+
+  # TODO: reflect names and dtypes
   def update_dataframe(%module{} = polars_df, %DataFrame{} = df)
       when module in @polars_df,
       do: %DataFrame{df | data: polars_df}

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -119,15 +119,4 @@ defmodule Explorer.Shared do
   def to_string(i, _opts) when is_nil(i), do: "nil"
   def to_string(i, _opts) when is_binary(i), do: "\"#{i}\""
   def to_string(i, _opts), do: Kernel.to_string(i)
-
-  @doc """
-  Updates the names and dtypes map of a df in memory.
-
-  The intention is to provide a "out_df" with updated names and dtypes map.
-  Note that columns must be a subset of column names in the DF. No new columns
-  will be added.
-  """
-  def update_names_and_dtypes(df, columns_to_keep) do
-    %{df | names: columns_to_keep, dtypes: Map.take(df.dtypes, columns_to_keep)}
-  end
 end

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -119,4 +119,15 @@ defmodule Explorer.Shared do
   def to_string(i, _opts) when is_nil(i), do: "nil"
   def to_string(i, _opts) when is_binary(i), do: "\"#{i}\""
   def to_string(i, _opts), do: Kernel.to_string(i)
+
+  @doc """
+  Updates the names and dtypes map of a df in memory.
+
+  The intention is to provide a "out_df" with updated names and dtypes map.
+  Note that columns must be a subset of column names in the DF. No new columns
+  will be added.
+  """
+  def update_names_and_dtypes(df, columns_to_keep) do
+    %{df | names: columns_to_keep, dtypes: Map.take(df.dtypes, columns_to_keep)}
+  end
 end

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -346,11 +346,19 @@ pub fn df_tail(data: ExDataFrame, length: Option<usize>) -> Result<ExDataFrame, 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_melt(
     data: ExDataFrame,
-    id_vars: Vec<&str>,
-    value_vars: Vec<&str>,
+    id_vars: Vec<String>,
+    value_vars: Vec<String>,
+    names_to: String,
+    values_to: String,
 ) -> Result<ExDataFrame, ExplorerError> {
     let df = &data.resource.0;
-    let new_df = df.melt(id_vars, value_vars)?;
+    let melt_opts = MeltArgs {
+        id_vars,
+        value_vars,
+        variable_name: Some(names_to),
+        value_name: Some(values_to),
+    };
+    let new_df = df.melt2(melt_opts)?;
     Ok(ExDataFrame::new(new_df))
 }
 

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -187,6 +187,7 @@ pub fn df_join(
     left_on: Vec<&str>,
     right_on: Vec<&str>,
     how: &str,
+    suffix: Option<String>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let how = match how {
         "left" => JoinType::Left,
@@ -203,7 +204,7 @@ pub fn df_join(
 
     let df = &data.resource.0;
     let df1 = &other.resource.0;
-    let new_df = df.join(df1, left_on, right_on, how, None)?;
+    let new_df = df.join(df1, left_on, right_on, how, suffix)?;
     Ok(ExDataFrame::new(new_df))
 }
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -129,6 +129,8 @@ defmodule Explorer.DataFrameTest do
                a_right: [5, 6, 7]
              }
 
+      assert df.names == ["a", "b", "c", "a_right"]
+
       df1 = DF.join(left, right, on: [{"a", "d"}], how: :left)
 
       assert DF.to_columns(df1, atom_keys: true) == %{
@@ -138,6 +140,8 @@ defmodule Explorer.DataFrameTest do
                a_right: [5, 6, 7, nil]
              }
 
+      assert df1.names == ["a", "b", "c", "a_right"]
+
       df2 = DF.join(left, right, on: [{"a", "d"}], how: :outer)
 
       assert DF.to_columns(df2, atom_keys: true) == %{
@@ -146,6 +150,8 @@ defmodule Explorer.DataFrameTest do
                c: ["d", "e", "f", nil],
                a_right: [5, 6, 7, nil]
              }
+
+      assert df2.names == ["a", "b", "c", "a_right"]
 
       df3 = DF.join(left, right, how: :cross)
 
@@ -157,6 +163,8 @@ defmodule Explorer.DataFrameTest do
                d: [1, 2, 2, 1, 2, 2, 1, 2, 2]
              }
 
+      assert df3.names == ["a", "b", "d", "c", "a_right"]
+
       df4 = DF.join(left, right, on: [{"a", "d"}], how: :right)
 
       assert DF.to_columns(df4, atom_keys: true) == %{
@@ -165,6 +173,8 @@ defmodule Explorer.DataFrameTest do
                c: ["d", "e", "f"],
                d: [1, 2, 2]
              }
+
+      assert df4.names == ["d", "c", "a", "b"]
     end
 
     test "with a custom 'on' but with repeated column on left side" do
@@ -180,6 +190,8 @@ defmodule Explorer.DataFrameTest do
                d: [5, 6, 6]
              }
 
+      assert df.names == ["a", "b", "d", "c"]
+
       df1 = DF.join(left, right, on: [{"a", "d"}], how: :left)
 
       assert DF.to_columns(df1, atom_keys: true) == %{
@@ -189,6 +201,8 @@ defmodule Explorer.DataFrameTest do
                d: [5, 6, 6, 7]
              }
 
+      assert df1.names == ["a", "b", "d", "c"]
+
       df2 = DF.join(left, right, on: [{"a", "d"}], how: :outer)
 
       assert DF.to_columns(df2, atom_keys: true) == %{
@@ -197,6 +211,8 @@ defmodule Explorer.DataFrameTest do
                c: ["d", "e", "f", nil],
                d: [5, 6, 6, 7]
              }
+
+      assert df2.names == ["a", "b", "d", "c"]
 
       df3 = DF.join(left, right, how: :cross)
 
@@ -208,6 +224,8 @@ defmodule Explorer.DataFrameTest do
                d_right: [1, 2, 2, 1, 2, 2, 1, 2, 2]
              }
 
+      assert df3.names == ["a", "b", "d", "d_right", "c"]
+
       df4 = DF.join(left, right, on: [{"a", "d"}], how: :right)
 
       assert DF.to_columns(df4, atom_keys: true) == %{
@@ -216,6 +234,8 @@ defmodule Explorer.DataFrameTest do
                d: [1, 2, 2],
                d_left: [5, 6, 6]
              }
+
+      assert df4.names == ["d", "c", "b", "d_left"]
     end
 
     test "with invalid join strategy" do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -67,6 +67,14 @@ defmodule Explorer.DataFrameTest do
                    "size of new column test (3) must match number of rows in the dataframe (1094)",
                    fn -> DF.mutate(df, test: [1, 2, 3]) end
     end
+
+    test "keeps the column order" do
+      df = DF.new(e: [1, 2, 3], c: ["a", "b", "c"], a: [1.2, 2.3, 4.5])
+
+      df1 = DF.mutate(df, d: 1, b: 2)
+
+      assert df1.names == ["e", "c", "a", "d", "b"]
+    end
   end
 
   describe "arrange/3" do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -707,4 +707,78 @@ defmodule Explorer.DataFrameTest do
   test "to_lazy/1", %{df: df} do
     assert %Explorer.PolarsBackend.LazyDataFrame{} = DF.to_lazy(df).data
   end
+
+  describe "select/3" do
+    test "keep column names" do
+      df = DF.new(a: ["a", "b", "c"], b: [1, 2, 3])
+      df = DF.select(df, ["a"])
+
+      assert DF.names(df) == ["a"]
+    end
+
+    test "keep column positions" do
+      df = DF.new(a: ["a", "b", "c"], b: [1, 2, 3])
+      df = DF.select(df, [1])
+
+      assert DF.names(df) == ["b"]
+    end
+
+    test "keep column range" do
+      df = DF.new(a: ["a", "b", "c"], b: [1, 2, 3], c: [42.0, 42.1, 42.2])
+      df = DF.select(df, 1..2)
+
+      assert DF.names(df) == ["b", "c"]
+    end
+
+    test "keep columns matching callback" do
+      df = DF.new(a: ["a", "b", "c"], b: [1, 2, 3], c: [42.0, 42.1, 42.2])
+      df = DF.select(df, fn name -> name in ~w(a c) end)
+
+      assert DF.names(df) == ["a", "c"]
+    end
+
+    test "keep column raises error with non-existent column" do
+      df = DF.new(a: ["a", "b", "c"], b: [1, 2, 3])
+
+      assert_raise ArgumentError, "could not find column name \"g\"", fn ->
+        DF.select(df, ["g"])
+      end
+    end
+
+    test "drop column names" do
+      df = DF.new(a: ["a", "b", "c"], b: [1, 2, 3])
+      df = DF.select(df, ["a"], :drop)
+
+      assert DF.names(df) == ["b"]
+    end
+
+    test "drop column positions" do
+      df = DF.new(a: ["a", "b", "c"], b: [1, 2, 3])
+      df = DF.select(df, [1], :drop)
+
+      assert DF.names(df) == ["a"]
+    end
+
+    test "drop column range" do
+      df = DF.new(a: ["a", "b", "c"], b: [1, 2, 3], c: [42.0, 42.1, 42.2])
+      df = DF.select(df, 1..2, :drop)
+
+      assert DF.names(df) == ["a"]
+    end
+
+    test "drop columns matching callback" do
+      df = DF.new(a: ["a", "b", "c"], b: [1, 2, 3], c: [42.0, 42.1, 42.2])
+      df = DF.select(df, fn name -> name in ~w(a c) end, :drop)
+
+      assert DF.names(df) == ["b"]
+    end
+
+    test "drop column raises error with non-existent column" do
+      df = DF.new(a: ["a", "b", "c"], b: [1, 2, 3])
+
+      assert_raise ArgumentError, "could not find column name \"g\"", fn ->
+        DF.select(df, ["g"], :drop)
+      end
+    end
+  end
 end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -732,6 +732,22 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "with a single id column and repeated values" do
+      df = DF.new(id: [1, 1, 2, 2], variable: ["a", "b", "a", "b"], value: [1, 2, 3, 4])
+
+      df2 = DF.pivot_wider(df, "variable", "value", id_columns: [:id])
+      assert DF.names(df2) == ["id", "a", "b"]
+
+      df2 = DF.pivot_wider(df, "variable", "value", id_columns: [0])
+      assert DF.names(df2) == ["id", "a", "b"]
+
+      assert DF.to_columns(df2, atom_keys: true) == %{
+               id: [1, 2],
+               a: [1, 3],
+               b: [2, 4]
+             }
+    end
+
     test "with a filter function for id columns" do
       df = DF.new(id_main: [1, 1], variable: ["a", "b"], value: [1, 2], other: [4, 5])
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -36,21 +36,29 @@ defmodule Explorer.DataFrameTest do
                b: ["a", "b", "c"],
                c: [true, false, true]
              }
+
+      assert df1.names == ["a", "b", "c"]
+      assert df1.dtypes == %{"a" => :integer, "b" => :string, "c" => :boolean}
     end
 
     test "adds a new column when there is a group" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"], c: [1, 1, 2])
 
       df1 = DF.group_by(df, :c)
-      df2 = DF.mutate(df1, d: &Series.add(&1["a"], -7))
+      df2 = DF.mutate(df1, d: &Series.add(&1["a"], -7.1))
 
-      # TODO: should we have the DF in the same order from original? 
-      assert DF.to_columns(DF.arrange(df2, :a), atom_keys: true) == %{
+      # We need to sort again because it breaks ordering in the process.
+      df3 = df2 |> DF.ungroup() |> DF.arrange(:a) |> DF.group_by(:c)
+
+      assert DF.to_columns(df3, atom_keys: true) == %{
                a: [1, 2, 3],
                b: ["a", "b", "c"],
                c: [1, 1, 2],
-               d: [-6, -5, -4]
+               d: [-6.1, -5.1, -4.1]
              }
+
+      assert df2.names == ["a", "b", "c", "d"]
+      assert df2.dtypes == %{"a" => :integer, "b" => :string, "c" => :integer, "d" => :float}
     end
 
     test "raises with series of invalid size", %{df: df} do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -47,10 +47,7 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.group_by(df, :c)
       df2 = DF.mutate(df1, d: &Series.add(&1["a"], -7.1))
 
-      # We need to sort again because it breaks ordering in the process.
-      df3 = df2 |> DF.ungroup() |> DF.arrange(:a) |> DF.group_by(:c)
-
-      assert DF.to_columns(df3, atom_keys: true) == %{
+      assert DF.to_columns(df2, atom_keys: true) == %{
                a: [1, 2, 3],
                b: ["a", "b", "c"],
                c: [1, 1, 2],

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1207,7 +1207,6 @@ defmodule Explorer.DataFrameTest do
       equal_filters =
         for country <- ["BRAZIL", "AUSTRALIA", "POLAND"], do: Series.equal(df["country"], country)
 
-      # TODO: build a smaller DF with departments, employees, salary
       filters = Enum.reduce(equal_filters, fn filter, acc -> Series.or(acc, filter) end)
 
       df1 =

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -659,8 +659,7 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.rename(df, ["c", "d"])
 
       assert DF.names(df1) == ["c", "d"]
-      # TODO: check if the rename is happening in Polars' Series
-      # assert df1["c"] == df["a"]
+      assert df1.names == ["c", "d"]
       assert Series.to_list(df1["c"]) == Series.to_list(df["a"])
     end
 
@@ -668,6 +667,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(a: ["a", "b", "a"], b: [1, 3, 1])
       df1 = DF.rename(df, a: "first")
 
+      assert df1.names == ["first", "b"]
       assert Series.to_list(df1["first"]) == Series.to_list(df["a"])
     end
 
@@ -675,6 +675,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(a: ["a", "b", "a"], b: [1, 3, 1])
       df1 = DF.rename(df, %{"a" => "first", "b" => "second"})
 
+      assert df1.names == ["first", "second"]
       assert Series.to_list(df1["first"]) == Series.to_list(df["a"])
       assert Series.to_list(df1["second"]) == Series.to_list(df["b"])
     end
@@ -715,6 +716,19 @@ defmodule Explorer.DataFrameTest do
 
       assert df_names -- df1_names == ["total", "cement"]
       assert df1_names -- df_names == ["TOTAL", "CEMENT"]
+
+      assert df1.names == [
+               "year",
+               "country",
+               "TOTAL",
+               "solid_fuel",
+               "liquid_fuel",
+               "gas_fuel",
+               "CEMENT",
+               "gas_flaring",
+               "per_capita",
+               "bunker_fuels"
+             ]
     end
 
     test "with ranges", %{df: df} do
@@ -770,6 +784,8 @@ defmodule Explorer.DataFrameTest do
                df4,
                atom_keys: true
              ) == %{id: [1], column_1: [1.0], column_2: [2.0]}
+
+      assert df4.names == ["id", "column_1", "column_2"]
     end
 
     test "with multiple id columns" do
@@ -777,6 +793,7 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.pivot_wider(df, "variable", "value")
 
       assert DF.names(df1) == ["id", "other_id", "a", "b"]
+      assert df1.names == ["id", "other_id", "a", "b"]
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                id: [1, 1],
@@ -794,6 +811,7 @@ defmodule Explorer.DataFrameTest do
 
       df2 = DF.pivot_wider(df, "variable", "value", id_columns: [0])
       assert DF.names(df2) == ["id", "a", "b"]
+      assert df2.names == ["id", "a", "b"]
 
       assert DF.to_columns(df2, atom_keys: true) == %{
                id: [1],
@@ -878,6 +896,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.select(df, ["a"])
 
       assert DF.names(df) == ["a"]
+      assert df.names == ["a"]
     end
 
     test "keep column positions" do
@@ -885,6 +904,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.select(df, [1])
 
       assert DF.names(df) == ["b"]
+      assert df.names == ["b"]
     end
 
     test "keep column range" do
@@ -892,6 +912,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.select(df, 1..2)
 
       assert DF.names(df) == ["b", "c"]
+      assert df.names == ["b", "c"]
     end
 
     test "keep columns matching callback" do
@@ -899,6 +920,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.select(df, fn name -> name in ~w(a c) end)
 
       assert DF.names(df) == ["a", "c"]
+      assert df.names == ["a", "c"]
     end
 
     test "keep column raises error with non-existent column" do
@@ -914,6 +936,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.select(df, ["a"], :drop)
 
       assert DF.names(df) == ["b"]
+      assert df.names == ["b"]
     end
 
     test "drop column positions" do
@@ -921,6 +944,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.select(df, [1], :drop)
 
       assert DF.names(df) == ["a"]
+      assert df.names == ["a"]
     end
 
     test "drop column range" do
@@ -928,6 +952,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.select(df, 1..2, :drop)
 
       assert DF.names(df) == ["a"]
+      assert df.names == ["a"]
     end
 
     test "drop columns matching callback" do
@@ -935,6 +960,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.select(df, fn name -> name in ~w(a c) end, :drop)
 
       assert DF.names(df) == ["b"]
+      assert df.names == ["b"]
     end
 
     test "drop column raises error with non-existent column" do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -67,6 +67,42 @@ defmodule Explorer.DataFrameTest do
       joined = DF.join(left, right, how: :cross)
       assert %DF{} = joined
     end
+
+    test "with a custom 'on'" do
+      left = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+      right = DF.new(d: [1, 2, 2], c: ["d", "e", "f"])
+
+      df = DF.join(left, right, on: [{"a", "d"}])
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               a: [1, 2, 2],
+               b: ["a", "b", "b"],
+               c: ["d", "e", "f"]
+             }
+    end
+
+    test "with a custom 'on' but with repeated column" do
+      left = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+      right = DF.new(d: [1, 2, 2], c: ["d", "e", "f"], a: [5, 6, 7])
+
+      df = DF.join(left, right, on: [{"a", "d"}])
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               a: [1, 2, 2],
+               b: ["a", "b", "b"],
+               c: ["d", "e", "f"],
+               a_right: [5, 6, 7]
+             }
+
+      df1 = DF.join(left, right, on: [{"a", "d"}], how: :left)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 2, 2, 3],
+               b: ["a", "b", "b", "c"],
+               c: ["d", "e", "f", nil],
+               a_right: [5, 6, 7, nil]
+             }
+    end
   end
 
   describe "from_csv/2 options" do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -45,7 +45,7 @@ defmodule Explorer.DataFrameTest do
       df2 = DF.mutate(df1, d: &Series.add(&1["a"], -7))
 
       # TODO: should we have the DF in the same order from original? 
-      assert DF.to_columns(DF.arrange(df2, [:a]), atom_keys: true) == %{
+      assert DF.to_columns(DF.arrange(df2, :a), atom_keys: true) == %{
                a: [1, 2, 3],
                b: ["a", "b", "c"],
                c: [1, 1, 2],

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -27,6 +27,32 @@ defmodule Explorer.DataFrameTest do
   end
 
   describe "mutate/2" do
+    test "adds a new column" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+      df1 = DF.mutate(df, c: [true, false, true])
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 2, 3],
+               b: ["a", "b", "c"],
+               c: [true, false, true]
+             }
+    end
+
+    test "adds a new column when there is a group" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"], c: [1, 1, 2])
+
+      df1 = DF.group_by(df, :c)
+      df2 = DF.mutate(df1, d: &Series.add(&1["a"], -7))
+
+      # TODO: should we have the DF in the same order from original? 
+      assert DF.to_columns(DF.arrange(df2, [:a]), atom_keys: true) == %{
+               a: [1, 2, 3],
+               b: ["a", "b", "c"],
+               c: [1, 1, 2],
+               d: [-6, -5, -4]
+             }
+    end
+
     test "raises with series of invalid size", %{df: df} do
       assert_raise ArgumentError,
                    "size of new column test (3) must match number of rows in the dataframe (1094)",


### PR DESCRIPTION
The idea of this change is to simplify the implementation of data frame backends
by applying the changes to a "virtual DF" and letting the backend decide how to apply those changes.

In this PR we have the following callbacks updated:

- [x] `select`
- [x] `mutate`
- [x] `rename`
- [x] `pivot_longer`
- [x] `group_by`
- [x] `ungroup`
- [x] `summarise`
- [x] `join` - a smaller change in the `on` specs
- [x] `join`
- [x] `distinct`

~~The PR is in WIP so we can evaluate if the changes makes sense.~~

~~PS: some of the changes here are duplicated from PR https://github.com/elixir-nx/explorer/pull/237, so after that merge I will rebase.~~