### PR TITLE
Add `filter_with/2` that works with lazy series

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -19,7 +19,7 @@ defmodule Explorer.Backend.DataFrame do
           | [basic_types()]
           | (df() -> series() | basic_types() | [basic_types()])
 
-  @type opaque_ldf :: Explorer.Backend.LazyFrame.t()
+  @type lazy_frame :: Explorer.Backend.LazyFrame.t()
   @type lazy_series :: Explorer.Backend.LazySeries.t()
 
   # IO
@@ -78,7 +78,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback tail(df, rows :: integer()) :: df
   @callback select(df, out_df :: df()) :: df
   @callback filter(df, mask :: series) :: df
-  @callback filter_with(df, (opaque_ldf() -> lazy_series())) :: df
+  @callback filter_with(df, (lazy_frame() -> lazy_series())) :: df
   @callback mutate(df, out_df :: df(), mutations :: [{column_name(), mutate_value()}]) :: df
   @callback arrange(df, columns :: [column_name() | {:asc | :desc, column_name()}]) :: df
   @callback distinct(df, out_df :: df(), columns :: [column_name()], keep_all? :: boolean()) :: df

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -128,9 +128,14 @@ defmodule Explorer.Backend.DataFrame do
   @doc """
   Creates a new DataFrame for a given backend.
   """
-  def new(data, names, dtypes) do
-    dtypes_pairs = Enum.zip(names, dtypes)
-    %DataFrame{data: data, names: names, dtypes: Map.new(dtypes_pairs), groups: []}
+  def new(data, names, dtypes) when is_list(dtypes) do
+    dtypes = Map.new(Enum.zip(names, dtypes))
+
+    new(data, names, dtypes)
+  end
+
+  def new(data, names, dtypes) when is_list(names) and is_map(dtypes) do
+    %DataFrame{data: data, names: names, dtypes: dtypes, groups: []}
   end
 
   @default_limit 5

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Backend.DataFrame do
   @type series :: Explorer.Series.t()
   @type column_name :: String.t()
   @type dtype :: Explorer.Series.dtype()
+  @type dtypes :: %{column_name() => dtype()}
 
   @typep basic_types :: float() | integer() | String.t() | Date.t() | DateTime.t()
   @type mutate_value ::
@@ -17,6 +18,9 @@ defmodule Explorer.Backend.DataFrame do
           | basic_types()
           | [basic_types()]
           | (df() -> series() | basic_types() | [basic_types()])
+
+  @type opaque_ldf :: Explorer.Backend.LazyFrame.t()
+  @type lazy_series :: Explorer.Backend.LazySeries.t()
 
   # IO
 
@@ -74,6 +78,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback tail(df, rows :: integer()) :: df
   @callback select(df, out_df :: df()) :: df
   @callback filter(df, mask :: series) :: df
+  @callback filter_with(df, (opaque_ldf() -> lazy_series())) :: df
   @callback mutate(df, out_df :: df(), mutations :: [{column_name(), mutate_value()}]) :: df
   @callback arrange(df, columns :: [column_name() | {:asc | :desc, column_name()}]) :: df
   @callback distinct(df, out_df :: df(), columns :: [column_name()], keep_all? :: boolean()) :: df

--- a/lib/explorer/backend/lazy_frame.ex
+++ b/lib/explorer/backend/lazy_frame.ex
@@ -1,0 +1,49 @@
+defmodule Explorer.Backend.LazyFrame do
+  @moduledoc """
+  Represents a dataframe in a lazy format.
+  """
+
+  defstruct dtypes: %{}, names: []
+  alias Explorer.Backend.LazySeries
+
+  @behaviour Explorer.Backend.DataFrame
+
+  @doc false
+  def new(df) do
+    %__MODULE__{names: df.names, dtypes: df.dtypes}
+  end
+
+  @impl true
+  def lazy, do: __MODULE__
+
+  @impl true
+  def to_lazy(ldf), do: ldf
+
+  @impl true
+  def inspect(_ldf, opts) do
+    df = Explorer.DataFrame.new(foo: [1, 2, 3], bar: ["a", "b", "c"])
+    Explorer.Backend.DataFrame.inspect(df, "LazyFrame", nil, opts)
+  end
+
+  @impl true
+  def pull(df, column) do
+    dtype_for_column = df.dtypes[column]
+    LazySeries.new(dtype_for_column, :column, [column])
+  end
+
+  # TODO: Make the functions of non-implemented functions
+  # explicit once the lazy interface is ready.
+  funs =
+    Explorer.Backend.DataFrame.behaviour_info(:callbacks) --
+      (Explorer.Backend.DataFrame.behaviour_info(:optional_callbacks) ++
+         Module.definitions_in(__MODULE__, :def) ++ [{:inspect, 2}])
+
+  for {fun, arity} <- funs do
+    args = Macro.generate_arguments(arity, __MODULE__)
+
+    @impl true
+    def unquote(fun)(unquote_splicing(args)) do
+      raise "cannot perform operation on an Explorer.Backend.LazyFrame"
+    end
+  end
+end

--- a/lib/explorer/backend/lazy_frame.ex
+++ b/lib/explorer/backend/lazy_frame.ex
@@ -1,7 +1,7 @@
 defmodule Explorer.Backend.LazyFrame do
   @moduledoc """
   Represents a lazy dataframe for building query expressions.
-  
+
   The LazyFrame is available inside `filter_with`, `mutate_with`, and
   similar. You cannot perform any operation on them except accessing
   its underlying series.
@@ -44,7 +44,7 @@ defmodule Explorer.Backend.LazyFrame do
   funs =
     Backend.DataFrame.behaviour_info(:callbacks) --
       (Backend.DataFrame.behaviour_info(:optional_callbacks) ++
-         Module.definitions_in(__MODULE__, :def)
+         Module.definitions_in(__MODULE__, :def))
 
   for {fun, arity} <- funs do
     args = Macro.generate_arguments(arity, __MODULE__)
@@ -53,7 +53,7 @@ defmodule Explorer.Backend.LazyFrame do
     def unquote(fun)(unquote_splicing(args)) do
       raise """
       cannot perform operation on an Explorer.Backend.LazyFrame.
