### PR TITLE
Improve datasets reads by caching them

### DIFF
--- a/lib/explorer/datasets.ex
+++ b/lib/explorer/datasets.ex
@@ -56,8 +56,7 @@ defmodule Explorer.Datasets do
     # Persistent term is used as a cache, in order to avoid
     # several calls to the filesystem. This is mostly useful
     # to speed up reads in tests.
-    :persistent_term.get(key, nil)
-    |> then(fn
+    case :persistent_term.get(key, nil) do
       nil ->
         @datasets_dir
         |> Path.join("#{name}.csv")
@@ -70,6 +69,6 @@ defmodule Explorer.Datasets do
       {names, df_as_map} ->
         data = for name <- names, do: {name, Map.fetch!(df_as_map, name)}
         DataFrame.new(data)
-    end)
+    end
   end
 end

--- a/lib/explorer/datasets.ex
+++ b/lib/explorer/datasets.ex
@@ -61,14 +61,10 @@ defmodule Explorer.Datasets do
         @datasets_dir
         |> Path.join("#{name}.csv")
         |> DataFrame.from_csv!()
-        |> tap(fn df ->
-          df_as_map = DataFrame.to_columns(df)
-          :persistent_term.put(key, {df.names, df_as_map})
-        end)
+        |> tap(&:persistent_term.put(key, &1))
 
-      {names, df_as_map} ->
-        data = for name <- names, do: {name, Map.fetch!(df_as_map, name)}
-        DataFrame.new(data)
+      %DataFrame{} = df ->
+        df
     end
   end
 end


### PR DESCRIPTION
This change makes the read of datasets (from the Explorer.Datasets
module) way faster, because it avoids touching the filesystem too often.

### Before
![before-persistent-term-explorer](https://user-images.githubusercontent.com/381213/185486017-fa2e41a9-37e4-4d6c-96d7-05a621ac2ff6.gif)

### After

![after-persistent-term-explorer-2](https://user-images.githubusercontent.com/381213/185486046-2d24574c-215e-401c-b8a2-e4354526733a.gif)

