### PR TITLE
Change encoding list of NaiveDateTimes to return the map directly

### DIFF
--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -5,7 +5,8 @@ use rustler::{Atom, Encoder, Env, NifStruct, Term};
 use std::convert::TryInto;
 
 use crate::atoms;
-use crate::atoms::{calendar, calendar_atom, day, month, year};
+use crate::atoms::{calendar, calendar_atom, day, hour, microsecond, minute, month, second, year};
+
 use rustler::types::atom::__struct__;
 use rustler::wrapper::list::make_list;
 use rustler::wrapper::{map, NIF_TERM};
@@ -141,7 +142,34 @@ macro_rules! encode_date {
     };
 }
 
+macro_rules! encode_datetime {
+    ($dt: ident, $datetime_struct_keys: ident, $calendar_iso_c_arg: ident, $datetime_module_atom: ident, $env: ident) => {
+        unsafe {
+            Term::new(
+                $env,
+                map::make_map_from_arrays(
+                    $env.as_c_arg(),
+                    $datetime_struct_keys,
+                    &[
+                        $datetime_module_atom,
+                        $calendar_iso_c_arg,
+                        $dt.year().encode($env).as_c_arg(),
+                        $dt.month().encode($env).as_c_arg(),
+                        $dt.day().encode($env).as_c_arg(),
+                        $dt.hour().encode($env).as_c_arg(),
+                        $dt.minute().encode($env).as_c_arg(),
+                        $dt.second().encode($env).as_c_arg(),
+                        ($dt.timestamp_subsec_micros(), 6).encode($env).as_c_arg(),
+                    ],
+                )
+                .unwrap(),
+            )
+        }
+    };
+}
+
 pub(crate) use encode_date;
+pub(crate) use encode_datetime;
 
 #[derive(NifStruct, Copy, Clone, Debug)]
 #[module = "NaiveDateTime"]
@@ -156,22 +184,24 @@ pub struct ExDateTime {
     pub microsecond: (u32, u32),
 }
 
+#[inline]
+fn timestamp_to_datetime(microseconds: i64) -> NaiveDateTime {
+    let sign = microseconds.signum();
+    let seconds = match sign {
+        -1 => microseconds / 1_000_000 - 1,
+        _ => microseconds / 1_000_000,
+    };
+    let remainder = match sign {
+        -1 => 1_000_000 + microseconds % 1_000_000,
+        _ => microseconds % 1_000_000,
+    };
+    let nanoseconds = remainder.abs() * 1_000;
+    NaiveDateTime::from_timestamp(seconds, nanoseconds.try_into().unwrap())
+}
+
 impl From<i64> for ExDateTime {
     fn from(microseconds: i64) -> Self {
-        let sign = microseconds.signum();
-        let seconds = match sign {
-            -1 => microseconds / 1_000_000 - 1,
-            _ => microseconds / 1_000_000,
-        };
-        let remainder = match sign {
-            -1 => 1_000_000 + microseconds % 1_000_000,
-            _ => microseconds % 1_000_000,
-        };
-        let nanoseconds = remainder.abs() * 1_000;
-        ExDateTime::from(NaiveDateTime::from_timestamp(
-            seconds,
-            nanoseconds.try_into().unwrap(),
-        ))
+        timestamp_to_datetime(microseconds).into()
     }
 }
 
@@ -249,30 +279,68 @@ fn encode_date_series<'b>(s: &Series, env: Env<'b>) -> Term<'b> {
                     env
                 )
             })
-            .encode(env)
-            .as_c_arg()
+                .encode(env)
+                .as_c_arg()
         })
         .collect::<Vec<NIF_TERM>>();
 
     unsafe { Term::new(env, make_list(env.as_c_arg(), &items)) }
 }
 