-      
+
       The LazyFrame is available inside filter_with, mutate_with, and \
       similar to build query expressions and you cannot perform any \
       operation on them except accessing its series

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -1,0 +1,46 @@
+defmodule Explorer.Backend.LazySeries do
+  @moduledoc """
+  This is an opaque implementation of a Series.
+
+  It represents an operation with its arguments.
+  """
+  alias Explorer.Series
+  alias Explorer.Backend
+
+  @behaviour Explorer.Backend.Series
+
+  defstruct op: nil, args: []
+
+  @doc false
+  def new(dtype, op, args) do
+    Backend.Series.new(%__MODULE__{op: op, args: args}, dtype)
+  end
+
+  @impl true
+  def eq(%Series{dtype: left_dtype, data: left_lazy}, value) do
+    new(left_dtype, :equal, [left_lazy, value])
+  end
+
+  @impl true
+  def inspect(_lseries, opts) do
+    series = Explorer.Series.from_list([1, 2, 3])
+
+    Backend.Series.inspect(series, "LazySeries", nil, opts)
+  end
+
+  # TODO: Make the functions of non-implemented functions
+  # explicit once the lazy interface is ready.
+  funs =
+    Backend.Series.behaviour_info(:callbacks) --
+      (Backend.Series.behaviour_info(:optional_callbacks) ++
+         Module.definitions_in(__MODULE__, :def) ++ [{:inspect, 2}])
+
+  for {fun, arity} <- funs do
+    args = Macro.generate_arguments(arity, __MODULE__)
+
+    @impl true
+    def unquote(fun)(unquote_splicing(args)) do
+      raise "cannot perform operation on an Explorer.Backend.LazySeries"
+    end
+  end
+end

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -17,6 +17,8 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
+  def eq(%Series{} = left, %Series{} = right), do: eq(left, right.data)
+
   def eq(%Series{dtype: left_dtype, data: left_lazy}, value) do
     new(left_dtype, :equal, [left_lazy, value])
   end

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -11,16 +11,21 @@ defmodule Explorer.Backend.LazySeries do
 
   defstruct op: nil, args: []
 
+  @operations [column: 1, eq: 2]
+
   @doc false
   def new(op, args) do
     %__MODULE__{op: op, args: args}
   end
 
+  @doc false
+  def operations, do: @operations
+
   @impl true
   def eq(%Series{} = left, %Series{} = right), do: eq(left, right.data)
 
   def eq(%Series{dtype: left_dtype, data: left_lazy}, value) do
-    data = new(:equal, [left_lazy, value])
+    data = new(:eq, [left_lazy, value])
 
     Backend.Series.new(data, left_dtype)
   end

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -3,6 +3,8 @@ defmodule Explorer.Backend.Series do
   The behaviour for series backends.
   """
 
+  @valid_dtypes [:integer, :float, :boolean, :string, :date, :datetime, :list]
+
   @type t :: struct()
 
   @type s :: Explorer.Series.t()
@@ -120,7 +122,7 @@ defmodule Explorer.Backend.Series do
   @doc """
   Create a new `Series`.
   """
-  def new(data, dtype) do
+  def new(data, dtype) when dtype in @valid_dtypes do
     %Explorer.Series{data: data, dtype: dtype}
   end
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -117,6 +117,13 @@ defmodule Explorer.Backend.Series do
 
   # Functions
 
+  @doc """
+  Create a new `Series`.
+  """
+  def new(data, dtype) do
+    %Explorer.Series{data: data, dtype: dtype}
+  end
+
   import Inspect.Algebra
   alias Explorer.Series
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1010,6 +1010,22 @@ defmodule Explorer.DataFrame do
         )
       )
 
+  @doc false
+  def filter_with(df, fun) when is_function(fun) do
+    ldf =
+      df
+      |> Explorer.Backend.LazyFrame.new()
+      |> Explorer.Backend.DataFrame.new(
+        df.names,
+        Enum.map(df.names, fn name -> df.dtypes[name] end)
+      )
+
+    case fun.(ldf) do
+      %Series{data: %Explorer.Backend.LazySeries{} = data} ->
+        Shared.apply_impl(df, :filter_with, [data])
+    end
+  end
+
   @doc """
   Creates and modifies columns.
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1015,10 +1015,7 @@ defmodule Explorer.DataFrame do
     ldf =
       df
       |> Explorer.Backend.LazyFrame.new()
-      |> Explorer.Backend.DataFrame.new(
-        df.names,
-        Enum.map(df.names, fn name -> df.dtypes[name] end)
-      )
+      |> Explorer.Backend.DataFrame.new(df.names, df.dtypes)
 
     case fun.(ldf) do
       %Series{data: %Explorer.Backend.LazySeries{} = data} ->

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1020,6 +1020,11 @@ defmodule Explorer.DataFrame do
     case fun.(ldf) do
       %Series{data: %Explorer.Backend.LazySeries{} = data} ->
         Shared.apply_impl(df, :filter_with, [data])
+
+      other ->
+        raise ArgumentError,
+              "expecting the function to return a LazySeries, but instead it returned " <>
+                inspect(other)
     end
   end
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -254,7 +254,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   # TODO: add callback behaviour
   def filter_with(df, %Explorer.Backend.LazySeries{} = lseries) do
-    expressions = Explorer.PolarsBackend.Expressions.to_expressions(lseries)
+    expressions = Explorer.PolarsBackend.Expression.to_expr(lseries)
     Shared.apply_dataframe(df, df, :df_filter_with, [expressions])
   end
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -252,7 +252,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   def filter(df, %Series{} = mask),
     do: Shared.apply_dataframe(df, :df_filter, [mask.data])
 
-  # TODO: add callback behaviour
+  @impl true
   def filter_with(df, %Explorer.Backend.LazySeries{} = lseries) do
     expressions = Explorer.PolarsBackend.Expression.to_expr(lseries)
     Shared.apply_dataframe(df, df, :df_filter_with, [expressions])

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -252,6 +252,11 @@ defmodule Explorer.PolarsBackend.DataFrame do
   def filter(df, %Series{} = mask),
     do: Shared.apply_dataframe(df, :df_filter, [mask.data])
 
+  def filter_with(df, %Explorer.Backend.LazySeries{} = lseries) do
+    IO.inspect(lseries, label: "lseries")
+    df
+  end
+
   @impl true
   def mutate(%DataFrame{groups: []} = df, out_df, columns) do
     ungrouped_mutate(df, out_df, columns)

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -252,9 +252,10 @@ defmodule Explorer.PolarsBackend.DataFrame do
   def filter(df, %Series{} = mask),
     do: Shared.apply_dataframe(df, :df_filter, [mask.data])
 
