### PR TITLE
Start adding CSV tests

### DIFF
--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -48,39 +48,30 @@ defmodule Explorer.DataFrame.CSVTest do
     assert_in_delta(57.653484, frame["lat"][0], @f64_epsilon)
 
     city = frame["city"]
-    # TODO: write a meaningful test, but references are apparently changing
-    # assert city == frame[0]
 
     assert city[0] == "Elgin, Scotland, the UK"
     assert city[13] == "Aberdeen, Aberdeen City, UK"
   end
 
-  # TODO: expose what is in Explorer.Backend.Series @valid_dtypes attributes, so that
-  # we ensure the tests remain up to date?
-
-  # NOTE: just a preliminary batch of data, we may want to add more than just one value,
-  # with all covered cases.
-  @valid_dtypes [
-    {:integer, "100", 100},
-    {:float, "2.3", 2.3},
-    {:boolean, "true", true},
-    {:string, "some string", "some string"},
-    {:date, "2022-12-01", ~D[2022-12-01]},
-    {:datetime, "2022-10-01T11:34:10.123456", ~N[2022-10-01 11:34:10.123456]}
-    # Unsupported?
-    # :list
-  ]
-
-  describe "dtypes support" do
-    Enum.each(@valid_dtypes, fn {type, csv_value, parsed_value} ->
-      test "conforms to requested dtype for #{type}" do
+  describe "dtypes" do
+    [
+      {:integer, "100", 100},
+      {:float, "2.3", 2.3},
+      {:boolean, "true", true},
+      {:string, "some string", "some string"},
+      {:date, "2022-12-01", ~D[2022-12-01]},
+      {:datetime, "2022-10-01T11:34:10.123456", ~N[2022-10-01 11:34:10.123456]}
+      # :list (to be implemented)
+    ]
+    |> Enum.each(fn {type, csv_value, parsed_value} ->
+      test "supports explicit #{type} parsing" do
         data = "column\n#{unquote(csv_value)}"
         frame = DF.from_csv!(tmp_file!(data), dtypes: [{"column", unquote(type)}])
         assert frame[0][0] == unquote(Macro.escape(parsed_value))
         assert frame[0].dtype == unquote(type)
       end
 
-      test "infers requested dtype for #{type}" do
+      test "supports inferred #{type} parsing" do
         data = "column\n#{unquote(csv_value)}"
         frame = DF.from_csv!(tmp_file!(data), parse_dates: true)
         assert frame[0][0] == unquote(Macro.escape(parsed_value))

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -1,10 +1,16 @@
 defmodule Explorer.DataFrame.CSVTest do
+  @moduledoc """
+  Integration tests, based on:
+  https://github.com/jorgecarleitao/arrow2/tree/main/src/io/csv/read
+  """
   use ExUnit.Case, async: true
+  alias Explorer.DataFrame, as: DF
+
+  # https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.EPSILON
+  @f64_epsilon 2.2204460492503131e-16
 
   @tag :focus
-  test "hello" do
-    # test data taken from arrow2
-    # https://github.com/jorgecarleitao/arrow2/tree/main/src/io/csv/read
+  test "read" do
     data = """
     city,lat,lng
     "Elgin, Scotland, the UK",57.653484,-3.335724
@@ -25,6 +31,24 @@ defmodule Explorer.DataFrame.CSVTest do
 
     filename = System.tmp_dir!() |> Path.join("input.csv")
     File.write!(filename, data)
-    frame = Explorer.DataFrame.from_csv!(filename)
+    frame = DF.from_csv!(filename)
+
+    assert DF.n_rows(frame) == 14
+    assert DF.n_columns(frame) == 3
+
+    assert frame.dtypes == %{
+             "city" => :string,
+             "lat" => :float,
+             "lng" => :float
+           }
+
+    assert_in_delta(57.653484, frame["lat"][0], @f64_epsilon)
+
+    city = frame["city"]
+    # TODO: write a meaningful test, but references are apparently changing
+    # assert city == frame[0]
+
+    assert city[0] == "Elgin, Scotland, the UK"
+    assert city[13] == "Aberdeen, Aberdeen City, UK"
   end
 end

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -15,7 +15,6 @@ defmodule Explorer.DataFrame.CSVTest do
     filename
   end
 
-  @tag :focus
   test "read" do
     data = """
     city,lat,lng
@@ -72,13 +71,19 @@ defmodule Explorer.DataFrame.CSVTest do
     # :list
   ]
 
-  describe "dtypes inference" do
+  describe "dtypes support" do
     Enum.each(@valid_dtypes, fn {type, csv_value, parsed_value} ->
-      @tag :focus
-      test "works for #{type}" do
+      test "conforms to requested dtype for #{type}" do
         data = "column\n#{unquote(csv_value)}"
-        frame = DF.from_csv!(tmp_file!(data))
-        # assert frame[0][0] == unquote(parsed_value)
+        frame = DF.from_csv!(tmp_file!(data), dtypes: [{"column", unquote(type)}])
+        assert frame[0][0] == unquote(Macro.escape(parsed_value))
+        assert frame[0].dtype == unquote(type)
+      end
+
+      test "infers requested dtype for #{type}" do
+        data = "column\n#{unquote(csv_value)}"
+        frame = DF.from_csv!(tmp_file!(data), parse_dates: true)
+        assert frame[0][0] == unquote(Macro.escape(parsed_value))
         assert frame[0].dtype == unquote(type)
       end
     end)

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -67,7 +67,7 @@ defmodule Explorer.DataFrame.CSVTest do
     {:boolean, "true", true},
     {:string, "some string", "some string"},
     {:date, "2022-12-01", ~D[2022-12-01]},
-    {:datetime, "2022-10-01T11:34:10+0000", ~U[2022-10-01 11:34:10Z]}
+    {:datetime, "2022-10-01T11:34:10.123456", ~N[2022-10-01 11:34:10.123456]}
     # Unsupported?
     # :list
   ]

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -1,0 +1,30 @@
+defmodule Explorer.DataFrame.CSVTest do
+  use ExUnit.Case, async: true
+
+  @tag :focus
+  test "hello" do
+    # test data taken from arrow2
+    # https://github.com/jorgecarleitao/arrow2/tree/main/src/io/csv/read
+    data = """
+    city,lat,lng
+    "Elgin, Scotland, the UK",57.653484,-3.335724
+    "Stoke-on-Trent, Staffordshire, the UK",53.002666,-2.179404
+    "Solihull, Birmingham, UK",52.412811,-1.778197
+    "Cardiff, Cardiff county, UK",51.481583,-3.179090
+    "Eastbourne, East Sussex, UK",50.768036,0.290472
+    "Oxford, Oxfordshire, UK",51.752022,-1.257677
+    "London, UK",51.509865,-0.118092
+    "Swindon, Swindon, UK",51.568535,-1.772232
+    "Gravesend, Kent, UK",51.441883,0.370759
+    "Northampton, Northamptonshire, UK",52.240479,-0.902656
+    "Rugby, Warwickshire, UK",52.370876,-1.265032
+    "Sutton Coldfield, West Midlands, UK",52.570385,-1.824042
+    "Harlow, Essex, UK",51.772938,0.102310
+    "Aberdeen, Aberdeen City, UK",57.149651,-2.099075
+    """
+
+    filename = System.tmp_dir!() |> Path.join("input.csv")
+    File.write!(filename, data)
+    frame = Explorer.DataFrame.from_csv!(filename)
+  end
+end


