### PR TITLE
Return Rustler Binary instead of allocating to a string for dump_csv

### DIFF
--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -3,6 +3,7 @@ use polars::prelude::*;
 use std::fs::File;
 use std::io::BufReader;
 use std::result::Result;
+use rustler::{Binary, Env, NewBinary};
 
 use crate::series::{to_ex_series_collection, to_series_collection};
 
@@ -89,19 +90,23 @@ pub fn df_write_parquet(data: ExDataFrame, filename: &str) -> Result<(), Explore
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_to_csv(
+    env: Env,
     data: ExDataFrame,
     has_headers: bool,
     delimiter: u8,
-) -> Result<String, ExplorerError> {
+) -> Result<Binary, ExplorerError> {
     let df = &data.resource.0;
-    let mut buf: Vec<u8> = Vec::with_capacity(81920);
+    let mut buf = vec![];
+
     CsvWriter::new(&mut buf)
         .has_header(has_headers)
         .with_delimiter(delimiter)
         .finish(&mut df.clone())?;
 
-    let s = String::from_utf8(buf)?;
-    Ok(s)
+    let mut values_binary = NewBinary::new(env, buf.len());
+    values_binary.copy_from_slice(&buf);
+
+    Ok(values_binary.into())
 }
 
 #[rustler::nif(schedule = "DirtyIo")]

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -1,9 +1,9 @@
 use polars::prelude::*;
 
+use rustler::{Binary, Env, NewBinary};
 use std::fs::File;
 use std::io::BufReader;
 use std::result::Result;
-use rustler::{Binary, Env, NewBinary};
 
 use crate::series::{to_ex_series_collection, to_series_collection};
 


### PR DESCRIPTION
When using dump_csv, it's converting to a String, which is then being encoded by Rustler.

Instead, we can create a binary using the returned bytes that we get from Polars. We know this will be valid, or Polars will throw an error. In future we should also use [simdutf8](https://github.com/rusticstuff/simdutf8), it's what arrow2 uses and it's a drop in replacement and faster.

I've also found that using with_capacity() is slower than just using vec, and using reserve no improvement either. https://doc.rust-lang.org/std/vec/struct.Vec.html#method.reserve 😮 

[The rust performance book about heap allocations is great for this topic](https://nnethercote.github.io/perf-book/heap-allocations.html#string)

```
Operating System: macOS
CPU Information: Apple M1
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.13.4
Erlang 25.0

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 30 s
memory time: 1 s
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 33 s

Benchmarking to_csv (70mb) ...

Name                    ips        average  deviation         median         99th %
to_csv (70mb)         13.26       75.43 ms    ±10.28%       73.56 ms      126.37 ms
binary (70mb)         14.04       71.22 ms     ±2.54%       70.86 ms       79.17 ms
vec    (70mb)         13.47       74.21 ms     ±7.62%       73.23 ms      101.33 ms
```

`to_csv` is the implementation as of today.
`binary` is the new implementation.
`vec` is using `vec![]` for the original implementation.

I ran these as three seperate benchmarks then merged the three results above.

This is using a 70mb test file containing 1,000,000 rows and 3 columns of fake data in CSV format, df is created before the test runs.