### PR TITLE
Add missing "concat" operation for lazy series

### DIFF
--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -368,6 +368,14 @@ pub fn expr_last(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_concat(left: ExExpr, right: ExExpr) -> ExExpr {
+    let left_expr: Expr = left.resource.0.clone();
+    let right_expr: Expr = right.resource.0.clone();
+
+    ExExpr::new(left_expr.append(right_expr, false))
+}
+
+#[rustler::nif]
 pub fn expr_coalesce(left: ExExpr, right: ExExpr) -> ExExpr {
     let predicate: Expr = left.resource.0.clone().is_not_null();
     let left_expr: Expr = left.resource.0.clone();

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -148,6 +148,7 @@ rustler::init!(
         expr_quotient,
         expr_remainder,
         // slice and dice expressions
+        expr_concat,
         expr_coalesce,
         // agg expressions
         expr_sum,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -541,6 +541,32 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "adds some columns with slice and dice functions" do
+      df = DF.new(a: [1, nil, 3], b: [20.0, 40.0, 60.0])
+
+      df1 =
+        DF.mutate_with(df, fn ldf ->
+          [
+            c: Series.concat(ldf["a"], ldf["b"]) |> Series.slice(1, 3),
+            d: Series.coalesce(ldf["a"], ldf["b"])
+          ]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, nil, 3],
+               b: [20.0, 40.0, 60.0],
+               c: [nil, 3, 20.0],
+               d: [1.0, 40.0, 3.0]
+             }
+
+      assert DF.dtypes(df1) == %{
+               "a" => :integer,
+               "b" => :float,
+               "c" => :float,
+               "d" => :float
+             }
+    end
+
     test "adds some columns with window functions" do
       df = DF.new(a: Enum.to_list(1..10))
 


### PR DESCRIPTION
This PR adds `concat/2` operation for LazySeries.