### PR TITLE
Avoid usage of MiMalloc on Linux with musl

### DIFF
--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -17,8 +17,9 @@ rand_pcg = "0.3.1"
 rustler = "0.25.0"
 thiserror = "1"
 
-# This is because when using GCC on Windows MiMalloc won´t compile
-[target.'cfg(not(all(windows, target_env = "gnu")))'.dependencies]
+# MiMalloc won´t compile on Windows with the GCC compiler.
+# On Linux with Musl it won´t load correctly.
+[target.'cfg(not(any(all(windows, target_env = "gnu"), all(target_os = "linux", target_env = "musl"))))'.dependencies]
 mimalloc = { version = "*", default-features = false }
 
 [dependencies.polars]

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -1,9 +1,16 @@
-// MiMalloc won´t compile on Windows with the GCC compiler
-#[cfg(not(all(windows, target_env = "gnu")))]
+// MiMalloc won´t compile on Windows with the GCC compiler.
+// On Linux with Musl it won´t load correctly.
+#[cfg(not(any(
+    all(windows, target_env = "gnu"),
+    all(target_os = "linux", target_env = "musl")
+)))]
 use mimalloc::MiMalloc;
 use rustler::{Env, Term};
 
-#[cfg(not(all(windows, target_env = "gnu")))]
+#[cfg(not(any(
+    all(windows, target_env = "gnu"),
+    all(target_os = "linux", target_env = "musl")
+)))]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 


### PR DESCRIPTION
This fixes a problem when trying to run Explorer in an Alpine Linux
container.

The error message was something like this:

    Error relocating {path_of_nif} initial-exec TLS resolves to dynamic definition

I could not find the root cause, but looks like MiMalloc does not follow the
Thread-Local Storage model implemented by the compiler using musl.

Thanks @polvalente for reporting the problem!