-fn encode_datetime_series<'b>(s: &Series, env: Env<'b>) -> Term<'b> {
-    s.datetime()
-        .unwrap()
-        .into_iter()
-        .map(|microsecond| microsecond.map(ExDateTime::from))
-        .collect::<Vec<Option<ExDateTime>>>()
-        .encode(env)
-}
+#[inline]
+fn encode_datetime_series<'b>(s: &Series, time_unit: TimeUnit, env: Env<'b>) -> Term<'b> {
+    // Here we build the NaiveDateTime struct manually, as it's faster than using NifStructs.
+    // It's faster because we already have the keys (we know this at compile time), and the type.
+    let datetime_struct_keys = &[
+        __struct__().encode(env).as_c_arg(),
+        calendar().encode(env).as_c_arg(),
+        year().encode(env).as_c_arg(),
+        month().encode(env).as_c_arg(),
+        day().encode(env).as_c_arg(),
+        hour().encode(env).as_c_arg(),
+        minute().encode(env).as_c_arg(),
+        second().encode(env).as_c_arg(),
+        microsecond().encode(env).as_c_arg(),
+    ];
 
-fn encode_datetime_ms_series<'b>(s: &Series, env: Env<'b>) -> Term<'b> {
-    s.datetime()
+    // This sets the value in the map to "Elixir.Calendar.ISO", which must be an atom.
+    let calendar_iso_c_arg = calendar_atom().encode(env).as_c_arg();
+
+    // This is used for the map to set __struct__ as NaiveDateTime.
+    let datetime_module_atom = Atom::from_str(env, "Elixir.NaiveDateTime")
         .unwrap()
-        .into_iter()
-        .map(|micro| micro.map(|milli| milli * 1_000).map(ExDateTime::from))
-        .collect::<Vec<Option<ExDateTime>>>()
         .encode(env)
+        .as_c_arg();
+
+    let items = s
+        .datetime()
+        .unwrap()
+        .downcast_iter()
+        .flat_map(move |iter| {
+            iter.into_iter().map(move |opt_v| {
+                opt_v.copied().map(|x| match time_unit {
+                    TimeUnit::Milliseconds => timestamp_to_datetime(x * 1_000),
+                    TimeUnit::Microseconds => timestamp_to_datetime(x),
+                    _ => unreachable!(),
+                })
+            })
+        })
+        .map(|d| {
+            d.map(|naive_datetime| {
+                encode_datetime!(
+                    naive_datetime,
+                    datetime_struct_keys,
+                    calendar_iso_c_arg,
+                    datetime_module_atom,
+                    env
+                )
+            })
+                .encode(env)
+                .as_c_arg()
+        })
+        .collect::<Vec<NIF_TERM>>();
+
+    unsafe { Term::new(env, make_list(env.as_c_arg(), &items)) }
 }
 
 macro_rules! encode {
@@ -325,9 +393,13 @@ impl Encoder for ExSeriesRef {
             DataType::UInt32 => encode!(s, env, u32),
             DataType::Float64 => encode!(s, env, f64),
             DataType::Date => encode_date_series(s, env),
-            DataType::Datetime(TimeUnit::Microseconds, None) => encode_datetime_series(s, env),
+            DataType::Datetime(TimeUnit::Microseconds, None) => {
+                encode_datetime_series(s, TimeUnit::Microseconds, env)
+            }
             // Note that "ms" is only used from IO readers/parsers (like CSV)
-            DataType::Datetime(TimeUnit::Milliseconds, None) => encode_datetime_ms_series(s, env),
+            DataType::Datetime(TimeUnit::Milliseconds, None) => {
+                encode_datetime_series(s, TimeUnit::Milliseconds, env)
+            }
             DataType::List(t) if t as &DataType == &DataType::UInt32 => {
                 encode_list!(s, env, u32, u32)
             }

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -184,6 +184,8 @@ pub struct ExDateTime {
     pub microsecond: (u32, u32),
 }
 
+/// Converts a microsecond i64 to a `NaiveDateTime`.
+/// This is because when getting a timestamp, it might have negative values.
 #[inline]
 fn timestamp_to_datetime(microseconds: i64) -> NaiveDateTime {
     let sign = microseconds.signum();
@@ -279,8 +281,8 @@ fn encode_date_series<'b>(s: &Series, env: Env<'b>) -> Term<'b> {
                     env
                 )
             })