+  # TODO: add callback behaviour
   def filter_with(df, %Explorer.Backend.LazySeries{} = lseries) do
-    IO.inspect(lseries, label: "lseries")
-    df
+    expressions = Explorer.PolarsBackend.Expressions.to_expressions(lseries)
+    Shared.apply_dataframe(df, df, :df_filter_with, [expressions])
   end
 
   @impl true

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -1,4 +1,4 @@
-defmodule Explorer.PolarsBackend.Expressions do
+defmodule Explorer.PolarsBackend.Expression do
   @moduledoc false
   # This module is responsible for translating the opaque LazySeries
   # into expressions that can be encoded to types in the Rustler side.
@@ -6,17 +6,17 @@ defmodule Explorer.PolarsBackend.Expressions do
 
   alias Explorer.Backend.LazySeries
 
-  def to_expressions(%LazySeries{op: :column, args: [name]}) do
+  def to_expr(%LazySeries{op: :column, args: [name]}) do
     {:column, name}
   end
 
-  def to_expressions(%LazySeries{op: :equal, args: [left, right]}) do
-    left = to_expressions(left)
-    right = to_expressions(right)
+  def to_expr(%LazySeries{op: :equal, args: [left, right]}) do
+    left = to_expr(left)
+    right = to_expr(right)
 
     {:equal, [left, right]}
   end
 
   # TODO: filter what can be anything
-  def to_expressions(anything), do: anything
+  def to_expr(anything), do: anything
 end

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -5,16 +5,29 @@ defmodule Explorer.PolarsBackend.Expression do
   # Type annotations are only for information propouses.
 
   alias Explorer.Backend.LazySeries
+  alias Explorer.PolarsBackend.Native
+
+  defstruct resource: nil, reference: nil
+
+  @type t :: %__MODULE__{resource: binary(), reference: reference()}
 
   def to_expr(%LazySeries{op: :column, args: [name]}) do
-    {:column, name}
+    Native.expr_column(name)
   end
 
   def to_expr(%LazySeries{op: :equal, args: [left, right]}) do
     left = to_expr(left)
     right = to_expr(right)
 
-    {:equal, [left, right]}
+    Native.expr_equal(left, right)
+  end
+
+  def to_expr(number) when is_integer(number) do
+    Native.expr_integer(number)
+  end
+
+  def to_expr(number) when is_float(number) do
+    Native.expr_float(number)
   end
 
   # TODO: filter what can be anything

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -1,9 +1,9 @@
 defmodule Explorer.PolarsBackend.Expression do
   @moduledoc false
   # This module is responsible for translating the opaque LazySeries
-  # into expressions that can be encoded to types in the Rustler side.
-  # Type annotations are only for information propouses.
+  # to polars expressions in the Rust side.
 
+  alias Explorer.DataFrame
   alias Explorer.Backend.LazySeries
   alias Explorer.PolarsBackend.Native
 
@@ -30,6 +30,8 @@ defmodule Explorer.PolarsBackend.Expression do
     Native.expr_float(number)
   end
 
-  # TODO: filter what can be anything
-  def to_expr(anything), do: anything
+  # Only for inspecting the expression in tests
+  def describe_filter_plan(%DataFrame{data: polars_df}, %__MODULE__{} = expression) do
+    Native.expr_describe_filter_plan(polars_df, expression)
+  end
 end

--- a/lib/explorer/polars_backend/expressions.ex
+++ b/lib/explorer/polars_backend/expressions.ex
@@ -1,0 +1,29 @@
+defmodule Explorer.PolarsBackend.Expressions do
+  @moduledoc false
+  # This module is responsible for translating the opaque LazySeries
+  # into expressions that can be encoded to types in the Rustler side.
+  # Type annotations are only for information propouses.
+
+  alias Explorer.Backend.LazySeries
+
+  def to_expressions(%LazySeries{op: :column, args: [name]}) do
+    {:column, name}
+  end
+
+  def to_expressions(%LazySeries{op: :equal, args: [left, right]}) do
+    left = to_expressions(left)
+    right = to_expressions(right)
+
+    op_name =
+      cond do
+        is_integer(right) -> :equal_int
+        is_float(right) -> :equal_float
+        true -> :equal
+      end
+
+    {op_name, left, right}
+  end
+
+  # TODO: filter what can be anything
+  def to_expressions(anything), do: anything
+end

--- a/lib/explorer/polars_backend/expressions.ex
+++ b/lib/explorer/polars_backend/expressions.ex
@@ -14,14 +14,7 @@ defmodule Explorer.PolarsBackend.Expressions do
     left = to_expressions(left)
     right = to_expressions(right)
 
-    op_name =
-      cond do
-        is_integer(right) -> :equal_int
-        is_float(right) -> :equal_float
-        true -> :equal
-      end
-
-    {op_name, left, right}
+    {:equal, [left, right]}
   end
 
   # TODO: filter what can be anything

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -101,6 +101,7 @@ defmodule Explorer.PolarsBackend.Native do
   def expr_equal(_left_expr, _right_expr), do: err()
   def expr_integer(_number), do: err()
   def expr_float(_number), do: err()
+  def expr_describe_filter_plan(_df, _expr), do: err()
 
   # LazyFrame
   def lf_collect(_df), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -96,9 +96,14 @@ defmodule Explorer.PolarsBackend.Native do
   def df_write_parquet(_df, _filename), do: err()
 
   # Expressions (for lazy queries)
+  # We first generate functions for known operations.
+  for {op, arity} <- Explorer.Backend.LazySeries.operations() do
+    args = Macro.generate_arguments(arity, __MODULE__)
+    expr_op = :"expr_#{op}"
+    def unquote(expr_op)(unquote_splicing(args)), do: err()
+  end
 
-  def expr_column(_name), do: err()
-  def expr_equal(_left_expr, _right_expr), do: err()
+  # Then we generate for some specific expressions
   def expr_integer(_number), do: err()
   def expr_float(_number), do: err()
   def expr_describe_filter_plan(_df, _expr), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -95,6 +95,13 @@ defmodule Explorer.PolarsBackend.Native do
   def df_write_ipc(_df, _filename, _compression), do: err()
   def df_write_parquet(_df, _filename), do: err()
 