### PR DESCRIPTION
This is just a draft to open discussion to implement CSV tests (#284). As I worked on it I had a few a-ha moments (partly due to my discovering of the `from_csv` API).

I used https://github.com/jorgecarleitao/arrow2/tree/main/src/io/csv/read as an initial basis.

I used a data-based approach to iterate and generate tests using `quote`/`unquote`, something I found useful to discover the API, but maybe we'll want something more explicit & more readable (e.g. one describe block per "dtype", manually written).

I have not attempted to cover in full what can be done, partly due to personal bandwidth, and also to get feedback.

Things I have noticed/questions I have that could be of interest to continue this:
- the `quote/unquote` implementation is not very readable, but makes it easy to add an extra sample
- My understanding is that Polars is the default backend, and `from_csv` goes via the backend, so presumably we'll want something that can be made backend-agnostic but still run on all the backends? (I haven't looked much into the backends code at this point)
- There would be a lot of interest to add tests around many more things: a misparsed datetime will result in nil (I believe), is the library failing fast on errors such as a random string in the middle of an int column with an explicitly passed dtype, how does float truncation occurs (I believe extra digits in the CSV column will be just lost at this point), etc etc
- `frame["city"] == frame[0]` returns false (a different reference) and I presume this could be linked to the Rust interop, but haven't looked into it yet