### PR TITLE
Add `DF.mutate_with` to mutate a DF with lazy series

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -85,6 +85,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback filter(df, mask :: series) :: df
   @callback filter_with(df, out_df :: df(), lazy_series()) :: df
   @callback mutate(df, out_df :: df(), mutations :: [{column_name(), mutate_value()}]) :: df
+  @callback mutate_with(df, out_df :: df(), mutations :: [{column_name(), mutate_value()}]) :: df
   @callback arrange(df, columns :: [column_name() | {:asc | :desc, column_name()}]) :: df
   @callback distinct(df, out_df :: df(), columns :: [column_name()], keep_all? :: boolean()) :: df
   @callback rename(df, out_df :: df()) :: df

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -137,7 +137,11 @@ defmodule Explorer.Backend.LazySeries do
     Backend.Series.new(data, dtype)
   end
 
-  defp dtype_for_agg_operation(op, series) when op in [:sum, :min, :max], do: series.dtype
+  defp dtype_for_agg_operation(:count, _), do: :integer
+
+  defp dtype_for_agg_operation(op, series) when op in [:first, :last, :sum, :min, :max],
+    do: series.dtype
+
   defp dtype_for_agg_operation(_, _), do: :float
 
   defp resolve_numeric_dtype(items) do

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1276,7 +1276,7 @@ defmodule Explorer.DataFrame do
     %{df | names: new_names, dtypes: new_dtypes}
   end
 
-  # TODO: handle case when using groups.
+  @doc false
   def mutate_with(%DataFrame{} = df, fun) when is_function(fun) do
     ldf = to_opaque_lazy(df)
 
@@ -1285,10 +1285,6 @@ defmodule Explorer.DataFrame do
     column_pairs =
       to_column_pairs(df, result, fn value ->
         case value do
-          # %Series{data: %LazySeries{aggregation: true, op: op}} ->
-          #   # TODO: there are some operations that may be accepted here (like first, last and count).
-          #   raise "expecting mutate without an aggregation operation inside. But instead got #{inspect(op)}."
-
           %Series{data: %LazySeries{}} ->
             value
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -308,6 +308,19 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
+  def mutate_with(%DataFrame{groups: []} = df, %DataFrame{} = out_df, column_pairs) do
+    exprs =
+      for {name, lazy_series} <- column_pairs do
+        original_expr = Explorer.PolarsBackend.Expression.to_expr(lazy_series)
+        Explorer.PolarsBackend.Expression.alias_expr(original_expr, name)
+      end
+
+    # groups_exprs = for group <- groups, do: Native.expr_column(group)
+
+    Shared.apply_dataframe(df, out_df, :df_with_column_exprs, [exprs])
+  end
+
+  @impl true
   def arrange(%DataFrame{groups: groups} = df, columns) do
     {directions, columns} =
       columns

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -93,6 +93,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_vstack_many(_df, _others), do: err()
   def df_width(_df), do: err()
   def df_with_columns(_df, _columns), do: err()
+  def df_with_column_exprs(_df, _exprs), do: err()
   def df_write_ipc(_df, _filename, _compression), do: err()
   def df_write_parquet(_df, _filename, _compression, _compression_level), do: err()
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -97,6 +97,7 @@ rustler::init!(
         df_vstack_many,
         df_width,
         df_with_columns,
+        df_with_column_exprs,
         df_write_ipc,
         df_write_parquet,
         // expressions

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -353,6 +353,39 @@ defmodule Explorer.DataFrame.GroupedTest do
     end
   end
 
+  describe "mutate_with/2" do
+    test "adds new columns when there is a group" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"], c: [1, 1, 2])
+
+      df1 = DF.group_by(df, :c)
+
+      df2 =
+        DF.mutate_with(df1, fn ldf ->
+          [d: Series.add(ldf["a"], -7.1), e: Series.count(ldf["c"])]
+        end)
+
+      assert DF.to_columns(df2, atom_keys: true) == %{
+               a: [1, 2, 3],
+               b: ["a", "b", "c"],
+               c: [1, 1, 2],
+               d: [-6.1, -5.1, -4.1],
+               e: [2, 2, 1]
+             }
+
+      assert df2.names == ["a", "b", "c", "d", "e"]
+
+      assert df2.dtypes == %{
+               "a" => :integer,
+               "b" => :string,
+               "c" => :integer,
+               "d" => :float,
+               "e" => :integer
+             }
+
+      assert df2.groups == ["c"]
+    end
+  end
+
   describe "distinct/2" do
     test "with one group", %{df: df} do
       df1 = DF.group_by(df, "year")

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -323,6 +323,66 @@ defmodule Explorer.DataFrameTest do
     end
   end
 
+  describe "mutate_with/2" do
+    test "adds a new column" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+
+      df1 =
+        DF.mutate_with(df, fn ldf ->
+          [c: Series.add(ldf["a"], 5)]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 2, 3],
+               b: ["a", "b", "c"],
+               c: [6, 7, 8]
+             }
+
+      assert df1.names == ["a", "b", "c"]
+      assert df1.dtypes == %{"a" => :integer, "b" => :string, "c" => :integer}
+    end
+
+    test "adds a new column with some aggregations without groups" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+
+      df1 =
+        DF.mutate_with(df, fn ldf ->
+          [
+            c: Series.first(ldf["a"]),
+            d: Series.last(ldf["a"]),
+            e: Series.count(ldf["a"]),
+            f: Series.median(ldf["a"]),
+            g: Series.sum(ldf["a"]),
+            h: Series.min(ldf["a"]) |> Series.add(ldf["a"])
+          ]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 2, 3],
+               b: ["a", "b", "c"],
+               c: [1, 1, 1],
+               d: [3, 3, 3],
+               e: [3, 3, 3],
+               f: [2.0, 2.0, 2.0],
+               g: [6, 6, 6],
+               h: [2, 3, 4]
+             }
+
+      assert df1.names == ["a", "b", "c", "d", "e", "f", "g", "h"]
+
+      assert df1.dtypes == %{
+               "a" => :integer,
+               "b" => :string,
+               "c" => :float,
+               "d" => :float,
+               "e" => :float,
+               "f" => :float,
+               "g" => :integer,
+               "h" => :integer
+             }
+    end
+  end
+
   describe "arrange/3" do
     test "raises with invalid column names", %{df: df} do
       assert_raise ArgumentError,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -373,9 +373,9 @@ defmodule Explorer.DataFrameTest do
       assert df1.dtypes == %{
                "a" => :integer,
                "b" => :string,
-               "c" => :float,
-               "d" => :float,
-               "e" => :float,
+               "c" => :integer,
+               "d" => :integer,
+               "e" => :integer,
                "f" => :float,
                "g" => :integer,
                "h" => :integer


### PR DESCRIPTION
This is one of the parts to implement `mutate_with`. It includes the basic support for
the existing operations and support for groups.

I'm going to add support for window functions in later PRs.