-                .encode(env)
-                .as_c_arg()
+            .encode(env)
+            .as_c_arg()
         })
         .collect::<Vec<NIF_TERM>>();
 


### PR DESCRIPTION
Closes #280

Notes:
1. In the future I would also like to move the call to new term to a function.
2. I also believe quick wins could be made in the encoding function when casting datetimes into the DF, as right now we have to do the *1000 when matching, I think we could use the built in datetime iter Polars has if we change it in the `s_new_date64` function.

Benchmarks:

Before:
```
Operating System: macOS
CPU Information: Apple M1
Number of Available Cores: 8
Available memory: 16 GB
Elixir 1.13.4
Erlang 25.0.2

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 10 s
memory time: 1 s
reduction time: 0 ns
parallel: 1
inputs: 100, 1k, 10k, 100k, 1 million, 10 million
Estimated total run time: 1.30 min

Benchmarking NaiveDateTime change with input 100 ...
Benchmarking NaiveDateTime change with input 1k ...
Benchmarking NaiveDateTime change with input 10k ...
Benchmarking NaiveDateTime change with input 100k ...
Benchmarking NaiveDateTime change with input 1 million ...
Benchmarking NaiveDateTime change with input 10 million ...

##### With input 100 #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change        4.98 K      200.79 μs    ±60.69%      183.29 μs      505.78 μs

Memory usage statistics:

Name                    Memory usage
NaiveDateTime change        21.15 KB

**All measurements for memory usage were the same**

##### With input 1k #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change        1.15 K      872.83 μs    ±59.40%      803.19 μs     2269.71 μs

Memory usage statistics:

Name                    Memory usage
NaiveDateTime change       196.93 KB

**All measurements for memory usage were the same**

##### With input 10k #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change        124.26        8.05 ms    ±13.95%        7.83 ms       11.12 ms

Memory usage statistics:

Name                    Memory usage
NaiveDateTime change         1.91 MB

**All measurements for memory usage were the same**

##### With input 100k #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change         62.38       16.03 ms     ±6.00%       15.96 ms       17.42 ms

Memory usage statistics:

Name                    Memory usage
NaiveDateTime change        19.07 MB

**All measurements for memory usage were the same**

##### With input 1 million #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change          0.82         1.22 s     ±1.33%         1.21 s         1.26 s

Memory usage statistics:

Name                    Memory usage
NaiveDateTime change       190.74 MB

**All measurements for memory usage were the same**

##### With input 10 million #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change        0.0405        24.70 s     ±0.00%        24.70 s        24.70 s
```

Now:
```

##### With input 100 #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change       12.28 K       81.42 μs    ±35.07%       82.71 μs      143.15 μs

Memory usage statistics:

Name                    Memory usage
NaiveDateTime change        20.99 KB

**All measurements for memory usage were the same**

##### With input 1k #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change        5.09 K      196.57 μs    ±14.45%      185.08 μs      282.58 μs

Memory usage statistics:

Name                    Memory usage
NaiveDateTime change       196.63 KB

**All measurements for memory usage were the same**

##### With input 10k #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change        817.88        1.22 ms     ±4.51%        1.21 ms        1.29 ms

Memory usage statistics:

Name                    Memory usage
NaiveDateTime change         1.91 MB

**All measurements for memory usage were the same**

##### With input 100k #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change         62.57       15.98 ms     ±3.02%       15.97 ms       16.96 ms

Memory usage statistics:

Name                    Memory usage
NaiveDateTime change        19.07 MB

**All measurements for memory usage were the same**

##### With input 1 million #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change          6.69      149.38 ms    ±23.18%      130.59 ms      261.13 ms

Memory usage statistics:

Name                    Memory usage
NaiveDateTime change       188.63 MB

**All measurements for memory usage were the same**

##### With input 10 million #####
Name                           ips        average  deviation         median         99th %
NaiveDateTime change          0.32         3.09 s    ±11.35%         3.18 s         3.41 s
```