### PR TITLE
Add POC grouped arrange

### DIFF
--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -319,15 +319,13 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def arrange(%DataFrame{groups: []} = df, columns) do
-    ungrouped_arrange(df, columns)
-  end
+  def arrange(%DataFrame{groups: groups} = df, columns) do
+    groups =
+      case groups do
+        [] -> nil
+        groups -> groups
+      end
 
-  def arrange(%DataFrame{groups: [_ | _]} = df, columns) do
-    apply_on_groups(df, df, fn group -> ungrouped_arrange(group, columns) end)
-  end
-
-  defp ungrouped_arrange(df, columns) do
     {directions, columns} =
       columns
       |> Enum.map(fn {dir, col} ->
@@ -335,7 +333,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
       end)
       |> Enum.unzip()
 
-    Shared.apply_dataframe(df, df, :df_sort, [columns, directions])
+    Shared.apply_dataframe(df, df, :df_sort, [columns, directions, groups])
   end
 
   @impl true
@@ -376,7 +374,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
       end)
     end)
     |> concat_rows()
-    |> ungrouped_arrange([{:asc, idx_column}])
+    |> arrange([{:asc, idx_column}])
     |> select(out_df)
   end
 
@@ -492,7 +490,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
     df
     |> Shared.apply_dataframe(out_df, :df_groupby_agg, [groups, columns])
-    |> ungrouped_arrange(order)
+    |> arrange(order)
   end
 
   # Inspect

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -320,12 +320,6 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def arrange(%DataFrame{groups: groups} = df, columns) do
-    groups =
-      case groups do
-        [] -> nil
-        groups -> groups
-      end
-
     {directions, columns} =
       columns
       |> Enum.map(fn {dir, col} ->

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -82,7 +82,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_set_column_names(_df, _names), do: err()
   def df_shape(_df), do: err()
   def df_slice(_df, _offset, _length), do: err()
-  def df_sort(_df, _by, _reverse), do: err()
+  def df_sort(_df, _by, _reverse, _groups), do: err()
   def df_tail(_df, _length), do: err()
   def df_take(_df, _indices), do: err()
   def df_to_dummies(_df, _columns), do: err()

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -325,21 +325,18 @@ pub fn df_sort(
     data: ExDataFrame,
     by_columns: Vec<String>,
     reverse: Vec<bool>,
-    groups: Option<Vec<String>>,
+    groups: Vec<String>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let df: DataFrame = data.resource.0.clone();
 
-    let new_df = match groups {
-        None => {
-            let new_df = &df.sort(by_columns, reverse)?;
-            new_df.clone()
-        }
-        Some(groups) => {
-            let new_df = &df
-                .groupby(groups)?
-                .apply(|df| df.sort(by_columns.clone(), reverse.clone()))?;
-            new_df.clone()
-        }
+    let new_df = if groups.is_empty() {
+        let new_df = &df.sort(by_columns, reverse)?;
+        new_df.clone()
+    } else {
+        let new_df = &df
+            .groupby(groups)?
+            .apply(|df| df.sort(by_columns.clone(), reverse.clone()))?;
+        new_df.clone()
     };
 
     Ok(ExDataFrame::new(new_df))

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -334,7 +334,7 @@ pub fn df_sort(
         new_df.clone()
     } else {
         let new_df = &df
-            .groupby(groups)?
+            .groupby_stable(groups)?
             .apply(|df| df.sort(by_columns.clone(), reverse.clone()))?;
         new_df.clone()
     };
@@ -447,7 +447,7 @@ pub fn df_set_column_names(
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_groups(data: ExDataFrame, groups: Vec<&str>) -> Result<ExDataFrame, ExplorerError> {
     let df = &data.resource.0;
-    let groups = df.groupby(groups)?.groups()?;
+    let groups = df.groupby_stable(groups)?.groups()?;
     Ok(ExDataFrame::new(groups))
 }
 
@@ -455,7 +455,7 @@ pub fn df_groups(data: ExDataFrame, groups: Vec<&str>) -> Result<ExDataFrame, Ex
 pub fn df_group_indices(data: ExDataFrame, groups: Vec<&str>) -> Result<ExSeries, ExplorerError> {
     let df = &data.resource.0;
     let series = df
-        .groupby(groups)?
+        .groupby_stable(groups)?
         .groups()?
         .column("groups")
         .map(|series| ExSeries::new(series.clone()))?;
@@ -469,7 +469,7 @@ pub fn df_groupby_agg(
     aggs: Vec<(&str, Vec<&str>)>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let df = &data.resource.0;
-    let new_df = df.groupby(groups)?.agg(&aggs)?;
+    let new_df = df.groupby_stable(groups)?.agg(&aggs)?;
     Ok(ExDataFrame::new(new_df))
 }
 

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -1,0 +1,25 @@
+defmodule Explorer.DataFrame.GroupedTest do
+  use ExUnit.Case, async: true
+
+  alias Explorer.DataFrame, as: DF
+  alias Explorer.Datasets
+  alias Explorer.Series
+
+  setup do
+    df = Datasets.fossil_fuels()
+    {:ok, df: df}
+  end
+
+  test "grouped arrange sorts by group", %{df: df} do
+    df = DF.arrange(df, "total")
+    grouped_df = df |> DF.group_by("country") |> DF.arrange("total")
+
+    assert df["total"][0] == Series.min(df["total"])
+
+    assert grouped_df
+           |> DF.ungroup()
+           |> DF.filter(&Series.equal(&1["country"], "HONDURAS"))
+           |> DF.pull("total")
+           |> Series.first() == 2175
+  end
+end


### PR DESCRIPTION
This is a POC (that works!) showing how we can leverage groups + apply to do more efficient grouped functions. Other verbs (e.g. filter) will require expressions. But this one works!

To do before merge:
- [x] add grouped tests
- [ ] ~benchmark~ I'm going to leave benchmarking for now and work it into a 0.2.0 blog post