### PR TITLE
Fix dtype mismatch between Explorer and Polars

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -265,7 +265,7 @@ defmodule Explorer.Backend.LazySeries do
 
       if aggregations?(args), do: raise_agg_inside_window(unquote(op))
 
-      dtype = resolve_numeric_dtype([series | List.wrap(weights)])
+      dtype = resolve_numeric_dtype(unquote(op), [series | List.wrap(weights)])
 
       data = new(unquote(op), args, false, true)
 
@@ -314,7 +314,7 @@ defmodule Explorer.Backend.LazySeries do
     Backend.Series.new(data, dtype)
   end
 
-  defp dtype_for_agg_operation(:count, _), do: :integer
+  defp dtype_for_agg_operation(op, _) when op in [:count, :n_distinct], do: :integer
 
   defp dtype_for_agg_operation(op, series) when op in [:first, :last, :sum, :min, :max],
     do: series.dtype
@@ -335,6 +335,9 @@ defmodule Explorer.Backend.LazySeries do
       [_, _] -> :float
     end
   end
+
+  defp resolve_numeric_dtype(:window_mean, _items), do: :float
+  defp resolve_numeric_dtype(_op, items), do: resolve_numeric_dtype(items)
 
   # Returns the inner `data` if it's a lazy series. Otherwise raises an error.
   defp lazy_series!(series) do

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2572,7 +2572,7 @@ defmodule Explorer.DataFrame do
             right_name
           end
 
-        {name, right.dtypes[name]}
+        {name, right.dtypes[right_name]}
       end)
   end
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1591,6 +1591,13 @@ defmodule Explorer.DataFrame do
   @doc """
   Takes distinct rows by a selection of columns.
 
+  Distinct is not affected by groups, although groups are kept in the
+  columns selection if `keep_all` option is false (the default).
+
+  ## Options
+
+    * `keep_all` - If set to `true`, keep all columns. Default is `false`.
+
   ## Examples
 
   By default will return unique values of the requested columns:

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -60,7 +60,7 @@ defmodule Explorer.PolarsBackend.Native do
 
   def df_column(_df, _name), do: err()
   def df_drop(_df, _name), do: err()
-  def df_drop_duplicates(_df, _maintain_order, _subset), do: err()
+  def df_drop_duplicates(_df, _maintain_order, _subset, _selection), do: err()
   def df_drop_nulls(_df, _subset), do: err()
   def df_dtypes(_df), do: err()
   def df_filter_with(_df, _operation), do: err()

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -52,7 +52,8 @@ defmodule Explorer.PolarsBackend.Shared do
         if @check_frames do
           check_df = create_dataframe(new_df)
 
-          if out_df.names != check_df.names or out_df.dtypes != check_df.dtypes do
+          if Enum.sort(out_df.names) != Enum.sort(check_df.names) or
+               out_df.dtypes != check_df.dtypes do
             raise """
             DataFrame mismatch.
 

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -517,13 +517,18 @@ pub fn df_drop_duplicates(
     data: ExDataFrame,
     maintain_order: bool,
     subset: Vec<String>,
+    columns_to_keep: Option<Vec<&str>>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let df: &DataFrame = &data.resource.0;
     let new_df = match maintain_order {
         false => df.unique(Some(&subset), UniqueKeepStrategy::First)?,
         true => df.unique_stable(Some(&subset), UniqueKeepStrategy::First)?,
     };
-    Ok(ExDataFrame::new(new_df))
+
+    match columns_to_keep {
+        Some(columns) => Ok(ExDataFrame::new(new_df.select(&columns)?)),
+        None => Ok(ExDataFrame::new(new_df)),
+    }
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]


### PR DESCRIPTION
This is a continuation of https://github.com/elixir-nx/explorer/pull/335

There are still two series operations with mismatched types:
- `quantile` returns `float` when it should return the series dtype (e.g. `:integer` in case of a series of ints).
- `pow` has the same problem.

**EDIT**: these two operations are incorrect in Polars. I should open an issue there.