### PR TITLE
Support more types in `DataFrame.filter_with/2`

### DIFF
--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -10,6 +10,7 @@ defmodule Explorer.Backend.Series do
   @type s :: Explorer.Series.t()
   @type df :: Explorer.DataFrame.t()
   @type dtype :: :integer | :float | :boolean | :string | :date | :datetime
+  @type valid_types :: number() | boolean() | String.t() | Date.t() | NaiveDateTime.t()
 
   # Conversion
 
@@ -69,12 +70,12 @@ defmodule Explorer.Backend.Series do
 
   # Comparisons
 
-  @callback eq(s, s | number()) :: s
-  @callback neq(s, s | number()) :: s
-  @callback gt(s, s | number()) :: s
-  @callback gt_eq(s, s | number()) :: s
-  @callback lt(s, s | number()) :: s
-  @callback lt_eq(s, s | number()) :: s
+  @callback eq(s, s | valid_types()) :: s
+  @callback neq(s, s | valid_types()) :: s
+  @callback gt(s, s | valid_types()) :: s
+  @callback gt_eq(s, s | valid_types()) :: s
+  @callback lt(s, s | valid_types()) :: s
+  @callback lt_eq(s, s | valid_types()) :: s
   @callback all_equal?(s, s) :: boolean()
 
   @callback binary_and(s, s) :: s

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -11,8 +11,13 @@ defmodule Explorer.PolarsBackend.Expression do
 
   @type t :: %__MODULE__{resource: binary(), reference: reference()}
 
+  def to_expr(%LazySeries{op: :column, args: [name]}) do
+    Native.expr_column(name)
+  end
+
   # We are going to generate all functions for each valid operation.
-  for {op, arity} <- Explorer.Backend.LazySeries.operations() do
+  for {op, arity} <-
+        Explorer.Backend.LazySeries.operations() -- [column: 1] do
     args = Macro.generate_arguments(arity, __MODULE__)
 
     updates =
@@ -29,9 +34,12 @@ defmodule Explorer.PolarsBackend.Expression do
     end
   end
 
+  def to_expr(bool) when is_boolean(bool), do: Native.expr_boolean(bool)
+  def to_expr(binary) when is_binary(binary), do: Native.expr_string(binary)
   def to_expr(number) when is_integer(number), do: Native.expr_integer(number)
   def to_expr(number) when is_float(number), do: Native.expr_float(number)
-  def to_expr(binary) when is_binary(binary), do: binary
+  def to_expr(%Date{} = date), do: Native.expr_date(date)
+  def to_expr(%NaiveDateTime{} = datetime), do: Native.expr_datetime(datetime)
 
   # Only for inspecting the expression in tests
   def describe_filter_plan(%DataFrame{data: polars_df}, %__MODULE__{} = expression) do

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -104,8 +104,12 @@ defmodule Explorer.PolarsBackend.Native do
   end
 
   # Then we generate for some specific expressions
-  def expr_integer(_number), do: err()
+  def expr_boolean(_bool), do: err()
+  def expr_date(_date), do: err()
+  def expr_datetime(_datetime), do: err()
   def expr_float(_number), do: err()
+  def expr_integer(_number), do: err()
+  def expr_string(_string), do: err()
   def expr_describe_filter_plan(_df, _expr), do: err()
 
   # LazyFrame

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -4,9 +4,11 @@
 // or an expression and returns an expression that is
 // wrapped in an Elixir struct.
 
+use chrono::{NaiveDate, NaiveDateTime};
 use polars::prelude::{col, DataFrame, IntoLazy};
 use polars::prelude::{Expr, Literal};
 
+use crate::datatypes::{ExDate, ExDateTime};
 use crate::{ExDataFrame, ExExpr};
 
 #[rustler::nif]
