### PR TITLE
Add `DF.summarise_with/2` that accepts lazy series

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -83,7 +83,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback tail(df, rows :: integer()) :: df
   @callback select(df, out_df :: df()) :: df
   @callback filter(df, mask :: series) :: df
-  @callback filter_with(df, (lazy_frame() -> lazy_series())) :: df
+  @callback filter_with(df, out_df :: df(), lazy_series()) :: df
   @callback mutate(df, out_df :: df(), mutations :: [{column_name(), mutate_value()}]) :: df
   @callback arrange(df, columns :: [column_name() | {:asc | :desc, column_name()}]) :: df
   @callback distinct(df, out_df :: df(), columns :: [column_name()], keep_all? :: boolean()) :: df
@@ -126,6 +126,9 @@ defmodule Explorer.Backend.DataFrame do
   # Groups
 
   @callback summarise(df, out_df :: df(), aggregations :: %{column_name() => [atom()]}) :: df
+
+  @callback summarise_with(df, out_df :: df(), aggregations :: [{column_name(), lazy_series()}]) ::
+              df
 
   # Functions
   alias Explorer.{DataFrame, Series}

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -8,6 +8,7 @@ defmodule Explorer.Backend.Series do
   @type t :: struct()
 
   @type s :: Explorer.Series.t()
+  @type lazy_s :: Explorer.Series.lazy()
   @type df :: Explorer.DataFrame.t()
   @type dtype :: :integer | :float | :boolean | :string | :date | :datetime
   @type valid_types :: number() | boolean() | String.t() | Date.t() | NaiveDateTime.t()
@@ -41,14 +42,14 @@ defmodule Explorer.Backend.Series do
 
   # Aggregation
 
-  @callback sum(s) :: number()
-  @callback min(s) :: number() | Date.t() | NaiveDateTime.t()
-  @callback max(s) :: number() | Date.t() | NaiveDateTime.t()
-  @callback mean(s) :: float()
-  @callback median(s) :: float()
-  @callback var(s) :: float()
-  @callback std(s) :: float()
-  @callback quantile(s, float()) :: number | Date.t() | NaiveDateTime.t()
+  @callback sum(s) :: number() | lazy_s()
+  @callback min(s) :: number() | Date.t() | NaiveDateTime.t() | lazy_s()
+  @callback max(s) :: number() | Date.t() | NaiveDateTime.t() | lazy_s()
+  @callback mean(s) :: float() | lazy_s()
+  @callback median(s) :: float() | lazy_s()
+  @callback var(s) :: float() | lazy_s()
+  @callback std(s) :: float() | lazy_s()
+  @callback quantile(s, float()) :: number | Date.t() | NaiveDateTime.t() | lazy_s()
 
   # Cumulative
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1047,14 +1047,11 @@ defmodule Explorer.DataFrame do
 
   @doc false
   def filter_with(df, fun) when is_function(fun) do
-    ldf =
-      df
-      |> Explorer.Backend.LazyFrame.new()
-      |> Explorer.Backend.DataFrame.new(df.names, df.dtypes)
+    ldf = to_opaque_lazy(df)
 
     case fun.(ldf) do
       %Series{dtype: :boolean, data: %LazySeries{} = data} ->
-        Shared.apply_impl(df, :filter_with, [data])
+        Shared.apply_impl(df, :filter_with, [df, data])
 
       %Series{dtype: dtype, data: %LazySeries{} = lazy} ->
         message =
@@ -1072,6 +1069,12 @@ defmodule Explorer.DataFrame do
               "expecting the function to return a LazySeries, but instead it returned " <>
                 inspect(other)
     end
