### PR TITLE
Add window function operations to LazySeries

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -35,6 +35,9 @@ defmodule Explorer.Backend.LazySeries do
     # Slice and dice
     coalesce: 2,
     # Window functions
+    cumulative_max: 2,
+    cumulative_min: 2,
+    cumulative_sum: 2,
     window_max: 5,
     window_mean: 5,
     window_min: 5,
@@ -60,6 +63,8 @@ defmodule Explorer.Backend.LazySeries do
   @aggregation_operations [:sum, :min, :max, :mean, :median, :var, :std, :count, :first, :last]
 
   @window_fun_operations [:window_max, :window_mean, :window_min, :window_sum]
+
+  @cumulative_operations [:cumulative_max, :cumulative_min, :cumulative_sum]
 
   @doc false
   def new(op, args, aggregation \\ false, window \\ false) do
@@ -132,6 +137,16 @@ defmodule Explorer.Backend.LazySeries do
       data = new(unquote(op), args, aggregations?(args), true)
 
       # TODO: dtype may change in case weights is float
+      Backend.Series.new(data, series.dtype)
+    end
+  end
+
+  for op <- @cumulative_operations do
+    @impl true
+    def unquote(op)(%Series{} = series, reverse) do
+      args = [lazy_series!(series), reverse]
+      data = new(unquote(op), args, aggregations?(args), true)
+
       Backend.Series.new(data, series.dtype)
     end
   end

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -63,7 +63,6 @@ defmodule Explorer.Backend.LazySeries do
   @aggregation_operations [:sum, :min, :max, :mean, :median, :var, :std, :count, :first, :last]
 
   @window_fun_operations [:window_max, :window_mean, :window_min, :window_sum]
-
   @cumulative_operations [:cumulative_max, :cumulative_min, :cumulative_sum]
 
   @doc false
@@ -73,6 +72,9 @@ defmodule Explorer.Backend.LazySeries do
 
   @doc false
   def operations, do: @operations
+
+  @doc false
+  def window_operations, do: @cumulative_operations ++ @window_fun_operations
 
   # Implements all the comparison operations that
   # accepts Series or number on the right-hand side.

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -34,6 +34,8 @@ defmodule Explorer.Backend.LazySeries do
     pow: 2,
     # Slice and dice
     coalesce: 2,
