### PR TITLE
Support more dtypes for series in native code

### DIFF
--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -321,7 +321,7 @@ pub fn df_drop_nulls(
     data: ExDataFrame,
     subset: Option<Vec<String>>,
 ) -> Result<ExDataFrame, ExplorerError> {
-    let df = &data.resource.0;
+    let df: &DataFrame = &data.resource.0;
     let new_df = df.drop_nulls(subset.as_ref().map(|s| s.as_ref()))?;
     Ok(ExDataFrame::new(new_df))
 }
@@ -456,7 +456,7 @@ pub fn df_drop_duplicates(
     maintain_order: bool,
     subset: Vec<String>,
 ) -> Result<ExDataFrame, ExplorerError> {
-    let df = &data.resource.0;
+    let df: &DataFrame = &data.resource.0;
     let new_df = match maintain_order {
         false => df.unique(Some(&subset), UniqueKeepStrategy::First)?,
         true => df.unique_stable(Some(&subset), UniqueKeepStrategy::First)?,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -468,18 +468,30 @@ pub fn s_sum(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
     let s = &data.resource.0;
     match s.dtype() {
         DataType::Boolean => Ok(s.sum::<i64>().encode(env)),
-        DataType::Int64 => Ok(s.sum::<i64>().encode(env)),
-        DataType::Float64 => Ok(s.sum::<f64>().encode(env)),
+        DataType::Int8
+        | DataType::UInt8
+        | DataType::Int16
+        | DataType::UInt16
+        | DataType::Int32
+        | DataType::UInt32
+        | DataType::Int64 => Ok(s.sum::<i64>().encode(env)),
+        DataType::Float32 | DataType::Float64 => Ok(s.sum::<f64>().encode(env)),
         dt => panic!("sum/1 not implemented for {:?}", dt),
     }
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_min(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
-    let s = &data.resource.0;
+    let s: &Series = &data.resource.0;
     match s.dtype() {
-        DataType::Int64 => Ok(s.min::<i64>().encode(env)),
-        DataType::Float64 => Ok(s.min::<f64>().encode(env)),
+        DataType::Int8
+        | DataType::UInt8
+        | DataType::Int16
+        | DataType::UInt16
+        | DataType::Int32
+        | DataType::UInt32
+        | DataType::Int64 => Ok(s.min::<i64>().encode(env)),
+        DataType::Float32 | DataType::Float64 => Ok(s.min::<f64>().encode(env)),
         DataType::Date => Ok(s.min::<i32>().map(ExDate::from).encode(env)),
         DataType::Datetime(TimeUnit::Microseconds, None) => {
             Ok(s.min::<i64>().map(ExDateTime::from).encode(env))
@@ -490,10 +502,16 @@ pub fn s_min(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_max(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
-    let s = &data.resource.0;
+    let s: &Series = &data.resource.0;
     match s.dtype() {
-        DataType::Int64 => Ok(s.max::<i64>().encode(env)),
-        DataType::Float64 => Ok(s.max::<f64>().encode(env)),
+        DataType::Int8
+        | DataType::UInt8
+        | DataType::Int16
+        | DataType::UInt16
+        | DataType::Int32
+        | DataType::UInt32
+        | DataType::Int64 => Ok(s.max::<i64>().encode(env)),
+        DataType::Float32 | DataType::Float64 => Ok(s.max::<f64>().encode(env)),
         DataType::Date => Ok(s.max::<i32>().map(ExDate::from).encode(env)),
         DataType::Datetime(TimeUnit::Microseconds, None) => {
             Ok(s.max::<i64>().map(ExDateTime::from).encode(env))
@@ -507,8 +525,15 @@ pub fn s_mean(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
     let s = &data.resource.0;
     match s.dtype() {
         DataType::Boolean => Ok(s.mean().encode(env)),
-        DataType::Int64 => Ok(s.mean().encode(env)),
-        DataType::Float64 => Ok(s.mean().encode(env)),
+        DataType::Int8
+        | DataType::UInt8
+        | DataType::Int16
+        | DataType::UInt16
+        | DataType::Int32
+        | DataType::UInt32
+        | DataType::Int64
+        | DataType::Float32
+        | DataType::Float64 => Ok(s.mean().encode(env)),
         dt => panic!("mean/1 not implemented for {:?}", dt),
     }
 }
@@ -517,8 +542,15 @@ pub fn s_mean(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 pub fn s_median(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
     let s = &data.resource.0;
     match s.dtype() {
-        DataType::Int64 => Ok(s.median().encode(env)),
-        DataType::Float64 => Ok(s.median().encode(env)),
+        DataType::Int8
+        | DataType::UInt8
+        | DataType::Int16
+        | DataType::UInt16
+        | DataType::Int32
+        | DataType::UInt32
+        | DataType::Int64
+        | DataType::Float32
+        | DataType::Float64 => Ok(s.median().encode(env)),
         dt => panic!("median/1 not implemented for {:?}", dt),
     }
 }
@@ -527,8 +559,14 @@ pub fn s_median(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 pub fn s_var(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
     let s = &data.resource.0;
     match s.dtype() {
-        DataType::Int64 => Ok(s.i64().unwrap().var().encode(env)),
-        DataType::Float64 => Ok(s.f64().unwrap().var().encode(env)),
+        DataType::Int8
+        | DataType::UInt8
+        | DataType::Int16
+        | DataType::UInt16
+        | DataType::Int32
+        | DataType::UInt32
+        | DataType::Int64 => Ok(s.i64().unwrap().var().encode(env)),
+        DataType::Float32 | DataType::Float64 => Ok(s.f64().unwrap().var().encode(env)),
         dt => panic!("var/1 not implemented for {:?}", dt),
     }
 }
@@ -537,8 +575,14 @@ pub fn s_var(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 pub fn s_std(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
     let s = &data.resource.0;
     match s.dtype() {
-        DataType::Int64 => Ok(s.i64().unwrap().std().encode(env)),
-        DataType::Float64 => Ok(s.f64().unwrap().std().encode(env)),
+        DataType::Int8
+        | DataType::UInt8
+        | DataType::Int16
+        | DataType::UInt16
+        | DataType::Int32
+        | DataType::UInt32
+        | DataType::Int64 => Ok(s.i64().unwrap().std().encode(env)),
+        DataType::Float32 | DataType::Float64 => Ok(s.f64().unwrap().std().encode(env)),
         dt => panic!("std/1 not implemented for {:?}", dt),
     }
 }
@@ -554,8 +598,16 @@ fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Term<'b> {
         AnyValue::Null => None::<bool>.encode(env),
         AnyValue::Boolean(v) => Some(v).encode(env),
         AnyValue::Utf8(v) => Some(v).encode(env),
+        AnyValue::Int8(v) => Some(v).encode(env),
+        AnyValue::Int16(v) => Some(v).encode(env),
+        AnyValue::Int32(v) => Some(v).encode(env),
         AnyValue::Int64(v) => Some(v).encode(env),
+        AnyValue::UInt8(v) => Some(v).encode(env),
+        AnyValue::UInt16(v) => Some(v).encode(env),
+        AnyValue::UInt32(v) => Some(v).encode(env),
+        AnyValue::UInt64(v) => Some(v).encode(env),
         AnyValue::Float64(v) => Some(v).encode(env),
+        AnyValue::Float32(v) => Some(v).encode(env),
         AnyValue::Date(v) => {
             // get the date value
             let naive_date = date32_to_date(v);

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -210,6 +210,16 @@ defmodule Explorer.DataFrame.GroupedTest do
                ]
              }
     end
+
+    test "pull from summarised DF", %{df: df} do
+      series =
+        df
+        |> DF.group_by("country")
+        |> DF.summarise(total: [:count])
+        |> DF.pull("total_count")
+
+      assert Series.min(series) == 2
+    end
   end
 
   describe "arrange/2" do


### PR DESCRIPTION
This is because some operations like aggregations can return dtypes we
were not expecting, specially for integer columns.

Closes https://github.com/elixir-nx/explorer/issues/287