### PR TITLE
Simplify `DF.distinct/2` with groups

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1245,6 +1245,18 @@ defmodule Explorer.DataFrame do
         x1 integer [1, 3]
         x2 string ["a", "c"]
       >
+
+  If the dataframe has groups, then the columns of each group will be added to the distinct columns.
+
+      iex> df = Explorer.Datasets.fossil_fuels() |> Explorer.DataFrame.group_by("country")
+      iex> Explorer.DataFrame.distinct(df, columns: ["year"])
+      #Explorer.DataFrame<
+        Polars[1094 x 2]
+        Groups: ["country"]
+        country string ["AFGHANISTAN", "AFGHANISTAN", "AFGHANISTAN", "AFGHANISTAN", "AFGHANISTAN", ...]
+        year integer [2010, 2011, 2012, 2013, 2014, ...]
+      >
+
   """
   @doc type: :single
   @spec distinct(df :: DataFrame.t(), opts :: Keyword.t()) :: DataFrame.t()
@@ -1270,7 +1282,8 @@ defmodule Explorer.DataFrame do
         if opts[:keep_all?] do
           df
         else
-          %{df | names: columns, dtypes: Map.take(df.dtypes, columns)}
+          columns_to_keep = Enum.uniq(df.groups ++ columns)
+          %{df | names: columns_to_keep, dtypes: Map.take(df.dtypes, columns_to_keep)}
         end
 
       Shared.apply_impl(df, :distinct, [out_df, columns, opts[:keep_all?]])

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -61,7 +61,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_column(_df, _name), do: err()
   def df_columns(_def), do: err()
   def df_drop(_df, _name), do: err()
-  def df_drop_duplicates(_df, _maintain_order, _subset), do: err()
+  def df_drop_duplicates(_df, _maintain_order, _subset, _groups), do: err()
   def df_drop_nulls(_df, _subset), do: err()
   def df_dtypes(_df), do: err()
   def df_filter(_df, _mask), do: err()

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -22,4 +22,56 @@ defmodule Explorer.DataFrame.GroupedTest do
            |> DF.pull("total")
            |> Series.first() == 2175
   end
+
+  describe "distinct/2" do
+    test "with one group", %{df: df} do
+      df1 = DF.group_by(df, "year")
+
+      df2 = DF.distinct(df1, columns: [:country])
+      assert DF.names(df2) == ["year", "country"]
+      assert DF.groups(df2) == ["year"]
+      assert DF.shape(df2) == {1094, 2}
+    end
+
+    test "with one group and distinct as the same", %{df: df} do
+      df1 = DF.group_by(df, "country")
+      df2 = DF.distinct(df1, columns: [:country])
+
+      assert DF.names(df2) == ["country"]
+      assert DF.groups(df2) == ["country"]
+      assert DF.shape(df2) == {222, 1}
+    end
+
+    test "multiple groups and different distinct", %{df: df} do
+      df1 = DF.group_by(df, ["country", "year"])
+
+      df2 = DF.distinct(df1, columns: [:bunker_fuels])
+      assert DF.names(df2) == ["country", "year", "bunker_fuels"]
+      assert DF.groups(df2) == ["country", "year"]
+      assert DF.shape(df2) == {1094, 3}
+    end
+
+    test "with groups and keeping all", %{df: df} do
+      df1 = DF.group_by(df, "year")
+
+      df2 = DF.distinct(df1, columns: [:country], keep_all?: true)
+
+      assert DF.names(df2) == [
+               "year",
+               "country",
+               "total",
+               "solid_fuel",
+               "liquid_fuel",
+               "gas_fuel",
+               "cement",
+               "gas_flaring",
+               "per_capita",
+               "bunker_fuels"
+             ]
+
+      assert DF.groups(df2) == ["year"]
+
+      assert DF.shape(df2) == {1094, 10}
+    end
+  end
 end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -797,6 +797,8 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.distinct(df, columns: [:year, :country])
       assert DF.names(df1) == ["year", "country"]
 
+      assert DF.shape(df1) == {1094, 2}
+
       df1 = DF.distinct(df, columns: [0, 1])
       assert DF.names(df1) == ["year", "country"]
 
@@ -804,6 +806,13 @@ defmodule Explorer.DataFrameTest do
 
       df2 = DF.distinct(df, columns: [:year, :country], keep_all?: true)
       assert DF.names(df2) == DF.names(df)
+    end
+
+    test "with one column", %{df: df} do
+      df1 = DF.distinct(df, columns: [:country])
+      assert DF.names(df1) == ["country"]
+
+      assert DF.shape(df1) == {222, 1}
     end
 
     test "with ranges", %{df: df} do


### PR DESCRIPTION
This makes the `distinct/2` function consider the columns from groups as
columns to distinct.

This also makes the DF keep the columns of groups, displaying the groups
in the final dataframe.