### PR TITLE
Change to_* functions to return only :ok

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -6,6 +6,7 @@ defmodule Explorer.Backend.DataFrame do
   @type t :: struct()
 
   @type df :: Explorer.DataFrame.t()
+  @type ok_result :: :ok | {:error, term()}
   @type result(t) :: {:ok, t} | {:error, term()}
   @type series :: Explorer.Series.t()
   @type column_name :: String.t()
@@ -38,7 +39,7 @@ defmodule Explorer.Backend.DataFrame do
               parse_dates :: boolean()
             ) :: result(df)
   @callback to_csv(df, filename :: String.t(), header? :: boolean(), delimiter :: String.t()) ::
-              result(String.t())
+              ok_result()
 
   @callback from_parquet(filename :: String.t()) :: result(df)
   @callback to_parquet(
@@ -46,21 +47,21 @@ defmodule Explorer.Backend.DataFrame do
               filename :: String.t(),
               compression :: {nil | atom(), nil | integer()}
             ) ::
-              result(String.t())
+              ok_result()
 
   @callback from_ipc(
               filename :: String.t(),
               columns :: list(String.t()) | list(atom()) | list(integer()) | nil
             ) :: result(df)
   @callback to_ipc(df, filename :: String.t(), compression :: {nil | atom(), nil | integer()}) ::
-              result(String.t())
+              ok_result()
 
   @callback from_ndjson(
               filename :: String.t(),
               infer_schema_length :: integer(),
               batch_size :: integer()
             ) :: result(df)
-  @callback to_ndjson(df, filename :: String.t()) :: result(String.t())
+  @callback to_ndjson(df, filename :: String.t()) :: ok_result()
 
   # Conversion
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -91,7 +91,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
     <<delimiter::utf8>> = delimiter
 
     case Native.df_to_csv_file(df, filename, header?, delimiter) do
-      {:ok, _} -> {:ok, filename}
+      {:ok, _} -> :ok
       {:error, error} -> {:error, error}
     end
   end
@@ -106,7 +106,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   @impl true
   def to_ndjson(%DataFrame{data: df}, filename) do
     with {:ok, _} <- Native.df_write_ndjson(df, filename) do
-      {:ok, filename}
+      :ok
     end
   end
 
@@ -127,7 +127,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   @impl true
   def to_parquet(%DataFrame{data: df}, filename, {compression, compression_level}) do
     case Native.df_write_parquet(df, filename, Atom.to_string(compression), compression_level) do
-      {:ok, _} -> {:ok, filename}
+      {:ok, _} -> :ok
       {:error, error} -> {:error, error}
     end
   end
@@ -145,7 +145,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   @impl true
   def to_ipc(%DataFrame{data: df}, filename, {compression, _level}) do
     case Native.df_write_ipc(df, filename, Atom.to_string(compression)) do
-      {:ok, _} -> {:ok, filename}
+      {:ok, _} -> :ok
       {:error, error} -> {:error, error}
     end
   end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1183,7 +1183,7 @@ defmodule Explorer.DataFrameTest do
     test "can write parquet to file", %{df: df, tmp_dir: tmp_dir} do
       parquet_path = Path.join(tmp_dir, "test.parquet")
 
-      assert {:ok, ^parquet_path} = DF.to_parquet(df, parquet_path)
+      assert :ok = DF.to_parquet(df, parquet_path)
       assert {:ok, parquet_df} = DF.from_parquet(parquet_path)
 
       assert DF.names(df) == DF.names(parquet_df)
@@ -1199,7 +1199,7 @@ defmodule Explorer.DataFrameTest do
       for compression <- [:snappy, :gzip, :brotli, :zstd, :lz4raw] do
         parquet_path = Path.join(tmp_dir, "test.parquet")
 
-        assert {:ok, ^parquet_path} = DF.to_parquet(df, parquet_path, compression: compression)
+        assert :ok = DF.to_parquet(df, parquet_path, compression: compression)
         assert {:ok, parquet_df} = DF.from_parquet(parquet_path)
 
         assert DF.names(df) == DF.names(parquet_df)
@@ -1216,8 +1216,7 @@ defmodule Explorer.DataFrameTest do
       for compression <- [:gzip, :brotli, :zstd], level <- [1, 2, 3] do
         parquet_path = Path.join(tmp_dir, "test.parquet")
 
-        assert {:ok, ^parquet_path} =
-                 DF.to_parquet(df, parquet_path, compression: {compression, level})
+        assert :ok = DF.to_parquet(df, parquet_path, compression: {compression, level})
 
         assert {:ok, parquet_df} = DF.from_parquet(parquet_path)
 
@@ -1296,7 +1295,7 @@ defmodule Explorer.DataFrameTest do
 
       ndjson_path = Path.join(tmp_dir, "test-write.ndjson")
 
-      assert {:ok, ^ndjson_path} = DF.to_ndjson(df, ndjson_path)
+      assert :ok = DF.to_ndjson(df, ndjson_path)
       assert {:ok, ndjson_df} = DF.from_ndjson(ndjson_path)
 
       assert DF.names(df) == DF.names(ndjson_df)


### PR DESCRIPTION
Changing the `to_*` functions to write to files on the Dataframe module to just return `:ok` on success (as the filename is an already an input of the function).

Closes #347 