### PR TITLE
Add arithmetic operations to LazySeries

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1052,8 +1052,13 @@ defmodule Explorer.DataFrame do
       |> Explorer.Backend.DataFrame.new(df.names, df.dtypes)
 
     case fun.(ldf) do
-      %Series{data: %Explorer.Backend.LazySeries{} = data} ->
+      %Series{dtype: :boolean, data: %Explorer.Backend.LazySeries{} = data} ->
         Shared.apply_impl(df, :filter_with, [data])
+
+      %Series{dtype: dtype, data: %Explorer.Backend.LazySeries{}} ->
+        raise ArgumentError,
+              "expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type " <>
+                inspect(dtype)
 
       other ->
         raise ArgumentError,

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -134,6 +134,38 @@ pub fn expr_is_not_nil(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_add(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr + right_expr)
+}
+
+#[rustler::nif]
+pub fn expr_subtract(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr - right_expr)
+}
+
+#[rustler::nif]
+pub fn expr_divide(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr / right_expr)
+}
+
+#[rustler::nif]
+pub fn expr_pow(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr.pow(right_expr))
+}
+
+#[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
     let df: DataFrame = data.resource.0.clone();
     let expressions: Expr = expr.resource.0.clone();

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -117,6 +117,11 @@ rustler::init!(
         expr_lt,
         expr_lt_eq,
         expr_neq,
+        // arithmetic expressions
+        expr_add,
+        expr_subtract,
+        expr_divide,
+        expr_pow,
         // inspect expressions
         expr_describe_filter_plan,
         // lazyframe


### PR DESCRIPTION
This also changes `DF.filter_with/2` to require a boolean operation at
the "root level".