+  # Expressions (for lazy queries)
+
+  def expr_column(_name), do: err()
+  def expr_equal(_left_expr, _right_expr), do: err()
+  def expr_integer(_number), do: err()
+  def expr_float(_number), do: err()
+
   # LazyFrame
   def lf_collect(_df), do: err()
   def lf_describe_plan(_df, _optimized), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -65,6 +65,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_drop_nulls(_df, _subset), do: err()
   def df_dtypes(_df), do: err()
   def df_filter(_df, _mask), do: err()
+  def df_filter_with(_df, _operation), do: err()
   def df_get_columns(_df), do: err()
   def df_group_indices(_df, _column_names), do: err()
   def df_groupby_agg(_df, _groups, _aggs), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -29,7 +29,7 @@ defmodule Explorer.PolarsBackend.Series do
         :datetime -> Native.s_new_date64(name, data)
       end
 
-    %Series{data: series, dtype: type}
+    Explorer.Backend.Series.new(series, type)
   end
 
   @impl true

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -67,7 +67,7 @@ defmodule Explorer.PolarsBackend.Shared do
 
   def create_series(%PolarsSeries{} = polars_series) do
     {:ok, dtype} = Native.s_dtype(polars_series)
-    %Series{data: polars_series, dtype: normalise_dtype(dtype)}
+    Explorer.Backend.Series.new(polars_series, normalise_dtype(dtype))
   end
 
   def normalise_dtype("u32"), do: :integer

--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -1153,8 +1153,7 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 [[package]]
 name = "rustler"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e6617fa86bacfb2de792c12e261e0f456bb9ff15038498ae421715bf4128c5"
