### PR TITLE
Fix rename of columns after a summarise

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -88,7 +88,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback mutate_with(df, out_df :: df(), mutations :: [{column_name(), mutate_value()}]) :: df
   @callback arrange(df, columns :: [column_name() | {:asc | :desc, column_name()}]) :: df
   @callback distinct(df, out_df :: df(), columns :: [column_name()], keep_all? :: boolean()) :: df
-  @callback rename(df, out_df :: df()) :: df
+  @callback rename(df, out_df :: df(), [{old :: column_name(), new :: column_name()}]) :: df
   @callback dummies(df, columns :: [column_name()]) :: df
   @callback sample(df, n :: integer(), replacement :: boolean(), seed :: integer()) :: df
   @callback pull(df, column :: column_name()) :: series

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1637,8 +1637,7 @@ defmodule Explorer.DataFrame do
             {Map.get(pairs_map, name, name), Map.fetch!(old_dtypes, name)}
           end
 
-        new_names =
-          Enum.map(new_dtypes, &elem(&1, 0))
+        new_names = Enum.map(new_dtypes, &elem(&1, 0))
 
         new_groups =
           for group <- df.groups do

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -225,33 +225,26 @@ defmodule Explorer.DataFrame do
   defp column_index_map(names),
     do: for({name, idx} <- Enum.with_index(names), into: %{}, do: {idx, name})
 
-  # Normalize column names without verifying if they exist.
-  defp to_column_names(names) when is_list(names),
-    do: Enum.map(names, &to_column_name/1)
-
   # Normalize column names and raise if column does not exist.
   defp to_existing_columns(df, columns) when is_list(columns) do
-    existing_columns = df.names
+    {columns, _cache} =
+      Enum.map_reduce(columns, nil, fn
+        column, maybe_map when is_integer(column) ->
+          map = maybe_map || column_index_map(df.names)
+          existing_column = fetch_column_at!(map, column)
+          {existing_column, map}
+
+        column, maybe_map when is_atom(column) ->
+          column = Atom.to_string(column)
+          maybe_raise_column_not_found(df, column)
+          {column, maybe_map}
+
+        column, maybe_map when is_binary(column) ->
+          maybe_raise_column_not_found(df, column)
+          {column, maybe_map}
+      end)
 
     columns
-    |> Enum.map_reduce(nil, fn
-      column, maybe_map when is_integer(column) ->
-        map = maybe_map || column_index_map(existing_columns)
-
-        existing_column = fetch_column_at!(map, column)
-
-        {existing_column, map}
-
-      column, maybe_map when is_atom(column) ->
-        column = Atom.to_string(column)
-        maybe_raise_column_not_found(existing_columns, column)
-        {column, maybe_map}
-
-      column, maybe_map when is_binary(column) ->
-        maybe_raise_column_not_found(existing_columns, column)
-        {column, maybe_map}
-    end)
-    |> then(fn {columns, _} -> columns end)
   end
 
   defp to_existing_columns(%{names: names}, %Range{} = columns) do
@@ -1622,38 +1615,39 @@ defmodule Explorer.DataFrame do
         ) ::
           DataFrame.t()
   def rename(df, [name | _] = names) when is_column_name(name) do
-    new_names = to_column_names(names)
-    check_new_names_length!(df, new_names)
-    mapping = Enum.zip(df.names, new_names)
-
-    dtypes =
-      for {old_name, new_name} <- mapping,
-          do: {new_name, Map.fetch!(df.dtypes, old_name)},
-          into: %{}
-
-    new_groups =
-      mapping
-      |> Map.new()
-      |> then(fn map -> Enum.map(df.groups, fn group -> Map.fetch!(map, group) end) end)
-
-    out_df = %{df | names: new_names, dtypes: dtypes, groups: new_groups}
-
-    Shared.apply_impl(df, :rename, [out_df])
+    check_new_names_length!(df, names)
+    rename(df, Enum.zip(df.names, names))
   end
 
   def rename(df, names) when is_column_pairs(names) do
