### PR TITLE
revert groupby_stable

### DIFF
--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -364,6 +364,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
       end)
     end)
     |> concat_rows()
+    |> DataFrame.ungroup()
     |> arrange([{:asc, idx_column}])
     |> select(out_df)
   end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -477,11 +477,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
     columns =
       Enum.map(columns, fn {key, values} -> {key, Enum.map(values, &Atom.to_string/1)} end)
 
-    order = Enum.map(groups, &{:asc, &1})
-
-    df
-    |> Shared.apply_dataframe(out_df, :df_groupby_agg, [groups, columns])
-    |> arrange(order)
+    Shared.apply_dataframe(df, out_df, :df_groupby_agg, [groups, columns])
   end
 
   # Inspect

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -334,7 +334,7 @@ pub fn df_sort(
         new_df.clone()
     } else {
         let new_df = &df
-            .groupby_stable(groups)?
+            .groupby(groups)?
             .apply(|df| df.sort(by_columns.clone(), reverse.clone()))?;
         new_df.clone()
     };
@@ -447,7 +447,7 @@ pub fn df_set_column_names(
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_groups(data: ExDataFrame, groups: Vec<&str>) -> Result<ExDataFrame, ExplorerError> {
     let df = &data.resource.0;
-    let groups = df.groupby_stable(groups)?.groups()?;
+    let groups = df.groupby(groups)?.groups()?;
     Ok(ExDataFrame::new(groups))
 }
 
@@ -455,7 +455,7 @@ pub fn df_groups(data: ExDataFrame, groups: Vec<&str>) -> Result<ExDataFrame, Ex
 pub fn df_group_indices(data: ExDataFrame, groups: Vec<&str>) -> Result<ExSeries, ExplorerError> {
     let df = &data.resource.0;
     let series = df
-        .groupby_stable(groups)?
+        .groupby(groups)?
         .groups()?
         .column("groups")
         .map(|series| ExSeries::new(series.clone()))?;


### PR DESCRIPTION
Reverts groupby_stable to groupby for all but `df_groupby_agg` which can use it to avoid arranging after returning. Closes #251.

Ungroups before arranging on grouped apply.