### PR TITLE
Ensure we can compare boolean series

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1657175312,
-        "narHash": "sha256-ZOTtKbL2VDPYJzfKZfPQTx7UdRkIb32fkwU64UOOS+Q=",
+        "lastModified": 1660112944,
+        "narHash": "sha256-6oRTsYGJXjFbcWz3H/1TJDbu2cYoXnYwK8NKfMQNuXU=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "c5933255cadd599e9d1b4b98d801c12a923ff9d8",
+        "rev": "b952fad30060fb7a98613b30e3b4df0d160e492c",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657114324,
-        "narHash": "sha256-fWuaUNXrHcz/ciHRHlcSO92dvV3EVS0GJQUSBO5JIB4=",
+        "lastModified": 1660071133,
+        "narHash": "sha256-XX6T9wcvEZIVWY4TO5O1d2MgFyFrF2v4TpCFs7fjdn8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a5c867d9fe9e4380452628e8f171c26b69fa9d3d",
+        "rev": "36cc29d837e7232e3176e4651e8e117a6f231793",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1657151932,
-        "narHash": "sha256-iql4MrFnUcbA0AY7Eo+jiOwdVo+b1Ts6AFOQMIriiwY=",
+        "lastModified": 1660078984,
+        "narHash": "sha256-EOazwimkZv9fCQ2IwUnUwpykYj7XiILiO7OBzT20xR0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "c296e777675860164f8e45571efd29c4c08ee7cc",
+        "rev": "5366009fe47ab06e53b68811873448de52c5cd8f",
         "type": "github"
       },
       "original": {

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1311,14 +1311,6 @@ defmodule Explorer.Series do
         [true, true, false]
       >
 
-      iex> s1 = Explorer.Series.from_list([true, false, true])
-      iex> s2 = Explorer.Series.from_list([false, false, true])
-      iex> Explorer.Series.equal(s1, s2)
-      #Explorer.Series<
-        boolean[3]
-        [false, true, true]
-      >
-
       iex> s = Explorer.Series.from_list([1, 2, 3])
       iex> Explorer.Series.equal(s, 1)
       #Explorer.Series<

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1311,6 +1311,14 @@ defmodule Explorer.Series do
         [true, true, false]
       >
 
+      iex> s1 = Explorer.Series.from_list([true, false, true])
+      iex> s2 = Explorer.Series.from_list([false, false, true])
+      iex> Explorer.Series.equal(s1, s2)
+      #Explorer.Series<
+        boolean[3]
+        [false, true, true]
+      >
+
       iex> s = Explorer.Series.from_list([1, 2, 3])
       iex> Explorer.Series.equal(s, 1)
       #Explorer.Series<
@@ -1558,9 +1566,8 @@ defmodule Explorer.Series do
     end
   end
 
-  defp valid_for_bool_mask_operation?(%Series{dtype: dtype}, %Series{dtype: dtype})
-       when numeric_or_date_dtype?(dtype),
-       do: true
+  defp valid_for_bool_mask_operation?(%Series{dtype: dtype}, %Series{dtype: dtype}),
+    do: true
 
   defp valid_for_bool_mask_operation?(%Series{dtype: left_dtype}, %Series{dtype: right_dtype})
        when K.and(numeric_dtype?(left_dtype), numeric_dtype?(right_dtype)),

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -48,4 +48,12 @@ defmodule Explorer.SeriesTest do
 
     assert Series.to_list(s2) == [1, 4, 3]
   end
+
+  describe "equal/2" do
+    test "can compare boolean series" do
+      s1 = Series.from_list([true, false, true])
+      s2 = Series.from_list([false, true, true])
+      assert s1 |> Series.equal(s2) |> Series.to_list() == [false, false, true]
+    end
+  end
 end


### PR DESCRIPTION
Came across this one in my own work. I was unable to compare (`equal/2` and `not_equal/2`) boolean series. I don't think we need any guard on `valid_for_bool_mask_operation?` if the dtypes are the same, no?