### PR TITLE
Make dtype for `count` and `n_distinct` aggregations explicit in `summarise/2`

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2935,6 +2935,9 @@ defmodule Explorer.DataFrame do
             :mean ->
               :float
 
+            agg when agg in [:count, :n_distinct] ->
+              :integer
+
             _other ->
               df.dtypes[column_name]
           end


### PR DESCRIPTION
The columns we use for `count` or `n_distinct` aggregations are not always integer columns. Hence when we perform those aggregations on columns other than of integers we get the `dtype` the same as the column's `dtype`. For example:

```elixir
iex(31)> df = DF.new(%{id: [1, 2, 3, 1, 1], name: ["foo", "bar", "foo", "bar", "bar"], price: [1.1, 1.2, 1.3, 1.5, 1.2]})
#Explorer.DataFrame<
  Polars[5 x 3]
  id integer [1, 2, 3, 1, 1]
  name string ["foo", "bar", "foo", "bar", "bar"]
  price float [1.1, 1.2, 1.3, 1.5, 1.2]
>

iex(32)> summed = df |> DF.group_by("id") |> DF.summarise(name: [:n_distinct], price: [:count])
#Explorer.DataFrame<
  Polars[3 x 3]
  id integer [1, 2, 3]
  name_n_distinct integer [2, 1, 1]
  price_count integer [3, 1, 1]
>

iex(33)> summed.dtypes
%{"id" => :integer, "name_n_distinct" => :string, "price_count" => :float}
```

This PR just explicitly mentions the `dtype` for `n_distinct` and `count` aggregations since they'll always be the same.

Please let me know what you think and also whether I should write a test for this under `summarise/2` in `grouped_tests`. I was just not sure whether there should be a test case for this one or not as I did not see for the others but I am happy to write.