### PR TITLE
rename_with instead of rename

### DIFF
--- a/notebooks/exploring_explorer.livemd
+++ b/notebooks/exploring_explorer.livemd
@@ -537,7 +537,9 @@ tidy_names = fn name ->
   |> String.replace(" ", "_")
 end
 
-df |> DataFrame.pivot_wider("country", "total", id_columns: ["year"]) |> DataFrame.rename(tidy_names)
+df
+|> DataFrame.pivot_wider("country", "total", id_columns: ["year"])
+|> DataFrame.rename_with(tidy_names)
 ```
 
 ### Joins


### PR DESCRIPTION
The pivot example cell with rename fails. To pass the rename function down, it should be `rename_with` I guess.

My humble support for this completely awesome library, and the livebook example just makes it crystal clear.