### PR TITLE
Add missing lazy series operations for aggregations

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -40,14 +40,18 @@ defmodule Explorer.Backend.LazySeries do
     median: 1,
     var: 1,
     std: 1,
-    quantile: 2
+    quantile: 2,
+    # Maybe aggregations
+    first: 1,
+    last: 1,
+    count: 1
   ]
 
   @comparison_operations [:eq, :neq, :gt, :gt_eq, :lt, :lt_eq]
 
   @arithmetic_operations [:add, :subtract, :multiply, :divide, :pow]
 
-  @aggregation_operations [:sum, :min, :max, :mean, :median, :var, :std]
+  @aggregation_operations [:sum, :min, :max, :mean, :median, :var, :std, :count]
 
   @doc false
   def new(op, args, aggregation \\ false) do
@@ -190,6 +194,9 @@ defmodule Explorer.Backend.LazySeries do
   @to_elixir_op %{
     add: :+,
     subtract: :-,
+    multiply: :*,
+    divide: :/,
+    pow: :**,
     eq: :==,
     neq: :!=,
     gt: :>,
@@ -204,9 +211,7 @@ defmodule Explorer.Backend.LazySeries do
     {Map.get(@to_elixir_op, op, op), [], Enum.map(args, &to_elixir_ast/1)}
   end
 
-  defp to_elixir_ast(other) do
-    other
-  end
+  defp to_elixir_ast(other), do: other
 
   # TODO: Make the functions of non-implemented functions
   # explicit once the lazy interface is ready.

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -51,7 +51,7 @@ defmodule Explorer.Backend.LazySeries do
 
   @arithmetic_operations [:add, :subtract, :multiply, :divide, :pow]
 
-  @aggregation_operations [:sum, :min, :max, :mean, :median, :var, :std, :count]
+  @aggregation_operations [:sum, :min, :max, :mean, :median, :var, :std, :count, :first, :last]
 
   @doc false
   def new(op, args, aggregation \\ false) do

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -175,14 +175,14 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
-  def nil?(%Series{} = series) do
+  def is_nil(%Series{} = series) do
     data = new(:is_nil, [lazy_series!(series)])
 
     Backend.Series.new(data, :boolean)
   end
 
   @impl true
-  def not_nil?(%Series{} = series) do
+  def is_not_nil(%Series{} = series) do
     data = new(:is_not_nil, [lazy_series!(series)])
 
     Backend.Series.new(data, :boolean)

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -39,6 +39,8 @@ defmodule Explorer.Backend.Series do
   @callback get(s, idx :: integer()) :: s
   @callback concat(s, s) :: s
   @callback coalesce(s, s) :: s
+  @callback first(s) :: valid_types() | lazy_s()
+  @callback last(s) :: valid_types() | lazy_s()
 
   # Aggregation
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -95,7 +95,7 @@ defmodule Explorer.Backend.Series do
   @callback distinct(s) :: s
   @callback unordered_distinct(s) :: s
   @callback n_distinct(s) :: integer()
-  @callback count(s) :: df
+  @callback count(s) :: df | lazy_s()
 
   # Rolling
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -114,8 +114,8 @@ defmodule Explorer.Backend.Series do
   # Nulls
 
   @callback fill_missing(s, strategy :: :backward | :forward | :min | :max | :mean) :: s
-  @callback nil?(s) :: s
-  @callback not_nil?(s) :: s
+  @callback is_nil(s) :: s
+  @callback is_not_nil(s) :: s
 
   # Escape hatch
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1053,16 +1053,11 @@ defmodule Explorer.DataFrame do
       %Series{dtype: :boolean, data: %LazySeries{} = data} ->
         Shared.apply_impl(df, :filter_with, [df, data])
 
-      %Series{dtype: dtype, data: %LazySeries{} = lazy} ->
-        message =
-          if lazy.aggregation do
-            "expecting the function to return a boolean LazySeries, but instead it returned an aggregation"
-          else
-            "expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type " <>
-              inspect(dtype)
-          end
-
-        raise ArgumentError, message
+      %Series{dtype: dtype, data: %LazySeries{}} ->
+        raise ArgumentError,
+              "expecting the function to return a boolean LazySeries, " <>
+                "but instead it returned a LazySeries of type " <>
+                inspect(dtype)
 
       other ->
         raise ArgumentError,
@@ -2616,13 +2611,12 @@ defmodule Explorer.DataFrame do
 
     column_pairs =
       to_column_pairs(df, result, fn value ->
-        # We need to ensure that the value is always an agg expression
         case value do
-          %Series{data: %LazySeries{op: op, aggregation: true}} when op in @supported_aggs ->
+          %Series{data: %LazySeries{aggregation: true}} ->
             value
 
           %Series{data: %LazySeries{op: op}} ->
-            raise "expecting summarise with an aggregation operation. But instead got #{inspect(op)}."
+            raise "expecting summarise with an aggregation operation inside. But instead got #{inspect(op)}."
 
           other ->
             raise "expecting a lazy series, but instead got #{inspect(other)}"

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2509,7 +2509,7 @@ defmodule Explorer.DataFrame do
 
   def ungroup(df, group) when is_column_name(group), do: ungroup(df, [group])
 
-  @supported_aggs ~w[min max sum mean median first last count n_unique]a
+  @supported_aggs ~w[min max sum mean median first last count n_distinct]a
 
   @doc """
   Summarise each group to a single row.
@@ -2528,18 +2528,18 @@ defmodule Explorer.DataFrame do
     * `:first` - Take the first value within the group. See `Explorer.Series.first/1`.
     * `:last` - Take the last value within the group. See `Explorer.Series.last/1`.
     * `:count` - Count the number of rows per group.
-    * `:n_unique` - Count the number of unique rows per group.
+    * `:n_distinct` - Count the number of unique rows per group.
 
   ## Examples
 
       iex> df = Explorer.Datasets.fossil_fuels()
-      iex> df |> Explorer.DataFrame.group_by("year") |> Explorer.DataFrame.summarise(total: [:max, :min], country: [:n_unique])
+      iex> df |> Explorer.DataFrame.group_by("year") |> Explorer.DataFrame.summarise(total: [:max, :min], country: [:n_distinct])
       #Explorer.DataFrame<
         Polars[5 x 4]
         year integer [2010, 2011, 2012, 2013, 2014]
         total_max integer [2393248, 2654360, 2734817, 2797384, 2806634]
         total_min integer [1, 2, 2, 2, 3]
-        country_n_unique integer [217, 217, 220, 220, 220]
+        country_n_distinct integer [217, 217, 220, 220, 220]
       >
   """
   @doc type: :single

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -68,7 +68,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_filter_with(_df, _operation), do: err()
   def df_get_columns(_df), do: err()
   def df_group_indices(_df, _column_names), do: err()
-  def df_groupby_agg(_df, _groups, _aggs), do: err()
+  def df_groupby_agg(_df, _groups, _aggs, _renames), do: err()
   def df_groupby_agg_with(_df, _groups_exprs, _aggs_pairs), do: err()
   def df_groups(_df, _column_names), do: err()
   def df_head(_df, _length), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -321,10 +321,10 @@ defmodule Explorer.PolarsBackend.Series do
   end
 
   @impl true
-  def nil?(series), do: Shared.apply_series(series, :s_is_null)
+  def is_nil(series), do: Shared.apply_series(series, :s_is_null)
 
   @impl true
-  def not_nil?(series), do: Shared.apply_series(series, :s_is_not_null)
+  def is_not_nil(series), do: Shared.apply_series(series, :s_is_not_null)
 
   # Escape hatch
   @impl true

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -60,6 +60,12 @@ defmodule Explorer.PolarsBackend.Series do
   def tail(series, n_elements), do: Shared.apply_series(series, :s_tail, [n_elements])
 
   @impl true
+  def first(series), do: series[0]
+
+  @impl true
+  def last(series), do: series[-1]
+
+  @impl true
   def sample(series, n, replacement, seed) when is_integer(n) do
     indices =
       series

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1948,14 +1948,14 @@ defmodule Explorer.Series do
   ## Examples
 
       iex> s = Explorer.Series.from_list([1, 2, nil, 4])
-      iex> Explorer.Series.nil?(s)
+      iex> Explorer.Series.is_nil(s)
       #Explorer.Series<
         boolean[4]
         [false, false, true, false]
       >
   """
-  @spec nil?(Series.t()) :: Series.t()
-  def nil?(series), do: Shared.apply_impl(series, :nil?)
+  @spec is_nil(Series.t()) :: Series.t()
+  def is_nil(series), do: Shared.apply_impl(series, :is_nil)
 
   @doc """
   Returns a mask of not nil values.
@@ -1963,14 +1963,14 @@ defmodule Explorer.Series do
   ## Examples
 
       iex> s = Explorer.Series.from_list([1, 2, nil, 4])
-      iex> Explorer.Series.not_nil?(s)
+      iex> Explorer.Series.is_not_nil(s)
       #Explorer.Series<
         boolean[4]
         [true, true, false, true]
       >
   """
-  @spec not_nil?(Series.t()) :: Series.t()
-  def not_nil?(series), do: Shared.apply_impl(series, :not_nil?)
+  @spec is_not_nil(Series.t()) :: Series.t()
+  def is_not_nil(series), do: Shared.apply_impl(series, :is_not_nil)
 
   # Escape hatch
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -676,7 +676,7 @@ defmodule Explorer.Series do
   `coalesce(s1, s2)` is equivalent to `coalesce([s1, s2])`.
   """
   @spec coalesce(s1 :: Series.t(), s2 :: Series.t()) :: Series.t()
-  def coalesce(s1, s2), do: concat([s1, s2])
+  def coalesce(s1, s2), do: coalesce([s1, s2])
 
   # Aggregation
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -405,7 +405,7 @@ defmodule Explorer.Series do
       1
   """
   @spec first(series :: Series.t()) :: any()
-  def first(series), do: series[0]
+  def first(series), do: Shared.apply_impl(series, :first, [])
 
   @doc """
   Returns the last element of the series.
@@ -417,7 +417,7 @@ defmodule Explorer.Series do
       100
   """
   @spec last(series :: Series.t()) :: any()
-  def last(series), do: series[-1]
+  def last(series), do: Shared.apply_impl(series, :last, [])
 
   @doc """
   Returns a random sample of the series.

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -667,16 +667,35 @@ defmodule Explorer.Series do
       >
   """
   @spec coalesce([Series.t()]) :: Series.t()
-  def coalesce([%Series{} = h | t] = _series),
-    do: Enum.reduce(t, h, &Shared.apply_impl(&2, :coalesce, [&1]))
+  def coalesce([%Series{} = h | t]),
+    do: Enum.reduce(t, h, &coalesce(&2, &1))
 
   @doc """
   Finds the first non-missing element at each position.
 
   `coalesce(s1, s2)` is equivalent to `coalesce([s1, s2])`.
+
+  ## Examples
+
+      iex> s1 = Explorer.Series.from_list([1, nil, 3, nil])
+      iex> s2 = Explorer.Series.from_list([1, 2, nil, 4])
+      iex> Explorer.Series.coalesce(s1, s2)
+      #Explorer.Series<
+        integer[4]
+        [1, 2, 3, 4]
+      >
+
+      iex> s1 = Explorer.Series.from_list(["foo", nil, "bar", nil])
+      iex> s2 = Explorer.Series.from_list([1, 2, nil, 4])
+      iex> Explorer.Series.coalesce(s1, s2)
+      ** (ArgumentError) cannot invoke Explorer.Series.coalesce/2 with mismatched dtypes: string and integer.
   """
   @spec coalesce(s1 :: Series.t(), s2 :: Series.t()) :: Series.t()
-  def coalesce(s1, s2), do: coalesce([s1, s2])
+  def coalesce(s1, s2) do
+    :ok = check_dtypes_for_coalesce!(s1, s2)
+
+    Shared.apply_impl(s1, :coalesce, [s2])
+  end
 
   # Aggregation
 
@@ -2009,6 +2028,15 @@ defmodule Explorer.Series do
         "cannot invoke Explorer.Series.#{function} with mismatched dtypes: #{left_dtype} and " <>
           "#{right_dtype}."
       )
+
+  defp check_dtypes_for_coalesce!(%Series{} = s1, %Series{} = s2) do
+    case {s1.dtype, s2.dtype} do
+      {dtype, dtype} -> :ok
+      {:integer, :float} -> :ok
+      {:float, :integer} -> :ok
+      {left, right} -> dtype_mismatch_error("coalesce/2", left, right)
+    end
+  end
 
   defimpl Inspect do
     import Inspect.Algebra

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -565,10 +565,21 @@ pub fn df_groupby_agg(
     data: ExDataFrame,
     groups: Vec<&str>,
     aggs: Vec<(&str, Vec<&str>)>,
+    renames: Vec<(&str, &str)>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let df = &data.resource.0;
     let new_df = df.groupby_stable(groups)?.agg(&aggs)?;
-    Ok(ExDataFrame::new(new_df))
+
+    if renames.is_empty() {
+        Ok(ExDataFrame::new(new_df))
+    } else {
+        let mut new_df = new_df.clone();
+        for (original, new_name) in renames {
+            new_df.rename(original, new_name).expect("should rename");
+        }
+
+        Ok(ExDataFrame::new(new_df))
+    }
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -231,6 +231,13 @@ pub fn expr_alias(expr: ExExpr, name: &str) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_count(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.count())
+}
+
+#[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
     let df: DataFrame = data.resource.0.clone();
     let expressions: Expr = expr.resource.0.clone();

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -5,7 +5,7 @@
 // wrapped in an Elixir struct.
 
 use chrono::{NaiveDate, NaiveDateTime};
-use polars::prelude::{col, DataFrame, IntoLazy};
+use polars::prelude::{col, when, DataFrame, IntoLazy};
 use polars::prelude::{Expr, Literal};
 
 use crate::datatypes::{ExDate, ExDateTime};
@@ -249,6 +249,17 @@ pub fn expr_last(expr: ExExpr) -> ExExpr {
     let expr: Expr = expr.resource.0.clone();
 
     ExExpr::new(expr.last())
+}
+
+#[rustler::nif]
+pub fn expr_coalesce(left: ExExpr, right: ExExpr) -> ExExpr {
+    let predicate: Expr = left.resource.0.clone().is_not_null();
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    let condition = when(predicate).then(left_expr).otherwise(right_expr);
+
+    ExExpr::new(condition)
 }
 
 #[rustler::nif]

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -238,6 +238,20 @@ pub fn expr_count(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_first(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.first())
+}
+
+#[rustler::nif]
+pub fn expr_last(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.last())
+}
+
+#[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
     let df: DataFrame = data.resource.0.clone();
     let expressions: Expr = expr.resource.0.clone();

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -137,6 +137,8 @@ rustler::init!(
         expr_count,
         expr_first,
         expr_last,
+        // slice and dice expressions
+        expr_coalesce,
         // inspect expressions
         expr_describe_filter_plan,
         // lazyframe

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -135,6 +135,8 @@ rustler::init!(
         expr_alias,
         // maybe agg expressions
         expr_count,
+        expr_first,
+        expr_last,
         // inspect expressions
         expr_describe_filter_plan,
         // lazyframe

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -133,6 +133,8 @@ rustler::init!(
         expr_var,
         expr_quantile,
         expr_alias,
+        // maybe agg expressions
+        expr_count,
         // inspect expressions
         expr_describe_filter_plan,
         // lazyframe

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -302,6 +302,20 @@ defmodule Explorer.DataFrame.GroupedTest do
                total_min: [2308, 1254, 32500, 141, 7924]
              }
     end
+
+    test "with one group and count", %{df: df} do
+      df1 =
+        df
+        |> DF.group_by(["year"])
+        |> DF.summarise_with(fn ldf ->
+          [count: Series.count(ldf["country"])]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               year: [2010, 2011, 2012, 2013, 2014],
+               count: [217, 217, 220, 220, 220]
+             }
+    end
   end
 
   describe "arrange/2" do

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -87,13 +87,13 @@ defmodule Explorer.DataFrame.GroupedTest do
     end
 
     test "with one group and two columns with aggregations", %{df: df} do
-      df1 = df |> DF.group_by("year") |> DF.summarise(total: [:max, :min], country: [:n_unique])
+      df1 = df |> DF.group_by("year") |> DF.summarise(total: [:max, :min], country: [:n_distinct])
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                year: [2010, 2011, 2012, 2013, 2014],
                total_min: [1, 2, 2, 2, 3],
                total_max: [2_393_248, 2_654_360, 2_734_817, 2_797_384, 2_806_634],
-               country_n_unique: [217, 217, 220, 220, 220]
+               country_n_distinct: [217, 217, 220, 220, 220]
              }
     end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -214,6 +214,20 @@ defmodule Explorer.DataFrameTest do
       assert DF.to_columns(df1, atom_keys: true) == %{a: [1, 2, 3], b: [9.2, 8.0, 7.1]}
     end
 
+    test "filter with last operation" do
+      df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9.2, 8.0, 7.1, 6.0, 5.0, 4.0, 3.2])
+
+      df1 =
+        DF.filter_with(df, fn ldf ->
+          a = ldf["a"]
+          b = ldf["b"]
+
+          Series.greater(b, Series.last(a))
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [1, 2, 3, 4], b: [9.2, 8.0, 7.1, 6.0]}
+    end
+
     test "raise an error if the last operation is an arithmetic operation" do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -109,7 +109,7 @@ defmodule Explorer.DataFrameTest do
 
       df1 =
         DF.filter_with(df, fn ldf ->
-          Series.nil?(ldf["a"])
+          Series.is_nil(ldf["a"])
         end)
 
       assert DF.to_columns(df1, atom_keys: true) == %{a: [nil, nil], b: [6, 4]}
@@ -120,7 +120,7 @@ defmodule Explorer.DataFrameTest do
 
       df1 =
         DF.filter_with(df, fn ldf ->
-          Series.not_nil?(ldf["a"])
+          Series.is_not_nil(ldf["a"])
         end)
 
       assert DF.to_columns(df1, atom_keys: true) == %{a: [1, 2, 3, 5, 5], b: [9, 8, 7, 5, 3]}
@@ -241,6 +241,17 @@ defmodule Explorer.DataFrameTest do
         end)
 
       assert DF.to_columns(df1, atom_keys: true) == %{a: [nil], b: [4]}
+
+      df2 =
+        DF.filter_with(df, fn ldf ->
+          a = ldf["a"]
+          b = ldf["b"]
+          c = Series.coalesce(a, b)
+
+          Series.is_nil(c)
+        end)
+
+      assert DF.to_columns(df2, atom_keys: true) == %{a: [], b: []}
     end
 
     test "raise an error if the last operation is an arithmetic operation" do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -228,6 +228,21 @@ defmodule Explorer.DataFrameTest do
       assert DF.to_columns(df1, atom_keys: true) == %{a: [1, 2, 3, 4], b: [9.2, 8.0, 7.1, 6.0]}
     end
 
+    test "filter with coalesce operation" do
+      df = DF.new(a: [1, nil, 3, nil], b: [nil, 2, nil, 4])
+
+      df1 =
+        DF.filter_with(df, fn ldf ->
+          a = ldf["a"]
+          b = ldf["b"]
+          c = Series.coalesce(a, b)
+
+          Series.greater(c, 3)
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [nil], b: [4]}
+    end
+
     test "raise an error if the last operation is an arithmetic operation" do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -186,6 +186,34 @@ defmodule Explorer.DataFrameTest do
       assert DF.to_columns(df1, atom_keys: true) == %{a: [2], b: [8.0]}
     end
 
+    test "filter with count operation" do
+      df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9.2, 8.0, 7.1, 6.0, 5.0, 4.0, 3.2])
+
+      df1 =
+        DF.filter_with(df, fn ldf ->
+          a = ldf["a"]
+          b = ldf["b"]
+
+          Series.greater(b, Series.count(a))
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [1, 2, 3], b: [9.2, 8.0, 7.1]}
+    end
+
+    test "filter with max operation" do
+      df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9.2, 8.0, 7.1, 6.0, 5.0, 4.0, 3.2])
+
+      df1 =
+        DF.filter_with(df, fn ldf ->
+          a = ldf["a"]
+          b = ldf["b"]
+
+          Series.greater(b, Series.max(a))
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [1, 2, 3], b: [9.2, 8.0, 7.1]}
+    end
+
     test "raise an error if the last operation is an arithmetic operation" do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
 
@@ -205,7 +233,8 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
 
       message =
-        "expecting the function to return a boolean LazySeries, but instead it returned an aggregation"
+        "expecting the function to return a boolean LazySeries, " <>
+          "but instead it returned a LazySeries of type :integer"
 
       assert_raise ArgumentError, message, fn ->
         DF.filter_with(df, fn ldf ->


### PR DESCRIPTION
This change adds support for operations like: `first`, `last` and `count`
to `filter_with/2` and `summarise_with/2`

Also this:
- removes the restriction for aggregated operations on `filter_with/2`
- renames `n_unique` to `n_distinct`
- renames `nil?/not_nil?` to `is_nil/is_not_nil` (Series)
- fix a small bug in the `Series.coalesce/2` function 
- adds `coalesce` operation to lazy series