+  end
+
+  defp to_opaque_lazy(%DataFrame{} = df) do
+    df
+    |> Explorer.Backend.LazyFrame.new()
+    |> Explorer.Backend.DataFrame.new(df.names, df.dtypes)
   end
 
   @doc """
@@ -2605,6 +2608,46 @@ defmodule Explorer.DataFrame do
         ArgumentError,
         "dataframe must be grouped in order to perform summarisation"
       )
+
+  def summarise_with(%DataFrame{} = df, fun) when is_function(fun) do
+    ldf = to_opaque_lazy(df)
+
+    result = fun.(ldf)
+
+    column_pairs =
+      to_column_pairs(df, result, fn value ->
+        # We need to ensure that the value is always an agg expression
+        case value do
+          %Series{data: %LazySeries{op: op, aggregation: true}} when op in @supported_aggs ->
+            value
+
+          %Series{data: %LazySeries{op: op}} ->
+            raise "expecting summarise with an aggregation operation. But instead got #{inspect(op)}."
+
+          other ->
+            raise "expecting a lazy series, but instead got #{inspect(other)}"
+        end
+      end)
+
+    new_dtypes = names_with_dtypes_for_summarise_with(df, column_pairs)
+    new_names = for {name, _} <- new_dtypes, do: name
+    df_out = %{df | names: new_names, dtypes: Map.new(new_dtypes), groups: []}
+
+    column_pairs = for {name, %Series{data: lazy_series}} <- column_pairs, do: {name, lazy_series}
+
+    Shared.apply_impl(df, :summarise_with, [df_out, column_pairs])
+  end
+
+  defp names_with_dtypes_for_summarise_with(df, column_pairs) do
+    groups = for group <- df.groups, do: {group, df.dtypes[group]}
+
+    agg_pairs =
+      for {column_name, aggregation} <- column_pairs do
+        {column_name, aggregation.dtype}
+      end
+
+    groups ++ agg_pairs
+  end
 
   @doc """
   Display the DataFrame in a tabular fashion.

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -42,6 +42,10 @@ defmodule Explorer.PolarsBackend.Expression do
   def to_expr(%Date{} = date), do: Native.expr_date(date)
   def to_expr(%NaiveDateTime{} = datetime), do: Native.expr_datetime(datetime)
 
+  def alias_expr(%__MODULE__{} = expr, alias_name) when is_binary(alias_name) do
+    Native.expr_alias(expr, alias_name)
+  end
+
   # Only for inspecting the expression in tests
   def describe_filter_plan(%DataFrame{data: polars_df}, %__MODULE__{} = expression) do
     Native.expr_describe_filter_plan(polars_df, expression)

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -69,6 +69,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_get_columns(_df), do: err()
   def df_group_indices(_df, _column_names), do: err()
   def df_groupby_agg(_df, _groups, _aggs), do: err()
+  def df_groupby_agg_with(_df, _groups_exprs, _aggs_pairs), do: err()
   def df_groups(_df, _column_names), do: err()
   def df_head(_df, _length), do: err()
   def df_height(_df), do: err()
@@ -111,6 +112,7 @@ defmodule Explorer.PolarsBackend.Native do
   def expr_integer(_number), do: err()
   def expr_string(_string), do: err()
   def expr_describe_filter_plan(_df, _expr), do: err()
+  def expr_alias(_ex_expr, _alias_name), do: err()
 
   # LazyFrame
   def lf_collect(_df), do: err()

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -29,7 +29,8 @@ defmodule Explorer.Series do
 
   @type data :: Explorer.Backend.Series.t()
   @type dtype :: Explorer.Backend.Series.dtype()
-  @type t :: %Series{data: data, dtype: dtype}
+  @type t :: %Series{data: data, dtype: dtype()}
+  @type lazy :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
 
   @enforce_keys [:data, :dtype]
   defstruct [:data, :dtype]

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -571,17 +571,25 @@ pub fn df_groupby_agg(
     Ok(ExDataFrame::new(new_df))
 }
 
