### PR TITLE
add compression for writing parquet

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1655706580,
-        "narHash": "sha256-7DshIT1Ya5W9NAW7UdnYCHsGmXfOXJZCEHbbB/cCX7g=",
+        "lastModified": 1657175312,
+        "narHash": "sha256-ZOTtKbL2VDPYJzfKZfPQTx7UdRkIb32fkwU64UOOS+Q=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "d895003d8e03ac2fc8ffe2aa898299cbef1a7048",
+        "rev": "c5933255cadd599e9d1b4b98d801c12a923ff9d8",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1653893745,
-        "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "1ed9fb1935d260de5fe1c2f7ee0ebaae17ed2fa1",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1655567057,
-        "narHash": "sha256-Cc5hQSMsTzOHmZnYm8OSJ5RNUp22bd5NADWLHorULWQ=",
+        "lastModified": 1657114324,
+        "narHash": "sha256-fWuaUNXrHcz/ciHRHlcSO92dvV3EVS0GJQUSBO5JIB4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e0a42267f73ea52adc061a64650fddc59906fc99",
+        "rev": "a5c867d9fe9e4380452628e8f171c26b69fa9d3d",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1655654433,
-        "narHash": "sha256-auHQ0XPCiaTPSn+R3Yu4J7oZ5Zq/FS5/Da1ivvdYb/Y=",
+        "lastModified": 1657151932,
+        "narHash": "sha256-iql4MrFnUcbA0AY7Eo+jiOwdVo+b1Ts6AFOQMIriiwY=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "427061da19723f2206fe4dcb175c9c43b9a6193d",
+        "rev": "c296e777675860164f8e45571efd29c4c08ee7cc",
         "type": "github"
       },
       "original": {

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -41,7 +41,7 @@ defmodule Explorer.Backend.DataFrame do
               result(String.t())
 
   @callback from_parquet(filename :: String.t()) :: result(df)
-  @callback to_parquet(df, filename :: String.t()) :: result(String.t())
+  @callback to_parquet(df, filename :: String.t(), compression :: atom()) :: result(String.t())
 
   @callback from_ipc(
               filename :: String.t(),

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -41,7 +41,12 @@ defmodule Explorer.Backend.DataFrame do
               result(String.t())
 
   @callback from_parquet(filename :: String.t()) :: result(df)
-  @callback to_parquet(df, filename :: String.t(), compression :: atom()) :: result(String.t())
+  @callback to_parquet(
+              df,
+              filename :: String.t(),
+              compression :: {nil | atom(), nil | integer()}
+            ) ::
+              result(String.t())
 
   @callback from_ipc(
               filename :: String.t(),

--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -52,7 +52,7 @@ defmodule Explorer.Backend.DataFrame do
               filename :: String.t(),
               columns :: list(String.t()) | list(atom()) | list(integer()) | nil
             ) :: result(df)
-  @callback to_ipc(df, filename :: String.t(), compression :: String.t()) ::
+  @callback to_ipc(df, filename :: String.t(), compression :: nil | atom()) ::
               result(String.t())
 
   @callback from_ndjson(

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -368,26 +368,15 @@ defmodule Explorer.DataFrame do
 
   defp normalise_compression(compression) when is_atom(compression), do: {compression, nil}
 
-  defp normalise_compression({:gzip, level}) when level not in 1..9 and not is_nil(level),
-    do:
-      raise(
-        ArgumentError,
-        "gzip compression level must be between 1 and 9 inclusive or nil, got #{level}"
-      )
-
-  defp normalise_compression({:brotli, level}) when level not in 1..11 and not is_nil(level),
-    do:
-      raise(
-        ArgumentError,
-        "brotli compression level must be between 1 and 11 inclusive or nil, got #{level}"
-      )
-
-  defp normalise_compression({:zstd, level}) when level not in -7..22 and not is_nil(level),
-    do:
-      raise(
-        ArgumentError,
-        "zstd compression level must be between -7 and 22 inclusive or nil, got #{level}"
-      )
+  for {algorithm, min, max} <- [{:gzip, 1, 9}, {:brotli, 1, 11}, {:zstd, -7, 22}] do
+    defp normalise_compression({unquote(algorithm), level})
+         when level not in unquote(min)..unquote(max) and not is_nil(level),
+         do:
+           raise(
+             ArgumentError,
+             "#{unquote(algorithm)} compression level must be between #{unquote(min)} and #{unquote(max)} inclusive or nil, got #{level}"
+           )
+  end
 
   defp normalise_compression(compression) when is_tuple(compression), do: compression
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -346,12 +346,18 @@ defmodule Explorer.DataFrame do
 
   @doc """
   Writes a dataframe to a parquet file.
+
+  ## Options
+
+    * `compression` - The compression algorithm to use when writing the Parquet files. Options include: `nil` (uncompressed, default), `:snappy`, `:gzip`, `:brotli`, `:zstd`, and `:lz4raw`.
   """
   @doc type: :io
   @spec to_parquet(df :: DataFrame.t(), filename :: String.t()) ::
           {:ok, String.t()} | {:error, term()}
-  def to_parquet(df, filename) do
-    Shared.apply_impl(df, :to_parquet, [filename])
+  def to_parquet(df, filename, opts \\ []) do
+    opts = Keyword.validate!(opts, compression: nil)
+
+    Shared.apply_impl(df, :to_parquet, [filename, opts[:compression]])
   end
 
   @doc """

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -435,7 +435,7 @@ defmodule Explorer.DataFrame do
   ## Options
 
     * `compression` - Sets the algorithm used to compress the IPC file.
-      It accepts `"ZSTD"` or `"LZ4"` compression. (default: `nil`)
+      It accepts `:zstd` or `:lz4` compression. (default: `nil`)
   """
   @doc type: :io
   @spec to_ipc(df :: DataFrame.t(), filename :: String.t()) ::

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -125,8 +125,10 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def to_parquet(%DataFrame{data: df}, filename) do
-    case Native.df_write_parquet(df, filename) do
+  def to_parquet(%DataFrame{data: df}, filename, compression) do
+    compression = if is_nil(compression), do: "uncompressed", else: "#{compression}"
+
+    case Native.df_write_parquet(df, filename, compression) do
       {:ok, _} -> {:ok, filename}
       {:error, error} -> {:error, error}
     end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -126,9 +126,13 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def to_parquet(%DataFrame{data: df}, filename, compression) do
-    compression = if is_nil(compression), do: "uncompressed", else: "#{compression}"
+    {compression, compression_level} =
+      case compression do
+        {nil, _} -> {nil, nil}
+        {compression, level} -> {"#{compression}", level}
+      end
 
-    case Native.df_write_parquet(df, filename, compression) do
+    case Native.df_write_parquet(df, filename, compression, compression_level) do
       {:ok, _} -> {:ok, filename}
       {:error, error} -> {:error, error}
     end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -150,7 +150,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def to_ipc(%DataFrame{data: df}, filename, compression) do
-    case Native.df_write_ipc(df, filename, compression) do
+    case Native.df_write_ipc(df, filename, "#{compression}") do
       {:ok, _} -> {:ok, filename}
       {:error, error} -> {:error, error}
     end

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -93,7 +93,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_width(_df), do: err()
   def df_with_columns(_df, _columns), do: err()
   def df_write_ipc(_df, _filename, _compression), do: err()
-  def df_write_parquet(_df, _filename), do: err()
+  def df_write_parquet(_df, _filename, _compression), do: err()
 
   # Expressions (for lazy queries)
   # We first generate functions for known operations.

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -93,7 +93,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_width(_df), do: err()
   def df_with_columns(_df, _columns), do: err()
   def df_write_ipc(_df, _filename, _compression), do: err()
-  def df_write_parquet(_df, _filename, _compression), do: err()
+  def df_write_parquet(_df, _filename, _compression, _compression_level), do: err()
 
   # Expressions (for lazy queries)
   # We first generate functions for known operations.

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -1,6 +1,7 @@
 use polars::prelude::*;
 
 use rustler::{Binary, Env, NewBinary};
+use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
 use std::result::Result;
@@ -85,18 +86,36 @@ pub fn df_read_parquet(filename: &str) -> Result<ExDataFrame, ExplorerError> {
 pub fn df_write_parquet(
     data: ExDataFrame,
     filename: &str,
-    compression: &str,
+    compression: Option<&str>,
+    compression_level: Option<i32>,
 ) -> Result<(), ExplorerError> {
     let df = &data.resource.0;
     let file = File::create(filename)?;
     let mut buf_writer = BufWriter::new(file);
-    let compression = match compression {
-        "uncompressed" => ParquetCompression::Uncompressed,
-        "snappy" => ParquetCompression::Snappy,
-        "gzip" => ParquetCompression::Gzip(None),
-        "brotli" => ParquetCompression::Brotli(None),
-        "zstd" => ParquetCompression::Zstd(None),
-        "lz4raw" => ParquetCompression::Lz4Raw,
+    let compression = match (compression, compression_level) {
+        (Some("snappy"), _) => ParquetCompression::Snappy,
+        (Some("gzip"), level) => {
+            let level = match level {
+                Some(level) => Some(GzipLevel::try_new(u8::try_from(level)?)?),
+                None => None,
+            };
+            ParquetCompression::Gzip(level)
+        }
+        (Some("brotli"), level) => {
+            let level = match level {
+                Some(level) => Some(BrotliLevel::try_new(u32::try_from(level)?)?),
+                None => None,
+            };
+            ParquetCompression::Brotli(level)
+        }
+        (Some("zstd"), level) => {
+            let level = match level {
+                Some(level) => Some(ZstdLevel::try_new(level)?),
+                None => None,
+            };
+            ParquetCompression::Zstd(level)
+        }
+        (Some("lz4raw"), _) => ParquetCompression::Lz4Raw,
         _ => ParquetCompression::Uncompressed,
     };
     ParquetWriter::new(&mut buf_writer)

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -186,8 +186,8 @@ pub fn df_write_ipc(
     let df = &data.resource.0;
     // Select the compression algorithm.
     let compression = match compression {
-        Some("LZ4") => Some(IpcCompression::LZ4),
-        Some("ZSTD") => Some(IpcCompression::ZSTD),
+        Some("lz4") => Some(IpcCompression::LZ4),
+        Some("zstd") => Some(IpcCompression::ZSTD),
         _ => None,
     };
 

--- a/native/explorer/src/error.rs
+++ b/native/explorer/src/error.rs
@@ -20,6 +20,10 @@ pub enum ExplorerError {
     #[error("Other error: {0}")]
     Other(String),
     #[error(transparent)]
+    TryFromInt(#[from] std::num::TryFromIntError),
+    #[error(transparent)]
+    Parquet(#[from] polars::export::arrow::io::parquet::read::ParquetError),
+    #[error(transparent)]
     Unknown(#[from] anyhow::Error),
 }
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -578,6 +578,23 @@ defmodule Explorer.DataFrameTest do
       assert DF.dtypes(df) == DF.dtypes(parquet_df)
       assert DF.to_columns(df) == DF.to_columns(parquet_df)
     end
+
+    @tag :tmp_dir
+    test "can write parquet to file with compression", %{
+      df: df,
+      tmp_dir: tmp_dir
+    } do
+      for compression <- [:snappy, :gzip, :brotli, :zstd, :lz4raw] do
+        parquet_path = Path.join(tmp_dir, "test.parquet")
+
+        assert {:ok, ^parquet_path} = DF.to_parquet(df, parquet_path, compression: compression)
+        assert {:ok, parquet_df} = DF.from_parquet(parquet_path)
+
+        assert DF.names(df) == DF.names(parquet_df)
+        assert DF.dtypes(df) == DF.dtypes(parquet_df)
+        assert DF.to_columns(df) == DF.to_columns(parquet_df)
+      end
+    end
   end
 
   describe "from_ndjson/2" do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -585,14 +585,18 @@ defmodule Explorer.DataFrameTest do
       tmp_dir: tmp_dir
     } do
       for compression <- [:snappy, :gzip, :brotli, :zstd, :lz4raw] do
-        parquet_path = Path.join(tmp_dir, "test.parquet")
+        for compression_level <- [nil, 1, 2, 3] do
+          parquet_path = Path.join(tmp_dir, "test.parquet")
 
-        assert {:ok, ^parquet_path} = DF.to_parquet(df, parquet_path, compression: compression)
-        assert {:ok, parquet_df} = DF.from_parquet(parquet_path)
+          assert {:ok, ^parquet_path} =
+                   DF.to_parquet(df, parquet_path, compression: {compression, compression_level})
 
-        assert DF.names(df) == DF.names(parquet_df)
-        assert DF.dtypes(df) == DF.dtypes(parquet_df)
-        assert DF.to_columns(df) == DF.to_columns(parquet_df)
+          assert {:ok, parquet_df} = DF.from_parquet(parquet_path)
+
+          assert DF.names(df) == DF.names(parquet_df)
+          assert DF.dtypes(df) == DF.dtypes(parquet_df)
+          assert DF.to_columns(df) == DF.to_columns(parquet_df)
+        end
       end
     end
   end


### PR DESCRIPTION
Adds compression as an option for the parquet writer. Closes #291. For reasons I can't figure out, lz4 and lzo are not supported. @joshuataylor can you see anything I can't re: those two?