+source = "git+https://github.com/rusterlium/rustler#f946092552f8057dabdb13c66fb9364ce03120a3"
 dependencies = [
  "lazy_static",
  "rustler_codegen",
@@ -1164,8 +1163,7 @@ dependencies = [
 [[package]]
 name = "rustler_codegen"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05cda738bc4260019ee078a699fac55ce3577fe2db736b2cc64a4d6696950fa6"
+source = "git+https://github.com/rusterlium/rustler#f946092552f8057dabdb13c66fb9364ce03120a3"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1176,8 +1174,7 @@ dependencies = [
 [[package]]
 name = "rustler_sys"
 version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff26a42e62d538f82913dd34f60105ecfdffbdb25abdc3c3580b0c622285332"
+source = "git+https://github.com/rusterlium/rustler#f946092552f8057dabdb13c66fb9364ce03120a3"
 dependencies = [
  "regex",
  "unreachable",

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -14,7 +14,9 @@ anyhow = "1"
 chrono = "0.4"
 rand = { version = "0.8.4", features = ["alloc"] }
 rand_pcg = "0.3.1"
-rustler = "0.25.0"
+# We are using Rustler from Git, since we need the TaggedEnum feature
+# rustler = "0.25.0"
+rustler = { git = "https://github.com/rusterlium/rustler" }
 thiserror = "1"
 
 # MiMalloc won´t compile on Windows with the GCC compiler.

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = "1"
 chrono = "0.4"
 rand = { version = "0.8.4", features = ["alloc"] }
 rand_pcg = "0.3.1"
-# We are using Rustler from Git, since we need the TaggedEnum feature
+# We are using Rustler from Git, since if fixes the build on nighthly
 # rustler = "0.25.0"
 rustler = { git = "https://github.com/rusterlium/rustler" }
 thiserror = "1"

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -1,14 +1,13 @@
 use polars::prelude::*;
 
-use rustler::{Binary, Env, NewBinary, Term};
+use rustler::{Binary, Env, NewBinary};
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::result::Result;
 
-use crate::expressions::term_to_expressions;
 use crate::series::{to_ex_series_collection, to_series_collection};
 
-use crate::{ExDataFrame, ExLazyFrame, ExSeries, ExplorerError};
+use crate::{ExDataFrame, ExExpr, ExLazyFrame, ExSeries, ExplorerError};
 
 #[rustler::nif(schedule = "DirtyIo")]
 #[allow(clippy::too_many_arguments)]
@@ -368,9 +367,9 @@ pub fn df_filter(data: ExDataFrame, mask: ExSeries) -> Result<ExDataFrame, Explo
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn df_filter_with(data: ExDataFrame, filter: Term) -> Result<ExDataFrame, ExplorerError> {
+pub fn df_filter_with(data: ExDataFrame, ex_expr: ExExpr) -> Result<ExDataFrame, ExplorerError> {
     let ldf: LazyFrame = data.resource.0.clone().lazy();
-    let exp = term_to_expressions(filter)?;
+    let exp: Expr = ex_expr.resource.0.clone();
 
     let new_df = ldf.filter(exp).collect()?;
 

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -368,10 +368,10 @@ pub fn df_filter(data: ExDataFrame, mask: ExSeries) -> Result<ExDataFrame, Explo
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_filter_with(data: ExDataFrame, ex_expr: ExExpr) -> Result<ExDataFrame, ExplorerError> {
-    let ldf: LazyFrame = data.resource.0.clone().lazy();
+    let df: DataFrame = data.resource.0.clone();
     let exp: Expr = ex_expr.resource.0.clone();
 
-    let new_df = ldf.filter(exp).collect()?;
+    let new_df = df.lazy().filter(exp).collect()?;
 
     Ok(ExDataFrame::new(new_df))
 }

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -10,16 +10,6 @@ use crate::series::{to_ex_series_collection, to_series_collection};
 
 use crate::{ExDataFrame, ExLazyFrame, ExSeries, ExplorerError};
 
-#[derive(rustler::NifTaggedEnum)]
-pub enum Operation {
-    EqualInt(Expression, i32),
-}
-
-#[derive(rustler::NifTaggedEnum)]
-pub enum Expression {
-    Column(String),
-}
-
 #[rustler::nif(schedule = "DirtyIo")]
 #[allow(clippy::too_many_arguments)]
 pub fn df_read_csv(

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -12,6 +12,7 @@ use rustler::wrapper::list::make_list;
 use rustler::wrapper::{map, NIF_TERM};
 
 pub struct ExDataFrameRef(pub DataFrame);
+pub struct ExExprRef(pub Expr);
 pub struct ExLazyFrameRef(pub LazyFrame);
 pub struct ExSeriesRef(pub Series);
 
@@ -19,6 +20,12 @@ pub struct ExSeriesRef(pub Series);
 #[module = "Explorer.PolarsBackend.DataFrame"]
 pub struct ExDataFrame {
     pub resource: ResourceArc<ExDataFrameRef>,
+}
+
+#[derive(NifStruct)]
+#[module = "Explorer.PolarsBackend.Expression"]
+pub struct ExExpr {
+    pub resource: ResourceArc<ExExprRef>,
 }
 
 #[derive(NifStruct)]
@@ -39,6 +46,12 @@ impl ExDataFrameRef {
     }
 }
 
+impl ExExprRef {
+    pub fn new(expr: Expr) -> Self {
+        Self(expr)
+    }
+}
+
 impl ExLazyFrameRef {
     pub fn new(df: LazyFrame) -> Self {
         Self(df)
@@ -55,6 +68,14 @@ impl ExDataFrame {
     pub fn new(df: DataFrame) -> Self {
         Self {
             resource: ResourceArc::new(ExDataFrameRef::new(df)),
+        }
+    }
+}
+
+impl ExExpr {
+    pub fn new(expr: Expr) -> Self {
+        Self {
+            resource: ResourceArc::new(ExExprRef::new(expr)),
         }
     }
 }

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -10,7 +10,6 @@ use crate::atoms::{calendar, calendar_atom, day, hour, microsecond, minute, mont
 use rustler::types::atom::__struct__;
 use rustler::wrapper::list::make_list;
 use rustler::wrapper::{map, NIF_TERM};
-use std::result::Result;
 
 pub struct ExDataFrameRef(pub DataFrame);
 pub struct ExLazyFrameRef(pub LazyFrame);

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -36,6 +36,62 @@ pub fn expr_eq(left: ExExpr, right: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_neq(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr.neq(right_expr))
+}
+
+#[rustler::nif]
+pub fn expr_gt(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr.gt(right_expr))
+}
+
+#[rustler::nif]
+pub fn expr_gt_eq(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr.gt_eq(right_expr))
+}
+
+#[rustler::nif]
+pub fn expr_lt(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr.lt(right_expr))
+}
+
+#[rustler::nif]
+pub fn expr_lt_eq(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr.lt_eq(right_expr))
+}
+
+#[rustler::nif]
+pub fn expr_binary_and(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr.and(right_expr))
+}
+
+#[rustler::nif]
+pub fn expr_binary_or(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr.or(right_expr))
+}
+
+#[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
     let df: DataFrame = data.resource.0.clone();
     let expressions: Expr = expr.resource.0.clone();

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -4,10 +4,10 @@
 // in the following format: `{:operation, args}` to
 // the Polars expressions.
 
-use polars::prelude::col;
+use polars::prelude::{col, DataFrame, IntoLazy};
 use polars::prelude::{Expr, Literal};
 
-use crate::ExExpr;
+use crate::{ExDataFrame, ExExpr};
 
 #[rustler::nif]
 pub fn expr_integer(number: i64) -> ExExpr {
@@ -33,4 +33,11 @@ pub fn expr_equal(left: ExExpr, right: ExExpr) -> ExExpr {
     let right_expr: Expr = right.resource.0.clone();
 
     ExExpr::new(left_expr.eq(right_expr))
+}
+
+#[rustler::nif]
+pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
+    let df: DataFrame = data.resource.0.clone();
+    let expressions: Expr = expr.resource.0.clone();
+    df.lazy().filter(expressions).describe_plan()
 }

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -18,22 +18,15 @@ rustler::atoms! {
 }
 
 pub fn term_to_expressions(term: Term) -> Result<Expr, ExplorerError> {
+    // {operation, args}
     if term.is_tuple() {
         let (key, args): (Atom, Term) = match term.decode() {
             Ok(pair) => pair,
             Err(_) => return Err(ExplorerError::Other("cannot read operation 1".to_string())),
         };
 
+        // {:column, "name"}
         if key == column() {
-            // let (name, _) = match args.decode() {
-            //     Ok(pair) => pair,
-            //     Err(_) => {
-            //         return Err(ExplorerError::Other(
-            //             "cannot read operation 2.0".to_string(),
-            //         ))
-            //     }
-            // };
-
             let decoded_name: &str = match args.decode() {
                 Ok(value) => value,
                 Err(_) => return Err(ExplorerError::Other("cannot read operation 2".to_string())),
@@ -41,15 +34,10 @@ pub fn term_to_expressions(term: Term) -> Result<Expr, ExplorerError> {
             return Ok(col(decoded_name));
         }
 
+        // {:equal, [left, right]}
         if key == equal() {
-            let (left, tail) = match args.list_get_cell() {
-                Ok(pair) => pair,
-                Err(_) => return Err(ExplorerError::Other("cannot read operation 4".to_string())),
-            };
-            let (right, _) = match tail.list_get_cell() {
-                Ok(pair) => pair,
-                Err(_) => return Err(ExplorerError::Other("cannot read operation 5".to_string())),
-            };
+            let (left, tail) = get_head_tail(args)?;
+            let (right, _) = get_head_tail(tail)?;
 
             let left_exp = term_to_expressions(left)?;
             let right_exp = term_to_expressions(right)?;
@@ -72,9 +60,9 @@ pub fn term_to_expressions(term: Term) -> Result<Expr, ExplorerError> {
     ));
 }
 
-// fn get_head_tail(term: Term) -> Result<(Term, Term), ExplorerError:> {
-//     match term.list_get_cell() {
-//         Ok(pair) => Ok(pair),
-//         Err(_) => Err(ExplorerError::Other("cannot read operation 4".to_string())),
-//     }
-// }
+fn get_head_tail(term: Term) -> Result<(Term, Term), ExplorerError> {
+    match term.list_get_cell() {
+        Ok(pair) => Ok(pair),
+        Err(_) => Err(ExplorerError::Other("cannot read operation 4".to_string())),
+    }
+}

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -28,7 +28,7 @@ pub fn expr_column(name: &str) -> ExExpr {
 }
 
 #[rustler::nif]
-pub fn expr_equal(left: ExExpr, right: ExExpr) -> ExExpr {
+pub fn expr_eq(left: ExExpr, right: ExExpr) -> ExExpr {
     let left_expr: Expr = left.resource.0.clone();
     let right_expr: Expr = right.resource.0.clone();
 

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -1,8 +1,8 @@
 // The idea of this file is to have functions that
 // transform the expressions from the Elixir side
-// to the Rust side. It's a conversion of Elixir tuples
-// in the following format: `{:operation, args}` to
-// the Polars expressions.
+// to the Rust side. Each function receives a basic type
+// or an expression and returns an expression that is
+// wrapped in an Elixir struct.
 
 use polars::prelude::{col, DataFrame, IntoLazy};
 use polars::prelude::{Expr, Literal};

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -1,0 +1,80 @@
+// The idea of this file is to have functions that
+// transform the expressions from the Elixir side
+// to the Rust side. It's a conversion of Elixir tuples
+// in the following format: `{:operation, args}` to
+// the Polars expressions.
+
+use polars::prelude::col;
+use polars::prelude::Expr;
+use polars::prelude::Literal;
+use rustler::types::atom::Atom;
+use rustler::Term;
+
+use crate::ExplorerError;
+
+rustler::atoms! {
+  equal,
+  column
+}
+
+pub fn term_to_expressions(term: Term) -> Result<Expr, ExplorerError> {
+    if term.is_tuple() {
+        let (key, args): (Atom, Term) = match term.decode() {
+            Ok(pair) => pair,
+            Err(_) => return Err(ExplorerError::Other("cannot read operation 1".to_string())),
+        };
+
+        if key == column() {
+            // let (name, _) = match args.decode() {
+            //     Ok(pair) => pair,
+            //     Err(_) => {
+            //         return Err(ExplorerError::Other(
+            //             "cannot read operation 2.0".to_string(),
+            //         ))
+            //     }
+            // };
+
+            let decoded_name: &str = match args.decode() {
+                Ok(value) => value,
+                Err(_) => return Err(ExplorerError::Other("cannot read operation 2".to_string())),
+            };
+            return Ok(col(decoded_name));
+        }
+
+        if key == equal() {
+            let (left, tail) = match args.list_get_cell() {
+                Ok(pair) => pair,
+                Err(_) => return Err(ExplorerError::Other("cannot read operation 4".to_string())),
+            };
+            let (right, _) = match tail.list_get_cell() {
+                Ok(pair) => pair,
+                Err(_) => return Err(ExplorerError::Other("cannot read operation 5".to_string())),
+            };
+
+            let left_exp = term_to_expressions(left)?;
+            let right_exp = term_to_expressions(right)?;
+            return Ok(left_exp.eq(right_exp));
+        }
+    }
+
+    if term.is_number() {
+        // TODO: make the case with floats pass
+        let int: i64 = match term.decode() {
+            Ok(value) => value,
+            Err(_) => return Err(ExplorerError::Other("cannot read operation 3".to_string())),
+        };
+
+        return Ok(int.lit());
+    }
+
+    return Err(ExplorerError::Other(
+        "cannot convert to expressions".to_string(),
+    ));
+}
+
+// fn get_head_tail(term: Term) -> Result<(Term, Term), ExplorerError:> {
+//     match term.list_get_cell() {
+//         Ok(pair) => Ok(pair),
+//         Err(_) => Err(ExplorerError::Other("cannot read operation 4".to_string())),
+//     }
+// }

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -24,14 +24,17 @@ mod series;
 
 use dataframe::*;
 pub use datatypes::{
-    ExDataFrame, ExDataFrameRef, ExLazyFrame, ExLazyFrameRef, ExSeries, ExSeriesRef,
+    ExDataFrame, ExDataFrameRef, ExExpr, ExExprRef, ExLazyFrame, ExLazyFrameRef, ExSeries,
+    ExSeriesRef,
 };
 pub use error::ExplorerError;
+use expressions::*;
 use lazyframe::*;
 use series::*;
 
 fn on_load(env: Env, _info: Term) -> bool {
     rustler::resource!(ExDataFrameRef, env);
+    rustler::resource!(ExExprRef, env);
     rustler::resource!(ExLazyFrameRef, env);
     rustler::resource!(ExSeriesRef, env);
     true
@@ -95,6 +98,11 @@ rustler::init!(
         df_with_columns,
         df_write_ipc,
         df_write_parquet,
+        // expressions
+        expr_column,
+        expr_equal,
+        expr_integer,
+        expr_float,
         // lazyframe
         lf_collect,
         lf_describe_plan,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -100,7 +100,7 @@ rustler::init!(
         df_write_parquet,
         // expressions
         expr_column,
-        expr_equal,
+        expr_eq,
         expr_integer,
         expr_float,
         expr_describe_filter_plan,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -18,6 +18,7 @@ mod dataframe;
 #[allow(clippy::extra_unused_lifetimes)]
 mod datatypes;
 mod error;
+mod expressions;
 mod lazyframe;
 mod series;
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -100,9 +100,16 @@ rustler::init!(
         df_write_parquet,
         // expressions
         expr_column,
-        expr_eq,
         expr_integer,
         expr_float,
+        expr_eq,
+        expr_neq,
+        expr_gt,
+        expr_gt_eq,
+        expr_lt,
+        expr_lt_eq,
+        expr_binary_and,
+        expr_binary_or,
         expr_describe_filter_plan,
         // lazyframe
         lf_collect,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -103,6 +103,7 @@ rustler::init!(
         expr_equal,
         expr_integer,
         expr_float,
+        expr_describe_filter_plan,
         // lazyframe
         lf_collect,
         lf_describe_plan,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -60,6 +60,7 @@ rustler::init!(
         df_drop_nulls,
         df_dtypes,
         df_filter,
+        df_filter_with,
         df_get_columns,
         df_groups,
         df_groupby_agg,

--- a/test/explorer/backend/lazy_frame_test.exs
+++ b/test/explorer/backend/lazy_frame_test.exs
@@ -12,7 +12,7 @@ defmodule Explorer.Backend.LazyFrameTest do
     assert inspect(opaque_df) ==
              """
              #Explorer.DataFrame<
-               OpaqueLazyFrame[??? x 2]
+               LazyFrame[??? x 2]
                a integer [1, 2]
                b float [3.1, 4.5]
              >

--- a/test/explorer/backend/lazy_frame_test.exs
+++ b/test/explorer/backend/lazy_frame_test.exs
@@ -4,7 +4,7 @@ defmodule Explorer.Backend.LazyFrameTest do
   alias Explorer.Backend
   alias Explorer.Backend.LazyFrame
 
-  test "inspect/2 proxies to the original dataframe" do
+  test "inspect/2 prints the columns without data" do
     df = Explorer.DataFrame.new(a: [1, 2], b: [3.1, 4.5])
     ldf = LazyFrame.new(df)
     opaque_df = Backend.DataFrame.new(ldf, df.names, df.dtypes)
@@ -13,8 +13,8 @@ defmodule Explorer.Backend.LazyFrameTest do
              """
              #Explorer.DataFrame<
                LazyFrame[??? x 2]
-               a integer [1, 2]
-               b float [3.1, 4.5]
+               a integer
+               b float
              >
              """
              |> String.trim_trailing()

--- a/test/explorer/backend/lazy_frame_test.exs
+++ b/test/explorer/backend/lazy_frame_test.exs
@@ -1,0 +1,22 @@
+defmodule Explorer.Backend.LazyFrameTest do
+  use ExUnit.Case, async: true
+
+  alias Explorer.Backend
+  alias Explorer.Backend.LazyFrame
+
+  test "inspect/2 proxies to the original dataframe" do
+    df = Explorer.DataFrame.new(a: [1, 2], b: [3.1, 4.5])
+    ldf = LazyFrame.new(df)
+    opaque_df = Backend.DataFrame.new(ldf, df.names, df.dtypes)
+
+    assert inspect(opaque_df) ==
+             """
+             #Explorer.DataFrame<
+               OpaqueLazyFrame[??? x 2]
+               a integer [1, 2]
+               b float [3.1, 4.5]
+             >
+             """
+             |> String.trim_trailing()
+  end
+end

--- a/test/explorer/backend/lazy_series_test.exs
+++ b/test/explorer/backend/lazy_series_test.exs
@@ -13,8 +13,24 @@ defmodule Explorer.Backend.LazySeriesTest do
              #Explorer.Series<
                LazySeries integer
                [???]
-               Operation: column
-               Args: ["col_a"]
+               column("col_a")
+             >
+             """
+             |> String.trim_trailing()
+  end
+
+  test "inspect/2 with nested operations" do
+    col = LazySeries.new(:column, ["col_a"])
+    eq = LazySeries.new(:equal, [col, 5])
+
+    series = Backend.Series.new(eq, :bool)
+
+    assert inspect(series) ==
+             """
+             #Explorer.Series<
+               LazySeries bool
+               [???]
+               equal(column("col_a"), 5)
              >
              """
              |> String.trim_trailing()

--- a/test/explorer/backend/lazy_series_test.exs
+++ b/test/explorer/backend/lazy_series_test.exs
@@ -21,7 +21,7 @@ defmodule Explorer.Backend.LazySeriesTest do
 
   test "inspect/2 with nested operations" do
     col = LazySeries.new(:column, ["col_a"])
-    eq = LazySeries.new(:equal, [col, 5])
+    eq = LazySeries.new(:eq, [col, 5])
 
     series = Backend.Series.new(eq, :bool)
 
@@ -30,7 +30,7 @@ defmodule Explorer.Backend.LazySeriesTest do
              #Explorer.Series<
                LazySeries bool
                [???]
-               equal(column("col_a"), 5)
+               column("col_a") == 5
              >
              """
              |> String.trim_trailing()

--- a/test/explorer/backend/lazy_series_test.exs
+++ b/test/explorer/backend/lazy_series_test.exs
@@ -1,0 +1,22 @@
+defmodule Explorer.Backend.LazySeriesTest do
+  use ExUnit.Case, async: true
+
+  alias Explorer.Backend
+  alias Explorer.Backend.LazySeries
+
+  test "inspect/2 gives a basic hint of lazy series" do
+    data = LazySeries.new(:column, ["col_a"])
+    opaque_series = Backend.Series.new(data, :integer)
+
+    assert inspect(opaque_series) ==
+             """
+             #Explorer.Series<
+               LazySeries integer
+               [???]
+               Operation: column
+               Args: ["col_a"]
+             >
+             """
+             |> String.trim_trailing()
+  end
+end

--- a/test/explorer/backend/lazy_series_test.exs
+++ b/test/explorer/backend/lazy_series_test.exs
@@ -23,12 +23,12 @@ defmodule Explorer.Backend.LazySeriesTest do
     col = LazySeries.new(:column, ["col_a"])
     eq = LazySeries.new(:eq, [col, 5])
 
-    series = Backend.Series.new(eq, :bool)
+    series = Backend.Series.new(eq, :boolean)
 
     assert inspect(series) ==
              """
              #Explorer.Series<
-               LazySeries bool
+               LazySeries boolean
                [???]
                column("col_a") == 5
              >

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -33,8 +33,20 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [5.3, 2.4, 1.0, 0.2, 6.1, 2.1, 2.2])
 
       df1 = DF.filter_with(df, fn ldf -> Series.equal(ldf["a"], 5) end)
-
       assert DF.to_columns(df1, atom_keys: true) == %{a: [5, 5], b: [6.1, 2.2]}
+
+      df2 = DF.filter_with(df, fn ldf -> Series.equal(ldf["b"], 2.1) end)
+      assert DF.to_columns(df2, atom_keys: true) == %{a: [6], b: [2.1]}
+
+      df3 = DF.filter_with(df, fn ldf -> Series.equal(ldf["b"], 52.1) end)
+      assert DF.to_columns(df3, atom_keys: true) == %{a: [], b: []}
+    end
+
+    test "filter a column that has values equal to the other column" do
+      df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
+
+      df1 = DF.filter_with(df, fn ldf -> Series.equal(ldf["a"], ldf["b"]) end)
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [5], b: [5]}
     end
   end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -28,6 +28,16 @@ defmodule Explorer.DataFrameTest do
     end
   end
 
+  describe "filter_with/2" do
+    test "filter a column that is equal to a value" do
+      df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [5.3, 2.4, 1.0, 0.2, 6.1, 2.1, 2.2])
+
+      df1 = DF.filter_with(df, fn ldf -> Series.equal(ldf["a"], 5) end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [5, 5], b: [6.1, 2.2]}
+    end
+  end
+
   describe "mutate/2" do
     test "adds a new column" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -49,6 +49,23 @@ defmodule Explorer.DataFrameTest do
       assert DF.to_columns(df1, atom_keys: true) == %{a: [5], b: [5]}
     end
 
+    test "filter with a complex filter" do
+      df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
+
+      df1 =
+        DF.filter_with(df, fn ldf ->
+          a = ldf["a"]
+          b = ldf["b"]
+
+          # a > 5 or a <= 2 and b != 9
+          Series.greater(a, 5)
+          |> Series.or(Series.less_equal(a, 2))
+          |> Series.and(Series.not_equal(b, 9))
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [2, 6], b: [8, 4]}
+    end
+
     test "returns an error if the function is not returning a lazy series" do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
       message = "expecting the function to return a LazySeries, but instead it returned :foo"

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -48,6 +48,15 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.filter_with(df, fn ldf -> Series.equal(ldf["a"], ldf["b"]) end)
       assert DF.to_columns(df1, atom_keys: true) == %{a: [5], b: [5]}
     end
+
+    test "returns an error if the function is not returning a lazy series" do
+      df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
+      message = "expecting the function to return a LazySeries, but instead it returned :foo"
+
+      assert_raise ArgumentError, message, fn ->
+        DF.filter_with(df, fn _ldf -> :foo end)
+      end
+    end
   end
 
   describe "mutate/2" do

--- a/test/explorer/polars_backend/expression_test.exs
+++ b/test/explorer/polars_backend/expression_test.exs
@@ -12,7 +12,7 @@ defmodule Explorer.PolarsBackend.ExpressionTest do
     end
 
     test "with basic int value", %{df: df} do
-      lazy = %LazySeries{op: :equal, args: [%LazySeries{op: :column, args: ["col_a"]}, 5]}
+      lazy = %LazySeries{op: :eq, args: [%LazySeries{op: :column, args: ["col_a"]}, 5]}
 
       assert %Expression{} = expr = Expression.to_expr(lazy)
 
@@ -27,14 +27,14 @@ defmodule Explorer.PolarsBackend.ExpressionTest do
     end
 
     test "with basic float value" do
-      lazy = %LazySeries{op: :equal, args: [%LazySeries{op: :column, args: ["col_b"]}, 1.4]}
+      lazy = %LazySeries{op: :eq, args: [%LazySeries{op: :column, args: ["col_b"]}, 1.4]}
 
       assert %Expression{} = Expression.to_expr(lazy)
     end
 
     test "with another column", %{df: df} do
       lazy = %LazySeries{
-        op: :equal,
+        op: :eq,
         args: [
           %LazySeries{op: :column, args: ["col_a"]},
           %LazySeries{op: :column, args: ["col_b"]}

--- a/test/explorer/polars_backend/expression_test.exs
+++ b/test/explorer/polars_backend/expression_test.exs
@@ -1,20 +1,20 @@
-defmodule Explorer.PolarsBackend.ExpressionsTest do
+defmodule Explorer.PolarsBackend.ExpressionTest do
   use ExUnit.Case, async: true
 
   alias Explorer.Backend.LazySeries
-  alias Explorer.PolarsBackend.Expressions
+  alias Explorer.PolarsBackend.Expression
 
-  describe "to_expressions/1" do
+  describe "to_expr/1" do
     test "with basic int value" do
       lazy = %LazySeries{op: :equal, args: [%LazySeries{op: :column, args: ["col_a"]}, 5]}
 
-      assert Expressions.to_expressions(lazy) == {:equal, [{:column, "col_a"}, 5]}
+      assert Expression.to_expr(lazy) == {:equal, [{:column, "col_a"}, 5]}
     end
 
     test "with basic float value" do
       lazy = %LazySeries{op: :equal, args: [%LazySeries{op: :column, args: ["col_a"]}, 1.4]}
 
-      assert Expressions.to_expressions(lazy) == {:equal, [{:column, "col_a"}, 1.4]}
+      assert Expression.to_expr(lazy) == {:equal, [{:column, "col_a"}, 1.4]}
     end
   end
 end

--- a/test/explorer/polars_backend/expression_test.exs
+++ b/test/explorer/polars_backend/expression_test.exs
@@ -8,13 +8,13 @@ defmodule Explorer.PolarsBackend.ExpressionTest do
     test "with basic int value" do
       lazy = %LazySeries{op: :equal, args: [%LazySeries{op: :column, args: ["col_a"]}, 5]}
 
-      assert Expression.to_expr(lazy) == {:equal, [{:column, "col_a"}, 5]}
+      assert %Expression{} = Expression.to_expr(lazy)
     end
 
     test "with basic float value" do
       lazy = %LazySeries{op: :equal, args: [%LazySeries{op: :column, args: ["col_a"]}, 1.4]}
 
-      assert Expression.to_expr(lazy) == {:equal, [{:column, "col_a"}, 1.4]}
+      assert %Expression{} = Expression.to_expr(lazy)
     end
   end
 end

--- a/test/explorer/polars_backend/expressions_test.exs
+++ b/test/explorer/polars_backend/expressions_test.exs
@@ -8,13 +8,13 @@ defmodule Explorer.PolarsBackend.ExpressionsTest do
     test "with basic int value" do
       lazy = %LazySeries{op: :equal, args: [%LazySeries{op: :column, args: ["col_a"]}, 5]}
 
-      assert Expressions.to_expressions(lazy) == {:equal_int, {:column, "col_a"}, 5}
+      assert Expressions.to_expressions(lazy) == {:equal, [{:column, "col_a"}, 5]}
     end
 
     test "with basic float value" do
       lazy = %LazySeries{op: :equal, args: [%LazySeries{op: :column, args: ["col_a"]}, 1.4]}
 
-      assert Expressions.to_expressions(lazy) == {:equal_float, {:column, "col_a"}, 1.4}
+      assert Expressions.to_expressions(lazy) == {:equal, [{:column, "col_a"}, 1.4]}
     end
   end
 end

--- a/test/explorer/polars_backend/expressions_test.exs
+++ b/test/explorer/polars_backend/expressions_test.exs
@@ -1,0 +1,20 @@
+defmodule Explorer.PolarsBackend.ExpressionsTest do
+  use ExUnit.Case, async: true
+
+  alias Explorer.Backend.LazySeries
+  alias Explorer.PolarsBackend.Expressions
+
+  describe "to_expressions/1" do
+    test "with basic int value" do
+      lazy = %LazySeries{op: :equal, args: [%LazySeries{op: :column, args: ["col_a"]}, 5]}
+
+      assert Expressions.to_expressions(lazy) == {:equal_int, {:column, "col_a"}, 5}
+    end
+
+    test "with basic float value" do
+      lazy = %LazySeries{op: :equal, args: [%LazySeries{op: :column, args: ["col_a"]}, 1.4]}
+
+      assert Expressions.to_expressions(lazy) == {:equal_float, {:column, "col_a"}, 1.4}
+    end
+  end
+end


### PR DESCRIPTION
This is an attempt to implement the basic functionality for the `filter_with/2` function
discussed in https://github.com/elixir-nx/explorer/issues/223

This change adds two new opaque backends - one for data frame and one for series.
They work in conjunction to create lazy series and accumulate operations on them before sending to the backend.