+    # Window functions
+    window_max: 5,
     # Aggregations
     sum: 1,
     min: 1,

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2763,11 +2763,7 @@ defmodule Explorer.DataFrame do
     column_pairs =
       to_column_pairs(df, result, fn value ->
         case value do
-          %Series{data: %LazySeries{aggregation: true} = lazy} ->
-            if lazy.window and lazy.op in LazySeries.window_operations() do
-              raise "expecting an aggregation operation, but instead got a window function operation: #{inspect(lazy.op)}."
-            end
-
+          %Series{data: %LazySeries{aggregation: true}} ->
             value
 
           %Series{data: %LazySeries{op: op}} ->

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2763,7 +2763,11 @@ defmodule Explorer.DataFrame do
     column_pairs =
       to_column_pairs(df, result, fn value ->
         case value do
-          %Series{data: %LazySeries{aggregation: true}} ->
+          %Series{data: %LazySeries{aggregation: true} = lazy} ->
+            if lazy.window and lazy.op in LazySeries.window_operations() do
+              raise "expecting an aggregation operation, but instead got a window function operation: #{inspect(lazy.op)}."
+            end
+
             value
 
           %Series{data: %LazySeries{op: op}} ->

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -11,7 +11,15 @@ defmodule Explorer.PolarsBackend.Expression do
 
   @type t :: %__MODULE__{resource: binary(), reference: reference()}
 
-  @window_operations [window_max: 5, window_mean: 5, window_min: 5, window_sum: 5]
+  @window_operations [
+    cumulative_max: 2,
+    cumulative_min: 2,
+    cumulative_sum: 2,
+    window_max: 5,
+    window_mean: 5,
+    window_min: 5,
+    window_sum: 5
+  ]
   @special_operations [column: 1, quantile: 2] ++ @window_operations
 
   # Some operations are special because they don't receive all args as lazy series.

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -11,14 +11,33 @@ defmodule Explorer.PolarsBackend.Expression do
 
   @type t :: %__MODULE__{resource: binary(), reference: reference()}
 
-  # Column is special
+  @window_operations [window_max: 5, window_mean: 5, window_min: 5, window_sum: 5]
+  @special_operations [column: 1, quantile: 2] ++ @window_operations
+
+  # Some operations are special because they don't receive all args as lazy series.
+  # We define them first.
   def to_expr(%LazySeries{op: :column, args: [name]}) do
     Native.expr_column(name)
   end
 
+  def to_expr(%LazySeries{op: :quantile, args: [lazy_series, quantile]}) do
+    expr = to_expr(lazy_series)
+    Native.expr_quantile(expr, quantile)
+  end
+
+  for {op, _arity} <- @window_operations do
+    expr_op = :"expr_#{op}"
+
+    def to_expr(%LazySeries{op: unquote(op), args: [lazy_series | args]}) do
+      expr = to_expr(lazy_series)
+
+      apply(Native, unquote(expr_op), [expr | args])
+    end
+  end
+
   # We are going to generate all functions for each valid operation.
   for {op, arity} <-
-        Explorer.Backend.LazySeries.operations() -- [column: 1] do
+        Explorer.Backend.LazySeries.operations() -- @special_operations do
     args = Macro.generate_arguments(arity, __MODULE__)
 
     updates =

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -288,20 +288,20 @@ init_window_expr_fun!(expr_window_mean, rolling_mean);
 
 #[rustler::nif]
 pub fn expr_cumulative_min(data: ExExpr, reverse: bool) -> ExExpr {
-  let expr: Expr = data.resource.0.clone();
-  ExExpr::new(expr.cummin(reverse))
+    let expr: Expr = data.resource.0.clone();
+    ExExpr::new(expr.cummin(reverse))
 }
 
 #[rustler::nif]
 pub fn expr_cumulative_max(data: ExExpr, reverse: bool) -> ExExpr {
-  let expr: Expr = data.resource.0.clone();
-  ExExpr::new(expr.cummax(reverse))
+    let expr: Expr = data.resource.0.clone();
+    ExExpr::new(expr.cummax(reverse))
 }
 
 #[rustler::nif]
 pub fn expr_cumulative_sum(data: ExExpr, reverse: bool) -> ExExpr {
-  let expr: Expr = data.resource.0.clone();
-  ExExpr::new(expr.cumsum(reverse))
+    let expr: Expr = data.resource.0.clone();
+    ExExpr::new(expr.cumsum(reverse))
 }
 
 #[rustler::nif]

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -5,10 +5,11 @@
 // wrapped in an Elixir struct.
 
 use chrono::{NaiveDate, NaiveDateTime};
-use polars::prelude::{col, when, DataFrame, IntoLazy, Duration, RollingOptions};
+use polars::prelude::{col, when, DataFrame, IntoLazy};
 use polars::prelude::{Expr, Literal};
 
 use crate::datatypes::{ExDate, ExDateTime};
+use crate::series::rolling_opts;
 use crate::{ExDataFrame, ExExpr};
 
 #[rustler::nif]
@@ -273,20 +274,8 @@ pub fn expr_window_max(
     center: bool,
 ) -> ExExpr {
     let expr: Expr = data.resource.0.clone();
-    let min_periods = if let Some(mp) = min_periods {
-        mp
-    } else {
-        window_size
-    };
-    let window_size_duration = Duration::new(window_size as i64);
-    let rolling_opts = RollingOptions {
-        window_size: window_size_duration,
-        weights,
-        min_periods,
-        center,
-        ..Default::default()
-    };
-    ExExpr::new(expr.rolling_max(rolling_opts))
+    let opts = rolling_opts(window_size, weights, min_periods, center);
+    ExExpr::new(expr.rolling_max(opts))
 }
 
 #[rustler::nif]

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -287,6 +287,24 @@ init_window_expr_fun!(expr_window_sum, rolling_sum);
 init_window_expr_fun!(expr_window_mean, rolling_mean);
 
 #[rustler::nif]
+pub fn expr_cumulative_min(data: ExExpr, reverse: bool) -> ExExpr {
+  let expr: Expr = data.resource.0.clone();
+  ExExpr::new(expr.cummin(reverse))
+}
+
+#[rustler::nif]
+pub fn expr_cumulative_max(data: ExExpr, reverse: bool) -> ExExpr {
+  let expr: Expr = data.resource.0.clone();
+  ExExpr::new(expr.cummax(reverse))
+}
+
+#[rustler::nif]
+pub fn expr_cumulative_sum(data: ExExpr, reverse: bool) -> ExExpr {
+  let expr: Expr = data.resource.0.clone();
+  ExExpr::new(expr.cumsum(reverse))
+}
+
+#[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
     let df: DataFrame = data.resource.0.clone();
     let expressions: Expr = expr.resource.0.clone();

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -140,6 +140,9 @@ rustler::init!(
         expr_first,
         expr_last,
         // window expressions
+        expr_cumulative_max,
+        expr_cumulative_min,
+        expr_cumulative_sum,
         expr_window_max,
         expr_window_mean,
         expr_window_min,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -141,6 +141,9 @@ rustler::init!(
         expr_last,
         // window expressions
         expr_window_max,
+        expr_window_mean,
+        expr_window_min,
+        expr_window_sum,
         // inspect expressions
         expr_describe_filter_plan,
         // lazyframe

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -139,6 +139,8 @@ rustler::init!(
         expr_count,
         expr_first,
         expr_last,
+        // window expressions
+        expr_window_max,
         // inspect expressions
         expr_describe_filter_plan,
         // lazyframe

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -359,22 +359,9 @@ pub fn s_rolling_sum(
     min_periods: Option<usize>,
     center: bool,
 ) -> Result<ExSeries, ExplorerError> {
-    let min_periods = if let Some(mp) = min_periods {
-        mp
-    } else {
-        window_size
-    };
-    let window_size_duration = Duration::new(window_size as i64);
-
-    let s = &data.resource.0;
-    let rolling_opts = RollingOptions {
-        window_size: window_size_duration,
-        weights,
-        min_periods,
-        center,
-        ..Default::default()
-    };
-    let s1 = s.rolling_sum(rolling_opts.into())?;
+    let s: &Series = &data.resource.0;
+    let opts = rolling_opts(window_size, weights, min_periods, center);
+    let s1 = s.rolling_sum(opts.into())?;
     Ok(ExSeries::new(s1))
 }
 
@@ -386,22 +373,9 @@ pub fn s_rolling_mean(
     min_periods: Option<usize>,
     center: bool,
 ) -> Result<ExSeries, ExplorerError> {
-    let min_periods = if let Some(mp) = min_periods {
-        mp
-    } else {
-        window_size
-    };
-    let window_size_duration = Duration::new(window_size as i64);
-
-    let s = &data.resource.0;
-    let rolling_opts = RollingOptions {
-        window_size: window_size_duration,
-        min_periods,
-        weights,
-        center,
-        ..Default::default()
-    };
-    let s1 = s.rolling_mean(rolling_opts.into())?;
+    let s: &Series = &data.resource.0;
+    let opts = rolling_opts(window_size, weights, min_periods, center);
+    let s1 = s.rolling_mean(opts.into())?;
     Ok(ExSeries::new(s1))
 }
 
@@ -413,21 +387,9 @@ pub fn s_rolling_max(
     min_periods: Option<usize>,
     center: bool,
 ) -> Result<ExSeries, ExplorerError> {
-    let min_periods = if let Some(mp) = min_periods {
-        mp
-    } else {
-        window_size
-    };
-    let s = &data.resource.0;
-    let window_size_duration = Duration::new(window_size as i64);
-    let rolling_opts = RollingOptions {
-        window_size: window_size_duration,
-        weights,
-        min_periods,
-        center,
-        ..Default::default()
-    };
-    let s1 = s.rolling_max(rolling_opts.into())?;
+    let s: &Series = &data.resource.0;
+    let opts = rolling_opts(window_size, weights, min_periods, center);
+    let s1 = s.rolling_max(opts.into())?;
     Ok(ExSeries::new(s1))
 }
 
@@ -439,22 +401,33 @@ pub fn s_rolling_min(
     min_periods: Option<usize>,
     center: bool,
 ) -> Result<ExSeries, ExplorerError> {
+    let s: &Series = &data.resource.0;
+    let opts = rolling_opts(window_size, weights, min_periods, center);
+    let s1 = s.rolling_min(opts.into())?;
+    Ok(ExSeries::new(s1))
+}
+
+// Used for rolling functions - also see "expressions" module
+pub fn rolling_opts(
+    window_size: usize,
+    weights: Option<Vec<f64>>,
+    min_periods: Option<usize>,
+    center: bool,
+) -> RollingOptions {
     let min_periods = if let Some(mp) = min_periods {
         mp
     } else {
         window_size
     };
     let window_size_duration = Duration::new(window_size as i64);
-    let s = &data.resource.0;
-    let rolling_opts = RollingOptions {
+
+    RollingOptions {
         window_size: window_size_duration,
         weights,
         min_periods,
         center,
         ..Default::default()
-    };
-    let s1 = s.rolling_min(rolling_opts.into())?;
-    Ok(ExSeries::new(s1))
+    }
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -374,8 +374,7 @@ defmodule Explorer.DataFrame.GroupedTest do
     end
 
     test "with one group and one window function with one aggregation inside", %{df: df} do
-      message =
-        "expecting an aggregation operation, but instead got a window function operation: :window_mean."
+      message = "it's not possible to have an aggregation operation inside a window function"
 
       assert_raise RuntimeError, message, fn ->
         df

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -417,7 +417,11 @@ defmodule Explorer.DataFrame.GroupedTest do
             b: Series.window_max(a, 2, weights: [1.0, 2.0]),
             c: Series.window_mean(a, 2, weights: [1.0, 2.0]),
             d: Series.window_min(a, 2, weights: [1.0, 2.0]),
-            e: Series.window_sum(a, 2, weights: [1.0, 2.0])
+            e: Series.window_sum(a, 2, weights: [1.0, 2.0]),
+            f: Series.cumulative_max(a),
+            g: Series.cumulative_min(a),
+            h: Series.cumulative_sum(a),
+            i: Series.cumulative_max(a, reverse: true)
           ]
         end)
 
@@ -427,6 +431,10 @@ defmodule Explorer.DataFrame.GroupedTest do
                c: [1.0, 2.5, 4.0, 5.5, 7.0, 6.0, 10.0, 11.5, 13.0, 14.5],
                d: [1.0, 1.0, 2.0, 3.0, 4.0, 6.0, 6.0, 7.0, 8.0, 9.0],
                e: [1.0, 5.0, 8.0, 11.0, 14.0, 6.0, 20.0, 23.0, 26.0, 29.0],
+               f: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+               g: [1, 1, 1, 1, 1, 6, 6, 6, 6, 6],
+               h: [1, 3, 6, 10, 15, 6, 13, 21, 30, 40],
+               i: [5, 5, 5, 5, 5, 10, 10, 10, 10, 10],
                z: [1, 1, 1, 1, 1, 2, 2, 2, 2, 2]
              }
     end

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -374,7 +374,9 @@ defmodule Explorer.DataFrame.GroupedTest do
     end
 
     test "with one group and one window function with one aggregation inside", %{df: df} do
-      message = "it's not possible to have an aggregation operation inside a window function"
+      message =
+        "it's not possible to have an aggregation operation inside :window_mean, " <>
+          "which is a window function"
 
       assert_raise RuntimeError, message, fn ->
         df

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -423,6 +423,18 @@ defmodule Explorer.DataFrameTest do
           ]
         end)
 
+      assert df1.dtypes == %{
+               "a" => :integer,
+               "b" => :float,
+               "c" => :float,
+               "d" => :float,
+               "e" => :float,
+               "f" => :integer,
+               "g" => :integer,
+               "h" => :integer,
+               "i" => :integer
+             }
+
       assert DF.to_columns(df1, atom_keys: true) == %{
                a: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
                b: [1.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0],

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -398,7 +398,11 @@ defmodule Explorer.DataFrameTest do
             b: Series.window_max(a, 2, weights: [1.0, 2.0]),
             c: Series.window_mean(a, 2, weights: [1.0, 2.0]),
             d: Series.window_min(a, 2, weights: [1.0, 2.0]),
-            e: Series.window_sum(a, 2, weights: [1.0, 2.0])
+            e: Series.window_sum(a, 2, weights: [1.0, 2.0]),
+            f: Series.cumulative_max(a),
+            g: Series.cumulative_min(a),
+            h: Series.cumulative_sum(a),
+            i: Series.cumulative_max(a, reverse: true)
           ]
         end)
 