-// Ref:https://pola-rs.github.io/polars/polars/docs/lazy/index.html#groupby
-// #[rustler::nif(schedule = "DirtyCpu")]
-// pub fn df_groupby_agg_with(
-//     data: ExDataFrame,
-//     groups: Vec<ExExpr>,
-//     aggs: Vec<(&str, ExExpr)>,
-// ) -> Result<ExDataFrame, ExplorerError> {
-//     let df = &data.resource.0;
-//     let new_df = df.groupby_stable(groups)?.agg(&aggs)?;
-//     Ok(ExDataFrame::new(new_df))
-// }
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn df_groupby_agg_with(
+    data: ExDataFrame,
+    groups: Vec<ExExpr>,
+    aggs: Vec<ExExpr>,
+) -> Result<ExDataFrame, ExplorerError> {
+    let df = data.resource.0.clone();
+    let groups: Vec<Expr> = groups
+        .iter()
+        .map(|ex_expr| ex_expr.resource.0.clone())
+        .collect();
+    let aggs: Vec<Expr> = aggs
+        .iter()
+        .map(|ex_expr| ex_expr.resource.0.clone())
+        .collect();
+
+    let new_df = df.lazy().groupby_stable(groups).agg(aggs).collect()?;
+    Ok(ExDataFrame::new(new_df))
+}
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_pivot_wider(

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -571,6 +571,18 @@ pub fn df_groupby_agg(
     Ok(ExDataFrame::new(new_df))
 }
 
+// Ref:https://pola-rs.github.io/polars/polars/docs/lazy/index.html#groupby
+// #[rustler::nif(schedule = "DirtyCpu")]
+// pub fn df_groupby_agg_with(
+//     data: ExDataFrame,
+//     groups: Vec<ExExpr>,
+//     aggs: Vec<(&str, ExExpr)>,
+// ) -> Result<ExDataFrame, ExplorerError> {
+//     let df = &data.resource.0;
+//     let new_df = df.groupby_stable(groups)?.agg(&aggs)?;
+//     Ok(ExDataFrame::new(new_df))
+// }
+
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_pivot_wider(
     data: ExDataFrame,

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -224,6 +224,13 @@ pub fn expr_quantile(expr: ExExpr, quantile: f64) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_alias(expr: ExExpr, name: &str) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.alias(name))
+}
+
+#[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
     let df: DataFrame = data.resource.0.clone();
     let expressions: Expr = expr.resource.0.clone();

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -166,6 +166,64 @@ pub fn expr_pow(left: ExExpr, right: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_sum(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.sum())
+}
+
+#[rustler::nif]
+pub fn expr_min(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.min())
+}
+
+#[rustler::nif]
+pub fn expr_max(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.max())
+}
+
+#[rustler::nif]
+pub fn expr_mean(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.mean())
+}
+
+#[rustler::nif]
+pub fn expr_median(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.median())
+}
+
+#[rustler::nif]
+pub fn expr_var(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.var())
+}
+
+#[rustler::nif]
+pub fn expr_std(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.std())
+}
+
+#[rustler::nif]
+pub fn expr_quantile(expr: ExExpr, quantile: f64) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+    // TODO: consider accepting strategy in the future.
+    let strategy = crate::parse_quantile_interpol_options("nearest");
+
+    ExExpr::new(expr.quantile(quantile, strategy))
+}
+
+#[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
     let df: DataFrame = data.resource.0.clone();
     let expressions: Expr = expr.resource.0.clone();

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -68,6 +68,7 @@ rustler::init!(
         df_get_columns,
         df_groups,
         df_groupby_agg,
+        df_groupby_agg_with,
         df_group_indices,
         df_head,
         df_height,
@@ -131,6 +132,7 @@ rustler::init!(
         expr_std,
         expr_var,
         expr_quantile,
+        expr_alias,
         // inspect expressions
         expr_describe_filter_plan,
         // lazyframe

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -122,6 +122,15 @@ rustler::init!(
         expr_subtract,
         expr_divide,
         expr_pow,
+        // agg expressions
+        expr_sum,
+        expr_min,
+        expr_max,
+        expr_mean,
+        expr_median,
+        expr_std,
+        expr_var,
+        expr_quantile,
         // inspect expressions
         expr_describe_filter_plan,
         // lazyframe

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -222,6 +222,26 @@ defmodule Explorer.DataFrame.GroupedTest do
     end
   end
 
+  describe "summarise_with/2" do
+    @tag skip: true
+    test "with one group and one column with aggregations", %{df: df} do
+      df1 =
+        df
+        |> DF.group_by("year")
+        |> DF.summarise_with(fn ldf ->
+          total = ldf["total"]
+
+          [total_min: Series.min(total), total_max: Series.max(total)]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               year: [2010, 2011, 2012, 2013, 2014],
+               total_min: [1, 2, 2, 2, 3],
+               total_max: [2_393_248, 2_654_360, 2_734_817, 2_797_384, 2_806_634]
+             }
+    end
+  end
+
   describe "arrange/2" do
     test "sorts by group", %{df: df} do
       df = DF.arrange(df, "total")

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -201,6 +201,19 @@ defmodule Explorer.DataFrameTest do
       end
     end
 
+    test "raise an error if the last operation is an aggregation operation" do
+      df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
+
+      message =
+        "expecting the function to return a boolean LazySeries, but instead it returned an aggregation"
+
+      assert_raise ArgumentError, message, fn ->
+        DF.filter_with(df, fn ldf ->
+          Series.sum(ldf["a"])
+        end)
+      end
+    end
+
     test "raise an error if the function is not returning a lazy series" do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
       message = "expecting the function to return a LazySeries, but instead it returned :foo"


### PR DESCRIPTION
This is a version of `summarise` that works with lazy series in a
callback function. The main difference is that more complex expressions
can be made, and each aggregation must be named.