### PR TITLE
Raise if `DF.pivot_wider/4` has floats as ID columns

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2185,9 +2185,11 @@ defmodule Explorer.DataFrame do
     with existing variables. May accept a filter callback, a list or a range of column names.
     Default value is `0..-1`. If an empty list is passed, or a range that results in a empty list of
     column names, it raises an error.
-    ID columns cannot be of the float type. So if there is any column name whose type is float, it
-    raises an error. In case you need to consider a float column, please try to cast it to an integer
-    or string column before.
+
+    ID columns cannot be of the float type and attempting so will raise an error.
+    If you need to use float columns as IDs, you must carefully consider rounding
+    or truncating the column and converting it to integer, as long as doing so
+    preserves the properties of the column.
 
   * `names_prefix` - String added to the start of every variable name.
     This is particularly useful if `names_from` is a numeric vector and you want to create syntactic variable names.

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2185,6 +2185,9 @@ defmodule Explorer.DataFrame do
     with existing variables. May accept a filter callback, a list or a range of column names.
     Default value is `0..-1`. If an empty list is passed, or a range that results in a empty list of
     column names, it raises an error.
+    ID columns cannot be of the float type. So if there is any column name whose type is float, it
+    raises an error. In case you need to consider a float column, please try to cast it to an integer
+    or string column before.
 
   * `names_prefix` - String added to the start of every variable name.
     This is particularly useful if `names_from` is a numeric vector and you want to create syntactic variable names.
@@ -2223,7 +2226,14 @@ defmodule Explorer.DataFrame do
 
     if id_columns == [] do
       raise ArgumentError,
-            "id_columns must select at least one existing column, but #{inspect(opts[:id_columns])} selects none"
+            "id_columns must select at least one existing column, but #{inspect(opts[:id_columns])} selects none."
+    end
+
+    for column_name <- id_columns do
+      if df.dtypes[column_name] == :float do
+        raise ArgumentError,
+              "id_columns cannot have columns of the type float, but #{inspect(column_name)} column is float."
+      end
     end
 
     Shared.apply_impl(df, :pivot_wider, [id_columns, names_from, values_from, opts[:names_prefix]])

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1549,7 +1549,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(id: [1, 1], variable: ["a", "b"], value: [1, 2], other_id: [4, 5])
 
       assert_raise ArgumentError,
-                   "id_columns must select at least one existing column, but [] selects none",
+                   "id_columns must select at least one existing column, but [] selects none.",
                    fn ->
                      DF.pivot_wider(df, "variable", "value", id_columns: [])
                    end
@@ -1560,6 +1560,22 @@ defmodule Explorer.DataFrameTest do
                      DF.pivot_wider(df, "variable", "value",
                        id_columns: &String.starts_with?(&1, "none")
                      )
+                   end
+    end
+
+    test "with an id column of type float" do
+      df = DF.new(float_id: [1.5, 1.6], variable: ["a", "b"], value: [1, 2])
+
+      assert_raise ArgumentError,
+                   "id_columns cannot have columns of the type float, but \"float_id\" column is float.",
+                   fn ->
+                     DF.pivot_wider(df, "variable", "value")
+                   end
+
+      assert_raise ArgumentError,
+                   "id_columns cannot have columns of the type float, but \"float_id\" column is float.",
+                   fn ->
+                     DF.pivot_wider(df, "variable", "value", id_columns: [:float_id])
                    end
     end
   end


### PR DESCRIPTION
This change makes more explicit that we are not expecting ID columns as
floats, because floats are harder to compare (`NaN` and `Infinity` things).

This should fix https://github.com/elixir-nx/explorer/issues/312