@@ -407,7 +411,11 @@ defmodule Explorer.DataFrameTest do
                b: [1.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0],
                c: [1.0, 2.5, 4.0, 5.5, 7.0, 8.5, 10.0, 11.5, 13.0, 14.5],
                d: [1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
-               e: [1.0, 5.0, 8.0, 11.0, 14.0, 17.0, 20.0, 23.0, 26.0, 29.0]
+               e: [1.0, 5.0, 8.0, 11.0, 14.0, 17.0, 20.0, 23.0, 26.0, 29.0],
+               f: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+               g: [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+               h: [1, 3, 6, 10, 15, 21, 28, 36, 45, 55],
+               i: [10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
              }
     end
   end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -347,13 +347,16 @@ defmodule Explorer.DataFrameTest do
 
       df1 =
         DF.mutate_with(df, fn ldf ->
+          a = ldf["a"]
+
           [
-            c: Series.first(ldf["a"]),
-            d: Series.last(ldf["a"]),
-            e: Series.count(ldf["a"]),
-            f: Series.median(ldf["a"]),
-            g: Series.sum(ldf["a"]),
-            h: Series.min(ldf["a"]) |> Series.add(ldf["a"])
+            c: Series.first(a),
+            d: Series.last(a),
+            e: Series.count(a),
+            f: Series.median(a),
+            g: Series.sum(a),
+            h: Series.min(a) |> Series.add(a),
+            i: Series.quantile(a, 0.2)
           ]
         end)
 
@@ -365,10 +368,11 @@ defmodule Explorer.DataFrameTest do
                e: [3, 3, 3],
                f: [2.0, 2.0, 2.0],
                g: [6, 6, 6],
-               h: [2, 3, 4]
+               h: [2, 3, 4],
+               i: [1, 1, 1]
              }
 
-      assert df1.names == ["a", "b", "c", "d", "e", "f", "g", "h"]
+      assert df1.names == ["a", "b", "c", "d", "e", "f", "g", "h", "i"]
 
       assert df1.dtypes == %{
                "a" => :integer,
@@ -378,7 +382,32 @@ defmodule Explorer.DataFrameTest do
                "e" => :integer,
                "f" => :float,
                "g" => :integer,
-               "h" => :integer
+               "h" => :integer,
+               "i" => :integer
+             }
+    end
+
+    test "adds some columns with window functions" do
+      df = DF.new(a: Enum.to_list(1..10))
+
+      df1 =
+        DF.mutate_with(df, fn ldf ->
+          a = ldf["a"]
+
+          [
+            b: Series.window_max(a, 2, weights: [1.0, 2.0]),
+            c: Series.window_mean(a, 2, weights: [1.0, 2.0]),
+            d: Series.window_min(a, 2, weights: [1.0, 2.0]),
+            e: Series.window_sum(a, 2, weights: [1.0, 2.0])
+          ]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+               b: [1.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0],
+               c: [1.0, 2.5, 4.0, 5.5, 7.0, 8.5, 10.0, 11.5, 13.0, 14.5],
+               d: [1.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0],
+               e: [1.0, 5.0, 8.0, 11.0, 14.0, 17.0, 20.0, 23.0, 26.0, 29.0]
              }
     end
   end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -254,6 +254,23 @@ defmodule Explorer.DataFrameTest do
       assert DF.to_columns(df2, atom_keys: true) == %{a: [], b: []}
     end
 
+    test "filter with window operation" do
+      df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9.2, 8.0, 7.1, 6.0, 5.0, 4.0, 3.2])
+
+      df1 =
+        DF.filter_with(df, fn ldf ->
+          a = ldf["a"]
+          c = Series.window_mean(a, 3)
+
+          Series.greater(a, c)
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [2, 3, 4, 5, 6],
+               b: [8.0, 7.1, 6.0, 5.0, 4.0]
+             }
+    end
+
     test "raise an error if the last operation is an arithmetic operation" do
       df = DF.new(a: [1, 2, 3, 4, 5, 6, 5], b: [9, 8, 7, 6, 5, 4, 3])
 


### PR DESCRIPTION
This is related to https://github.com/elixir-nx/explorer/issues/289

All the `window_` and `cumulative_` function were added. We also have a restriction for `summarise`, to only work with window function if they are not at the root of the operation tree.