-    pairs = to_column_pairs(df, names, &to_column_name(&1))
-    old_names = df.names
+    case to_column_pairs(df, names, &to_column_name(&1)) do
+      [] ->
+        df
 
-    for {name, _} <- pairs do
-      maybe_raise_column_not_found(old_names, name)
+      pairs ->
+        pairs_map = Map.new(pairs)
+        old_dtypes = df.dtypes
+
+        for {name, _} <- pairs do
+          maybe_raise_column_not_found(df, name)
+        end
+
+        new_dtypes =
+          for name <- df.names do
+            {Map.get(pairs_map, name, name), Map.fetch!(old_dtypes, name)}
+          end
+
+        new_names =
+          Enum.map(new_dtypes, &elem(&1, 0))
+
+        new_groups =
+          for group <- df.groups do
+            Map.get(pairs_map, group, group)
+          end
+
+        out_df = %{df | names: new_names, dtypes: Map.new(new_dtypes), groups: new_groups}
+        Shared.apply_impl(df, :rename, [out_df, pairs])
     end
-
-    pairs_map = Map.new(pairs)
-
-    old_names
-    |> Enum.map(fn name -> Map.get(pairs_map, name, name) end)
-    |> then(&rename(df, &1))
   end
 
   defp check_new_names_length!(df, names) do
@@ -1740,15 +1734,9 @@ defmodule Explorer.DataFrame do
   end
 
   def rename_with(df, columns, callback) when is_function(callback) do