@@ -18,6 +20,32 @@ pub fn expr_integer(number: i64) -> ExExpr {
 #[rustler::nif]
 pub fn expr_float(number: f64) -> ExExpr {
     let expr = number.lit();
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
+pub fn expr_string(string: String) -> ExExpr {
+    let expr = string.lit();
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
+pub fn expr_boolean(boolean: bool) -> ExExpr {
+    let expr = boolean.lit();
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
+pub fn expr_date(date: ExDate) -> ExExpr {
+    let naive_date = NaiveDate::from(date);
+    let expr = naive_date.lit();
+    ExExpr::new(expr)
+}
+
+#[rustler::nif]
+pub fn expr_datetime(datetime: ExDateTime) -> ExExpr {
+    let naive_datetime = NaiveDateTime::from(datetime);
+    let expr = naive_datetime.lit();
     ExExpr::new(expr)
 }
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -99,17 +99,23 @@ rustler::init!(
         df_write_ipc,
         df_write_parquet,
         // expressions
+        expr_boolean,
         expr_column,
-        expr_integer,
+        expr_date,
+        expr_datetime,
         expr_float,
+        expr_integer,
+        expr_string,
+        // comparison expressions
+        expr_binary_and,
+        expr_binary_or,
         expr_eq,
-        expr_neq,
         expr_gt,
         expr_gt_eq,
         expr_lt,
         expr_lt_eq,
-        expr_binary_and,
-        expr_binary_or,
+        expr_neq,
+        // inspect expressions
         expr_describe_filter_plan,
         // lazyframe
         lf_collect,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -49,6 +49,44 @@ defmodule Explorer.DataFrameTest do
       assert DF.to_columns(df1, atom_keys: true) == %{a: [5], b: [5]}
     end
 
+    test "filter by a string value" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+
+      df1 = DF.filter_with(df, fn ldf -> Series.equal(ldf["b"], "b") end)
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [2], b: ["b"]}
+    end
+
+    test "filter by a boolean value" do
+      df = DF.new(a: [1, 2, 3], b: [true, true, false])
+
+      df1 = DF.filter_with(df, fn ldf -> Series.equal(ldf["b"], false) end)
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [3], b: [false]}
+    end
+
+    test "filter by a given date" do
+      df = DF.new(a: [1, 2, 3], b: [~D[2022-07-07], ~D[2022-07-08], ~D[2022-07-09]])
+
+      df1 = DF.filter_with(df, fn ldf -> Series.equal(ldf["b"], ~D[2022-07-07]) end)
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [1], b: [~D[2022-07-07]]}
+    end
+
+    test "filter by a given datetime" do
+      df =
+        DF.new(
+          a: [1, 2, 3],
+          b: [
+            ~N[2022-07-07 17:43:08.473561],
+            ~N[2022-07-07 17:44:13.020548],
+            ~N[2022-07-07 17:45:00.116337]
+          ]
+        )
+
+      df1 =
+        DF.filter_with(df, fn ldf -> Series.greater(ldf["b"], ~N[2022-07-07 17:44:13.020548]) end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [3], b: [~N[2022-07-07 17:45:00.116337]]}
+    end
+
     test "filter with a complex filter" do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
 

--- a/test/explorer/polars_backend/expression_test.exs
+++ b/test/explorer/polars_backend/expression_test.exs
@@ -32,6 +32,36 @@ defmodule Explorer.PolarsBackend.ExpressionTest do
       assert %Expression{} = Expression.to_expr(lazy)
     end
 
+    test "with a string value" do
+      lazy = %LazySeries{op: :eq, args: [%LazySeries{op: :column, args: ["col_b"]}, "foo"]}
+
+      assert %Expression{} = Expression.to_expr(lazy)
+    end
+
+    test "with a bool value" do
+      lazy = %LazySeries{op: :eq, args: [%LazySeries{op: :column, args: ["col_b"]}, true]}
+
+      assert %Expression{} = Expression.to_expr(lazy)
+    end
+
+    test "with date value" do
+      lazy = %LazySeries{
+        op: :eq,
+        args: [%LazySeries{op: :column, args: ["col_b"]}, ~D[2022-07-07]]
+      }
+
+      assert %Expression{} = Expression.to_expr(lazy)
+    end
+
+    test "with datetime value" do
+      lazy = %LazySeries{
+        op: :eq,
+        args: [%LazySeries{op: :column, args: ["col_b"]}, ~N[2022-07-07 18:09:17.824019]]
+      }
+
+      assert %Expression{} = Expression.to_expr(lazy)
+    end
+
     test "with another column", %{df: df} do
       lazy = %LazySeries{
         op: :eq,


### PR DESCRIPTION
This change adds support for Date, NaiveDateTime, String and boolean.
This also treats the "column" operation as especial, and avoid
encoding its argument to an expression.