### PR TITLE
Build Dates and DateTimes as maps instead of using NifStruct when encoding as a list

### DIFF
--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -38,7 +38,15 @@ fn on_load(env: Env, _info: Term) -> bool {
 
 mod atoms {
     rustler::atoms! {
-        calendar = "Elixir.Calendar.ISO"
+        calendar_atom = "Elixir.Calendar.ISO",
+        hour,
+        minute,
+        second,
+        day,
+        month,
+        year,
+        microsecond,
+        calendar
     }
 }
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -1,14 +1,18 @@
-use polars::prelude::*;
-use rand::seq::IteratorRandom;
-use rand::{Rng, SeedableRng};
-use rand_pcg::Pcg64;
-use rustler::{Encoder, Env, Term};
-use std::result::Result;
-
+use crate::atoms::{calendar, calendar_atom, day, month, year};
 use crate::{
     datatypes::{ExDate, ExDateTime},
     ExDataFrame, ExSeries, ExSeriesRef, ExplorerError,
 };
+use chrono::Datelike;
+use polars::export::arrow::temporal_conversions::date32_to_date;
+use polars::prelude::*;
+use rand::seq::IteratorRandom;
+use rand::{Rng, SeedableRng};
+use rand_pcg::Pcg64;
+use rustler::types::atom::__struct__;
+use rustler::wrapper::map;
+use rustler::{Atom, Encoder, Env, Term};
+use std::result::Result;
 
 pub(crate) fn to_series_collection(s: Vec<ExSeries>) -> Vec<Series> {
     s.into_iter().map(|c| c.resource.0.clone()).collect()
@@ -552,7 +556,38 @@ fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Term<'b> {
         AnyValue::Utf8(v) => Some(v).encode(env),
         AnyValue::Int64(v) => Some(v).encode(env),
         AnyValue::Float64(v) => Some(v).encode(env),
-        AnyValue::Date(v) => Some(ExDate::from(v)).encode(env),
+        AnyValue::Date(v) => {
+            // get the date value
+            let naive_date = date32_to_date(v);
+
+            // Here we build the Date struct manually, as it's much faster than using Date NifStruct
+            // This is because we already have the keys (we know this at compile time), and the types,
+            // so we can build the struct directly.
+            let date_struct_keys = &[
+                __struct__().encode(env).as_c_arg(),
+                calendar().encode(env).as_c_arg(),
+                day().encode(env).as_c_arg(),
+                month().encode(env).as_c_arg(),
+                year().encode(env).as_c_arg(),
+            ];
+
+            // This sets the value in the map to "Elixir.Calendar.ISO", which must be an atom.
+            let calendar_iso_c_arg = calendar_atom().encode(env).as_c_arg();
+
+            // This is used for the map to know that it's a struct. Define it here so it's not redefined in the loop.
+            let date_module_atom = Atom::from_str(env, "Elixir.Date")
+                .unwrap()
+                .encode(env)
+                .as_c_arg();
+
+            crate::datatypes::encode_date!(
+                naive_date,
+                date_struct_keys,
+                calendar_iso_c_arg,
+                date_module_atom,
+                env
+            )
+        }
         AnyValue::Datetime(v, TimeUnit::Microseconds, None) => {
             Some(ExDateTime::from(v)).encode(env)
         }


### PR DESCRIPTION
This is the first part of the PR, which is just adding dates. Before I go and add Datetimes (the biggest win for this is Datetimes!) I would like to ensure that everyone is happy with this approach.

The change I would probably make is moving/cleaning up the macro?

This benchmark is against ~137k Arrow IPC Streaming dates, with a mix of nulls. It also includes reading the file (the majority of the time for a 28mb file), so having many columns makes the biggest difference.

In the Snowflake arrow project, I see drops the biggest drops around datetimes. Switching to this method is ~4x faster, making parsing go from ~220ms down to 60ms!


```
Operating System: macOS
CPU Information: Apple M1
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.13.4
Erlang 25.0.2

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 30 s
memory time: 1 s
reduction time: 0 ns
parallel: 1
inputs: none specified
Estimated total run time: 33 s

Benchmarking with date change ...

Name                       ips        average  deviation         median         99th %
with date change         48.46       20.64 ms    ±24.47%       20.06 ms       33.71 ms
with date struct         27.55       36.30 ms     ±4.15%       36.25 ms       41.39 ms
```