### PR TITLE
Normalize how column | columns are handled

### DIFF
--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -8,9 +8,9 @@ defmodule Explorer.Backend.Series do
   @type t :: struct()
 
   @type s :: Explorer.Series.t()
-  @type lazy_s :: Explorer.Series.lazy()
+  @type lazy_s :: Explorer.Series.lazy_t()
   @type df :: Explorer.DataFrame.t()
-  @type dtype :: :integer | :float | :boolean | :string | :date | :datetime
+  @type dtype :: Explorer.Series.dtype()
   @type valid_types :: number() | boolean() | String.t() | Date.t() | NaiveDateTime.t()
 
   # Conversion

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -27,10 +27,8 @@ defmodule Explorer.Series do
 
   @valid_dtypes Explorer.Shared.dtypes()
 
-  @type data :: Explorer.Backend.Series.t()
   @type dtype :: Explorer.Backend.Series.dtype()
-  @type t :: %Series{data: data, dtype: dtype()}
-  @type lazy :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
+  @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}
 
   @enforce_keys [:data, :dtype]
   defstruct [:data, :dtype]

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -27,8 +27,9 @@ defmodule Explorer.Series do
 
   @valid_dtypes Explorer.Shared.dtypes()
 
-  @type dtype :: Explorer.Backend.Series.dtype()
+  @type dtype :: :integer | :float | :boolean | :string | :date | :datetime
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}
+  @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
 
   @enforce_keys [:data, :dtype]
   defstruct [:data, :dtype]


### PR DESCRIPTION
Make sure that we support column | columns on as many
places as possible. In addition, make sure that all of
them can be one of:

  * a list of columns indexes or names as atoms and strings

  * a range

  * a one-arity function that receives column names and returns
    true for column names to keep

  * a two-arity function that receives column names and types and
    returns true for column names to keep

The fourth is a new addition in this PR that can be useful
in functions like dummy.