### PR TITLE
Add docs to the `_with` dataframe functions

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -17,6 +17,9 @@ defmodule Explorer.Backend.LazySeries do
   @operations [
     cast: 2,
     column: 1,
+    reverse: 1,
+    argsort: 2,
+    sort: 2,
     # Comparisons
     eq: 2,
     neq: 2,
@@ -97,6 +100,30 @@ defmodule Explorer.Backend.LazySeries do
     data = new(:cast, args, aggregations?(args), window_functions?(args))
 
     Backend.Series.new(data, dtype)
+  end
+
+  @impl true
+  def reverse(%Series{} = s) do
+    args = [lazy_series!(s)]
+    data = new(:reverse, args, aggregations?(args), window_functions?(args))
+
+    Backend.Series.new(data, s.dtype)
+  end
+
+  @impl true
+  def argsort(%Series{} = s, reverse?) do
+    args = [lazy_series!(s), reverse?]
+    data = new(:argsort, args, aggregations?(args), window_functions?(args))
+
+    Backend.Series.new(data, :integer)
+  end
+
+  @impl true
+  def sort(%Series{} = s, reverse?) do
+    args = [lazy_series!(s), reverse?]
+    data = new(:sort, args, aggregations?(args), window_functions?(args))
+
+    Backend.Series.new(data, s.dtype)
   end
 
   # Implements all the comparison operations that

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -49,6 +49,7 @@ defmodule Explorer.Backend.LazySeries do
     max: 1,
     mean: 1,
     median: 1,
+    n_distinct: 1,
     var: 1,
     std: 1,
     quantile: 2,
@@ -61,7 +62,19 @@ defmodule Explorer.Backend.LazySeries do
 
   @arithmetic_operations [:add, :subtract, :multiply, :divide, :pow]
 
-  @aggregation_operations [:sum, :min, :max, :mean, :median, :var, :std, :count, :first, :last]
+  @aggregation_operations [
+    :sum,
+    :min,
+    :max,
+    :mean,
+    :median,
+    :var,
+    :std,
+    :count,
+    :first,
+    :last,
+    :n_distinct
+  ]
 
   @window_fun_operations [:window_max, :window_mean, :window_min, :window_sum]
   @cumulative_operations [:cumulative_max, :cumulative_min, :cumulative_sum]

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -15,6 +15,7 @@ defmodule Explorer.Backend.LazySeries do
   @type t :: %__MODULE__{op: atom(), args: list(), aggregation: boolean(), window: boolean()}
 
   @operations [
+    cast: 2,
     column: 1,
     # Comparisons
     eq: 2,
@@ -89,6 +90,14 @@ defmodule Explorer.Backend.LazySeries do
 
   @doc false
   def window_operations, do: @cumulative_operations ++ @window_fun_operations
+
+  @impl true
+  def cast(%Series{} = s, dtype) when is_atom(dtype) do
+    args = [lazy_series!(s), dtype]
+    data = new(:cast, args, aggregations?(args), window_functions?(args))
+
+    Backend.Series.new(data, dtype)
+  end
 
   # Implements all the comparison operations that
   # accepts Series or number on the right-hand side.

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -96,7 +96,7 @@ defmodule Explorer.Backend.Series do
 
   @callback distinct(s) :: s
   @callback unordered_distinct(s) :: s
-  @callback n_distinct(s) :: integer()
+  @callback n_distinct(s) :: integer() | lazy_s()
   @callback count(s) :: df | lazy_s()
 
   # Rolling

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -74,7 +74,7 @@ defmodule Explorer.DataFrame do
   - `summarise_with/2`
   - `mutate_with/2`
   - `arrange_with/2`
-  
+
   Those functions work by having a "lazy" representation of the dataframe and series,
   which adds the possibility to perform complex operations that are optimized by the backend.
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1146,18 +1146,7 @@ defmodule Explorer.DataFrame do
 
   This function is efficient because it uses a representation of the
   series without pulling them. The only restriction is that
-  you need to use one of the following functions to perform a comparison:
-
-    - `Explorer.Series.equal/2`
-    - `Explorer.Series.not_equal/2`
-    - `Explorer.Series.greater/2`
-    - `Explorer.Series.greater_equal/2`
-    - `Explorer.Series.less/2`
-    - `Explorer.Series.less_equal/2`
-    - `Explorer.Series.is_nil/1`
-    - `Explorer.Series.is_not_nil/1`
-    - `Explorer.Series.and/2`
-    - `Explorer.Series.or/2`
+  you need to use a function that returns boolean.
 
   But you can also use window functions and aggregations inside comparisons.
 
@@ -1183,7 +1172,7 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.filter_with(df, fn df -> Explorer.Series.cumulative_max(df["col2"]) end)
       ** (ArgumentError) expecting the function to return a boolean LazySeries, but instead it returned a LazySeries of type :integer
      
-      But it's possible to use a boolean operation based on another function:
+  But it's possible to use a boolean operation based on another function:
 
       iex> df = Explorer.DataFrame.new(col1: ["a", "b", "c"], col2: [1, 2, 3])
       iex> Explorer.DataFrame.filter_with(df, fn df -> Explorer.Series.equal(Explorer.Series.cumulative_max(df["col2"]), 1) end)

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -27,14 +27,23 @@ defmodule Explorer.DataFrame do
 
   ## Creating dataframes
 
-  Dataframes can be created from normal Elixir objects. The main ways you might do this are
-  `from_columns/1` and `from_rows/1`. For example:
+  Dataframes can be created from normal Elixir objects. The main way you might do this is
+  with the `new/1` function. For example:
 
       iex> Explorer.DataFrame.new(a: ["a", "b"], b: [1, 2])
       #Explorer.DataFrame<
         Polars[2 x 2]
         a string ["a", "b"]
         b integer [1, 2]
+      >
+
+  Or with a list of maps:
+
+      iex> Explorer.DataFrame.new([%{"col1" => "a", "col2" => 1}, %{"col1" => "b", "col2" => 2}])
+      #Explorer.DataFrame<
+        Polars[2 x 2]
+        col1 string ["a", "b"]
+        col2 integer [1, 2]
       >
 
   ## Verbs
@@ -58,6 +67,16 @@ defmodule Explorer.DataFrame do
   - `pivot_longer/3` and `pivot_wider/4` for massaging dataframes into longer or wider forms, respectively
 
   Each of these combine with `Explorer.DataFrame.group_by/2` for operating by group.
+
+  For more flexibility we also have functions that accept callback functions:
+
+  - `filter_with/2`
+  - `summarise_with/2`
+  - `mutate_with/2`
+  - `arrange_with/2`
+  
+  Those functions work by having a "lazy" representation of the dataframe and series,
+  which adds the possibility to perform complex operations that are optimized by the backend.
 
   ### Multiple table verbs
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1125,9 +1125,22 @@ defmodule Explorer.DataFrame do
   @doc """
   Picks rows based on a callback function. 
 
-  This function is efficient because uses a representation of the
+  This function is efficient because it uses a representation of the
   series without pulling them. The only restriction is that
-  you need to use one of the boolean series functions.
+  you need to use one of the following functions to perform a comparison:
+
+    - `Explorer.Series.equal/2`
+    - `Explorer.Series.not_equal/2`
+    - `Explorer.Series.greater/2`
+    - `Explorer.Series.greater_equal/2`
+    - `Explorer.Series.less/2`
+    - `Explorer.Series.less_equal/2`
+    - `Explorer.Series.is_nil/1`
+    - `Explorer.Series.is_not_nil/1`
+    - `Explorer.Series.and/2`
+    - `Explorer.Series.or/2`
+
+  But you can also use window functions and aggregations inside comparisons.
 
   ## Examples
 

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -20,10 +20,16 @@ defmodule Explorer.PolarsBackend.Expression do
     window_min: 5,
     window_sum: 5
   ]
-  @special_operations [column: 1, quantile: 2] ++ @window_operations
+  @special_operations [cast: 2, column: 1, quantile: 2] ++ @window_operations
 
   # Some operations are special because they don't receive all args as lazy series.
   # We define them first.
+
+  def to_expr(%LazySeries{op: :cast, args: [lazy_series, dtype]}) do
+    expr = to_expr(lazy_series)
+    Native.expr_cast(expr, Atom.to_string(dtype))
+  end
+
   def to_expr(%LazySeries{op: :column, args: [name]}) do
     Native.expr_column(name)
   end

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -20,7 +20,9 @@ defmodule Explorer.PolarsBackend.Expression do
     window_min: 5,
     window_sum: 5
   ]
-  @special_operations [cast: 2, column: 1, quantile: 2] ++ @window_operations
+
+  @lazy_series_and_literal_args_funs [quantile: 2, argsort: 2, sort: 2] ++ @window_operations
+  @special_operations [cast: 2, column: 1] ++ @lazy_series_and_literal_args_funs
 
   # Some operations are special because they don't receive all args as lazy series.
   # We define them first.
@@ -34,12 +36,7 @@ defmodule Explorer.PolarsBackend.Expression do
     Native.expr_column(name)
   end
 
-  def to_expr(%LazySeries{op: :quantile, args: [lazy_series, quantile]}) do
-    expr = to_expr(lazy_series)
-    Native.expr_quantile(expr, quantile)
-  end
-
-  for {op, _arity} <- @window_operations do
+  for {op, _arity} <- @lazy_series_and_literal_args_funs do
     expr_op = :"expr_#{op}"
 
     def to_expr(%LazySeries{op: unquote(op), args: [lazy_series | args]}) do

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -268,9 +268,7 @@ defmodule Explorer.PolarsBackend.Series do
         {:error, error} -> raise "#{error}"
       end
 
-    df
-    |> DataFrame.rename(["values", "counts"])
-    |> DataFrame.mutate(counts: &Series.cast(&1["counts"], :integer))
+    DataFrame.rename(df, ["values", "counts"])
   end
 
   # Window

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -9,7 +9,7 @@ use polars::prelude::{col, when, DataFrame, IntoLazy};
 use polars::prelude::{Expr, Literal};
 
 use crate::datatypes::{ExDate, ExDateTime};
-use crate::series::{rolling_opts, cast_str_to_dtype};
+use crate::series::{cast_str_to_dtype, rolling_opts};
 use crate::{ExDataFrame, ExExpr};
 
 #[rustler::nif]

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -320,6 +320,27 @@ pub fn expr_cumulative_sum(data: ExExpr, reverse: bool) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_reverse(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.reverse())
+}
+
+#[rustler::nif]
+pub fn expr_sort(expr: ExExpr, reverse: bool) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.sort(reverse))
+}
+
+#[rustler::nif]
+pub fn expr_argsort(expr: ExExpr, reverse: bool) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.arg_sort(reverse))
+}
+
+#[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
     let df: DataFrame = data.resource.0.clone();
     let expressions: Expr = expr.resource.0.clone();

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -239,6 +239,13 @@ pub fn expr_count(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_n_distinct(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.n_unique())
+}
+
+#[rustler::nif]
 pub fn expr_first(expr: ExExpr) -> ExExpr {
     let expr: Expr = expr.resource.0.clone();
 

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -9,7 +9,7 @@ use polars::prelude::{col, when, DataFrame, IntoLazy};
 use polars::prelude::{Expr, Literal};
 
 use crate::datatypes::{ExDate, ExDateTime};
-use crate::series::rolling_opts;
+use crate::series::{rolling_opts, cast_str_to_dtype};
 use crate::{ExDataFrame, ExExpr};
 
 #[rustler::nif]
@@ -48,6 +48,14 @@ pub fn expr_datetime(datetime: ExDateTime) -> ExExpr {
     let naive_datetime = NaiveDateTime::from(datetime);
     let expr = naive_datetime.lit();
     ExExpr::new(expr)
+}
+
+#[rustler::nif]
+pub fn expr_cast(data: ExExpr, to_dtype: &str) -> ExExpr {
+    let expr: Expr = data.resource.0.clone();
+    let to_dtype = cast_str_to_dtype(to_dtype).expect("dtype is not valid");
+
+    ExExpr::new(expr.cast(to_dtype))
 }
 
 #[rustler::nif]

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -133,6 +133,7 @@ rustler::init!(
         expr_max,
         expr_mean,
         expr_median,
+        expr_n_distinct,
         expr_std,
         expr_var,
         expr_quantile,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -103,6 +103,7 @@ rustler::init!(
         df_write_parquet,
         // expressions
         expr_boolean,
+        expr_cast,
         expr_column,
         expr_date,
         expr_datetime,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -110,6 +110,10 @@ rustler::init!(
         expr_float,
         expr_integer,
         expr_string,
+        // sort
+        expr_argsort,
+        expr_reverse,
+        expr_sort,
         // comparison expressions
         expr_binary_and,
         expr_binary_or,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -695,7 +695,8 @@ pub fn s_n_unique(data: ExSeries) -> Result<usize, ExplorerError> {
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_pow(data: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
     let s = &data.resource.0;
-    let s = s.cast(&DataType::Float64)?
+    let s = s
+        .cast(&DataType::Float64)?
         .f64()?
         .apply(|v| v.powf(exponent))
         .into_series();

--- a/notebooks/exploring_explorer.livemd
+++ b/notebooks/exploring_explorer.livemd
@@ -392,22 +392,24 @@ DataFrame.filter_with(df, &Series.equal(&1["cuontry"], "AFGHANISTAN"))
 A common task in data analysis is to add columns or change existing ones. Mutate is a handy verb.
 
 ```elixir
-DataFrame.mutate(df, new_column: &Series.add(&1["solid_fuel"], &1["cement"]))
+DataFrame.mutate_with(df, &[new_column: Series.add(&1["solid_fuel"], &1["cement"])])
 ```
 
 Did you catch that? You can pass in new columns as keyword arguments. It also works to transform existing columns.
 
 ```elixir
-DataFrame.mutate(df,
-  gas_fuel: &Series.cast(&1["gas_fuel"], :float),
-  gas_and_liquid_fuel: &Series.add(&1["gas_fuel"], &1["liquid_fuel"])
-)
+DataFrame.mutate_with(df, fn df ->
+  [
+    gas_fuel: Series.cast(df["gas_fuel"], :float),
+    gas_and_liquid_fuel: Series.add(df["gas_fuel"], df["liquid_fuel"])
+  ]
+end)
 ```
 
 `DataFrame.mutate/2` is flexible though. You may not always want to use keyword arguments. Given that column names are `String.t()`, it may make more sense to use a map.
 
 ```elixir
-DataFrame.mutate(df, %{"gas_fuel" => &Series.subtract(&1["gas_fuel"], 10)})
+DataFrame.mutate_with(df, &%{"gas_fuel" => Series.subtract(&1["gas_fuel"], 10)})
 ```
 
 `DataFrame.transmute/2`, which is `DataFrame.mutate/2` that only retains the specified columns, is forthcoming.
@@ -617,6 +619,21 @@ Speaking of `mutate`, it's 'group-aware'. As are `arrange`, `distinct`, and `n_r
 
 ```elixir
 DataFrame.arrange(grouped, desc: :total)
+```
+
+In case you need more complex operations, like calculations inside groups, you can use the
+more flexible `Explorer.DataFrame.summarise_with/2` function.
+
+```elixir
+DataFrame.summarise_with(grouped, fn df ->
+  max = Series.max(df["per_capita"])
+
+  [
+    per_capita_max: max,
+    greater_than_9: Series.greater(max, 9.0)
+  ]
+end)
+|> DataFrame.arrange(desc: :per_capita_max)
 ```
 
 ### That's it!

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -426,13 +426,13 @@ defmodule Explorer.DataFrame.GroupedTest do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"], c: [1, 1, 2])
 
       df1 = DF.group_by(df, :c)
-      df2 = DF.mutate(df1, d: &Series.add(&1["a"], -7.1))
+      df2 = DF.mutate(df1, d: -7.1)
 
       assert DF.to_columns(df2, atom_keys: true) == %{
                a: [1, 2, 3],
                b: ["a", "b", "c"],
                c: [1, 1, 2],
-               d: [-6.1, -5.1, -4.1]
+               d: [-7.1, -7.1, -7.1]
              }
 
       assert df2.names == ["a", "b", "c", "d"]

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -376,6 +376,37 @@ defmodule Explorer.DataFrameTest do
       assert df1.dtypes == %{"a" => :float, "b" => :string}
     end
 
+    test "adds new columns with reverse, sort and argsort" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+
+      df1 =
+        DF.mutate_with(df, fn ldf ->
+          [
+            c: Series.reverse(ldf["a"]),
+            d: Series.argsort(ldf["a"], true),
+            e: Series.sort(ldf["b"], true)
+          ]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 2, 3],
+               b: ["a", "b", "c"],
+               c: [3, 2, 1],
+               d: [2, 1, 0],
+               e: ["c", "b", "a"]
+             }
+
+      assert df1.names == ["a", "b", "c", "d", "e"]
+
+      assert df1.dtypes == %{
+               "a" => :integer,
+               "b" => :string,
+               "c" => :integer,
+               "d" => :integer,
+               "e" => :string
+             }
+    end
+
     test "adds a new column with some aggregations without groups" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -359,6 +359,23 @@ defmodule Explorer.DataFrameTest do
       assert df1.dtypes == %{"a" => :integer, "b" => :string, "c" => :integer}
     end
 
+    test "changes a column" do
+      df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+
+      df1 =
+        DF.mutate_with(df, fn ldf ->
+          [a: Series.cast(ldf["a"], :float)]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1.0, 2.0, 3.0],
+               b: ["a", "b", "c"]
+             }
+
+      assert df1.names == ["a", "b"]
+      assert df1.dtypes == %{"a" => :float, "b" => :string}
+    end
+
     test "adds a new column with some aggregations without groups" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -485,6 +485,16 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "with a simple df one column and without order" do
+      df = DF.new(a: [1, 2, 4, 3, 6, 5], b: ["a", "b", "d", "c", "f", "e"])
+      df1 = DF.arrange_with(df, fn ldf -> ldf["a"] end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 2, 3, 4, 5, 6],
+               b: ["a", "b", "c", "d", "e", "f"]
+             }
+    end
+
     test "with a simple df and desc order" do
       df = DF.new(a: [1, 2, 4, 3, 6, 5], b: ["a", "b", "d", "c", "f", "e"])
       df1 = DF.arrange_with(df, fn ldf -> [desc: ldf["a"]] end)


### PR DESCRIPTION
This change adds docs to the newer dataframe `_with` APIs (see https://github.com/elixir-nx/explorer/issues/289)

This PR also includes some fixes and include two lazy series operations: `cast` and `n_distinct`.