### PR TITLE
Add `datetime[ns]` dtype

### DIFF
--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -62,6 +62,7 @@ defmodule Explorer.PolarsBackend.Series do
       "date" -> {:s, 32}
       "datetime[ms]" -> {:s, 64}
       "datetime[μs]" -> {:s, 64}
+      "datetime[ns]" -> {:s, 64}
       dtype -> raise "cannot convert dtype #{inspect(dtype)} to memtype"
     end
   end

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -116,6 +116,7 @@ defmodule Explorer.PolarsBackend.Shared do
   def normalise_dtype("date"), do: :date
   def normalise_dtype("datetime[ms]"), do: :datetime
   def normalise_dtype("datetime[μs]"), do: :datetime
+  def normalise_dtype("datetime[ns]"), do: :datetime
   def normalise_dtype("list[u32]"), do: :integer
 
   def internal_from_dtype(:integer), do: "i64"

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -69,8 +69,9 @@ fn dtype_from_str(dtype: &str) -> Result<DataType, ExplorerError> {
         "i64" => Ok(DataType::Int64),
         "bool" => Ok(DataType::Boolean),
         "date" => Ok(DataType::Date),
-        "datetime[μs]" => Ok(DataType::Datetime(TimeUnit::Microseconds, None)),
         "datetime[ms]" => Ok(DataType::Datetime(TimeUnit::Milliseconds, None)),
+        "datetime[μs]" => Ok(DataType::Datetime(TimeUnit::Microseconds, None)),
+        "datetime[ns]" => Ok(DataType::Datetime(TimeUnit::Nanoseconds, None)),
         _ => Err(ExplorerError::Internal("Unrecognised datatype".into())),
     }
 }

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -145,7 +145,7 @@ fn time_to_microseconds(v: i64, time_unit: TimeUnit) -> i64 {
         TimeUnit::Nanoseconds => (v as f64 * 0.001) as i64,
         _ => unreachable!(),
     }
-  }
+}
 
 #[inline]
 fn encode_datetime(v: i64, time_unit: TimeUnit, env: Env) -> Term {

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -138,10 +138,11 @@ fn naive_datetime_struct_keys(env: Env) -> [NIF_TERM; 9] {
 }
 
 #[inline]
-fn time_unit_to_factor(time_unit: TimeUnit) -> i64 {
+fn time_unit_to_factor(time_unit: TimeUnit) -> f64 {
     match time_unit {
-        TimeUnit::Milliseconds => 1000,
-        TimeUnit::Microseconds => 1,
+        TimeUnit::Milliseconds => 1000.0,
+        TimeUnit::Microseconds => 1.0,
+        TimeUnit::Nanoseconds => 0.001,
         _ => unreachable!(),
     }
 }
@@ -154,7 +155,7 @@ fn encode_datetime(v: i64, time_unit: TimeUnit, env: Env) -> Term {
     let factor = time_unit_to_factor(time_unit);
 
     unsafe_encode_datetime!(
-        v * factor,
+        (v as f64 * factor) as i64,
         naive_datetime_struct_keys,
         calendar_iso_module,
         naive_datetime_module,
@@ -174,7 +175,7 @@ fn encode_datetime_series<'b>(s: &Series, time_unit: TimeUnit, env: Env<'b>) -> 
         s.datetime().unwrap().into_iter().map(|option| option
             .map(|v| {
                 unsafe_encode_datetime!(
-                    v * factor,
+                    (v as f64 * factor) as i64,
                     naive_datetime_struct_keys,
                     calendar_iso_module,
                     naive_datetime_module,

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -143,7 +143,6 @@ fn time_to_microseconds(v: i64, time_unit: TimeUnit) -> i64 {
         TimeUnit::Milliseconds => v * 1000,
         TimeUnit::Microseconds => v,
         TimeUnit::Nanoseconds => (v as f64 * 0.001) as i64,
-        _ => unreachable!(),
     }
 }
 

--- a/test/explorer/data_frame/parquet_test.ex
+++ b/test/explorer/data_frame/parquet_test.ex
@@ -1,0 +1,82 @@
+defmodule Explorer.DataFrame.ParquetTest do
+  @moduledoc """
+  Integration tests, based on `Explorer.DataFrame.CsvTest`.
+  """
+  use ExUnit.Case, async: true
+  alias Explorer.DataFrame, as: DF
+  alias Explorer.Series
+
+  # https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.EPSILON
+  @f64_epsilon 2.2204460492503131e-16
+
+  def tmp_file!(data) do
+    filename = System.tmp_dir!() |> Path.join("data.parquet")
+    :ok = DF.to_parquet(data, filename)
+    filename
+  end
+
+  test "read" do
+    data = Explorer.Datasets.iris()
+
+    {:ok, frame} = DF.from_parquet(tmp_file!(data))
+
+    assert DF.n_rows(frame) == 150
+    assert DF.n_columns(frame) == 5
+
+    assert frame.dtypes == %{
+             "sepal_length" => :float,
+             "sepal_width" => :float,
+             "petal_length" => :float,
+             "petal_width" => :float,
+             "species" => :string
+           }
+
+    assert_in_delta(5.1, frame["sepal_length"][0], @f64_epsilon)
+
+    species = frame["species"]
+
+    assert species[0] == "Iris-setosa"
+    assert species[149] == "Iris-virginica"
+  end
+
+  def assert_parquet(type, value, parsed_value) do
+    data = [value] |> Series.from_list() |> Series.cast(type) |> then(&DF.new(column: &1))
+    # parsing should work as expected
+    {:ok, frame} = DF.from_parquet(tmp_file!(data))
+    assert frame[0][0] == parsed_value
+    assert frame[0].dtype == type
+  end
+
+  describe "dtypes" do
+    test "integer" do
+      assert_parquet(:integer, "100", 100)
+      assert_parquet(:integer, "-101", -101)
+    end
+
+    test "float" do
+      assert_parquet(:float, "2.3", 2.3)
+      assert_parquet(:float, "57.653484", 57.653484)
+      assert_parquet(:float, "-1.772232", -1.772232)
+    end
+
+    # cast not used as it is not implemented for boolean values
+    test "boolean" do
+      assert_parquet(:boolean, true, true)
+      assert_parquet(:boolean, false, false)
+    end
+
+    test "string" do
+      assert_parquet(:string, "some string", "some string")
+      assert_parquet(:string, "éphémère", "éphémère")
+    end
+
+    test "date" do
+      assert_parquet(:date, "19327", ~D[2022-12-01])
+      assert_parquet(:date, "-3623", ~D[1960-01-31])
+    end
+
+    test "datetime" do
+      assert_parquet(:datetime, "1664624050123456", ~N[2022-10-01 11:34:10.123456])
+    end
+  end
+end


### PR DESCRIPTION
Added here a missing dtype needed to import datasets that contain data of this type.

Closes https://github.com/elixir-nx/explorer/issues/364