-    case to_existing_columns(df, columns) do
-      [] ->
-        df
-
-      columns ->
-        df.names
-        |> Enum.map(fn name -> if name in columns, do: callback.(name), else: name end)
-        |> then(&rename(df, &1))
-    end
+    columns = to_existing_columns(df, columns)
+    renames = for name <- df.names, name in columns, do: {name, callback.(name)}
+    rename(df, renames)
   end
 
   @doc """
@@ -2858,13 +2846,13 @@ defmodule Explorer.DataFrame do
     :"#{backend}.DataFrame"
   end
 
-  defp maybe_raise_column_not_found(names, name) do
-    if name not in names,
-      do:
-        raise(
-          ArgumentError,
-          List.to_string(["could not find column name \"#{name}\""] ++ did_you_mean(name, names))
-        )
+  defp maybe_raise_column_not_found(df, name) do
+    unless Map.has_key?(df.dtypes, name) do
+      raise ArgumentError,
+            List.to_string(
+              ["could not find column name \"#{name}\""] ++ did_you_mean(name, df.names)
+            )
+    end
   end
 
   @threshold 0.77

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -386,7 +386,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def rename(%DataFrame{} = df, %DataFrame{} = out_df),
-    do: Shared.apply_dataframe(df, out_df, :df_set_column_names, [out_df.names])
+    do: Shared.apply_dataframe(df, out_df, :df_rename_columns, [Enum.zip(df.names, out_df.names)])
 
   @impl true
   def dummies(df, names),
@@ -435,7 +435,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
       end)
 
     if names != new_names do
-      Shared.apply_dataframe(df, :df_set_column_names, [new_names])
+      Shared.apply_dataframe(df, :df_rename_columns, [Enum.zip(names, new_names)])
     else
       df
     end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -385,8 +385,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def rename(%DataFrame{} = df, %DataFrame{} = out_df),
-    do: Shared.apply_dataframe(df, out_df, :df_rename_columns, [Enum.zip(df.names, out_df.names)])
+  def rename(%DataFrame{} = df, %DataFrame{} = out_df, pairs),
+    do: Shared.apply_dataframe(df, out_df, :df_rename_columns, [pairs])
 
   @impl true
   def dummies(df, names),
@@ -434,12 +434,20 @@ defmodule Explorer.PolarsBackend.DataFrame do
         if name in id_columns, do: name, else: names_prefix <> name
       end)
 
-    if names != new_names do
-      Shared.apply_dataframe(df, :df_rename_columns, [Enum.zip(names, new_names)])
-    else
-      df
+    case zip_diff(names, new_names) do
+      [] -> df
+      renames -> Shared.apply_dataframe(df, :df_rename_columns, [renames])
     end
   end
+
+  defp zip_diff([name | lefties], [name | righties]),
+    do: zip_diff(lefties, righties)
+
+  defp zip_diff([old_name | lefties], [new_name | righties]),
+    do: [{old_name, new_name} | zip_diff(lefties, righties)]
+
+  defp zip_diff([], []),
+    do: []
 
   # Two or more table verbs
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -82,7 +82,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_read_parquet(_filename), do: err()
   def df_select(_df, _selection), do: err()
   def df_select_at_idx(_df, _idx), do: err()
-  def df_set_column_names(_df, _names), do: err()
+  def df_rename_columns(_df, _old_new_pairs), do: err()
   def df_shape(_df), do: err()
   def df_slice(_df, _offset, _length), do: err()
   def df_sort(_df, _by, _reverse, _groups), do: err()

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -546,14 +546,16 @@ pub fn df_new(columns: Vec<ExSeries>) -> Result<ExDataFrame, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn df_set_column_names(
+pub fn df_rename_columns(
     data: ExDataFrame,
-    names: Vec<&str>,
+    renames: Vec<(&str, &str)>,
 ) -> Result<ExDataFrame, ExplorerError> {
-    let df = &data.resource.0;
-    let mut new_df = df.clone();
-    new_df.set_column_names(&names)?;
-    Ok(ExDataFrame::new(new_df))
+    let mut df: DataFrame = data.resource.0.clone();
+    for (original, new_name) in renames {
+        df.rename(original, new_name).expect("should rename");
+    }
+
+    Ok(ExDataFrame::new(df))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -84,7 +84,7 @@ rustler::init!(
         df_write_ndjson,
         df_select,
         df_select_at_idx,
-        df_set_column_names,
+        df_rename_columns,
         df_shape,
         df_slice,
         df_sort,

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -109,7 +109,7 @@ defmodule Explorer.DataFrame.GroupedTest do
              }
     end
 
-    test "pivote_wider and then summarise with a rename" do
+    test "pivot_wider and then summarise with a rename" do
       df =
         DF.new(
           names: ["cou", "adv", "spo", "cou", "adv", "spo"],

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -109,6 +109,26 @@ defmodule Explorer.DataFrame.GroupedTest do
              }
     end
 
+    test "pivote_wider and then summarise with a rename" do
+      df =
+        DF.new(
+          names: ["cou", "adv", "spo", "cou", "adv", "spo"],
+          val: [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+          team: ["A", "A", "A", "B", "B", "B"]
+        )
+
+      df2 =
+        df
+        |> DF.pivot_wider("names", "val")
+        |> DF.group_by("team")
+        |> DF.summarise(%{"adv" => [:max], "cou" => [:max], "spo" => [:max]})
+        |> DF.rename(cou_max: "cou", adv_max: "adv", spo_max: "spo")
+
+      assert Series.to_list(df2["cou"]) == [1.0, 4.0]
+      assert Series.to_list(df2["adv"]) == [2.0, 5.0]
+      assert Series.to_list(df2["spo"]) == [3.0, 6.0]
+    end
+
     test "with two groups and two columns with aggregations", %{df: df} do
       equal_filters =
         for country <- ["BRAZIL", "AUSTRALIA", "POLAND"], do: Series.equal(df["country"], country)


### PR DESCRIPTION
We can´t be sure the order of columns after a summarise is performed by
polars. So using a proper `rename` makes sure that we are rename the
correct - named - column.

Fixes https://github.com/elixir-nx/explorer/issues/310