### PR TITLE
Refactor PolarsBackend.Series to improve ops using scalar values

### DIFF
--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -384,7 +384,7 @@ defmodule Explorer.PolarsBackend.Series do
 
   defp apply_scalar_on_rhs(fun_name, %Series{} = left, scalar) when is_atom(fun_name) do
     df =
-      DataFrame.mutate_with(DataFrame.new(left: left), fn ldf ->
+      DataFrame.mutate_with(polars_df(left: left), fn ldf ->
         [result: apply(Explorer.Series, fun_name, [ldf["left"], scalar])]
       end)
 
@@ -393,11 +393,15 @@ defmodule Explorer.PolarsBackend.Series do
 
   defp apply_scalar_on_lhs(fun_name, scalar, %Series{} = right) when is_atom(fun_name) do
     df =
-      DataFrame.mutate_with(DataFrame.new(right: right), fn ldf ->
+      DataFrame.mutate_with(polars_df(right: right), fn ldf ->
         [result: apply(Explorer.Series, fun_name, [scalar, ldf["right"]])]
       end)
 
     df["result"]
+  end
+
+  defp polars_df(series) do
+    Explorer.PolarsBackend.DataFrame.from_series(series)
   end
 end
 

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -7,7 +7,6 @@ defmodule Explorer.PolarsBackend.Series do
   alias Explorer.PolarsBackend.Native
   alias Explorer.PolarsBackend.Shared
   alias Explorer.Series
-  alias __MODULE__, as: PolarsSeries
 
   @type t :: %__MODULE__{resource: binary(), reference: term()}
 
@@ -165,49 +164,53 @@ defmodule Explorer.PolarsBackend.Series do
   def peaks(series, :min), do: Shared.apply_series(series, :s_peak_min)
 
   # Arithmetic
-  # OPTIMIZE: change the scalar versions to work without creating a series.
 
   @impl true
   def add(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_add, [right.data])
 
-  def add(left, right) when is_number(right), do: add(left, scalar_rhs(right, left))
-  def add(left, right) when is_number(left), do: add(scalar_rhs(left, right), right)
+  def add(left, right) when is_number(right), do: apply_scalar_on_rhs(:add, left, right)
+  def add(left, right) when is_number(left), do: apply_scalar_on_lhs(:add, left, right)
 
   @impl true
   def subtract(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_sub, [right.data])
 
-  def subtract(left, right) when is_number(right), do: subtract(left, scalar_rhs(right, left))
-  def subtract(left, right) when is_number(left), do: subtract(scalar_rhs(left, right), right)
+  def subtract(left, right) when is_number(right), do: apply_scalar_on_rhs(:subtract, left, right)
+  def subtract(left, right) when is_number(left), do: apply_scalar_on_lhs(:subtract, left, right)
 
   @impl true
   def multiply(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_mul, [right.data])
 
-  def multiply(left, right) when is_number(right), do: multiply(left, scalar_rhs(right, left))
-  def multiply(left, right) when is_number(left), do: multiply(scalar_rhs(left, right), right)
+  def multiply(left, right) when is_number(right), do: apply_scalar_on_rhs(:multiply, left, right)
+  def multiply(left, right) when is_number(left), do: apply_scalar_on_lhs(:multiply, left, right)
 
   @impl true
   def divide(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_div, [right.data])
 
-  def divide(left, right) when is_number(right), do: divide(left, scalar_rhs(right, left))
-  def divide(left, right) when is_number(left), do: divide(scalar_rhs(left, right), right)
+  def divide(left, right) when is_number(right), do: apply_scalar_on_rhs(:divide, left, right)
+  def divide(left, right) when is_number(left), do: apply_scalar_on_lhs(:divide, left, right)
 
   @impl true
   def quotient(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_quotient, [right.data])
 
-  def quotient(left, right) when is_integer(right), do: quotient(left, scalar_rhs(right, left))
-  def quotient(left, right) when is_integer(left), do: quotient(scalar_rhs(left, right), right)
+  def quotient(left, right) when is_integer(right),
+    do: apply_scalar_on_rhs(:quotient, left, right)
+
+  def quotient(left, right) when is_integer(left), do: apply_scalar_on_lhs(:quotient, left, right)
 
   @impl true
   def remainder(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_remainder, [right.data])
 
-  def remainder(left, right) when is_integer(right), do: remainder(left, scalar_rhs(right, left))
-  def remainder(left, right) when is_integer(left), do: remainder(scalar_rhs(left, right), right)
+  def remainder(left, right) when is_integer(right),
+    do: apply_scalar_on_rhs(:remainder, left, right)
+
+  def remainder(left, right) when is_integer(left),
+    do: apply_scalar_on_lhs(:remainder, left, right)
 
   # TODO: make pow/2 accept series on both sides.
   @impl true
@@ -227,43 +230,43 @@ defmodule Explorer.PolarsBackend.Series do
   def eq(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_eq, [right.data])
 
-  def eq(%Series{} = left, right), do: eq(left, scalar_rhs(right, left))
-  def eq(left, %Series{} = right), do: eq(scalar_rhs(left, right), right)
+  def eq(%Series{} = left, right), do: apply_scalar_on_rhs(:equal, left, right)
+  def eq(left, %Series{} = right), do: apply_scalar_on_lhs(:equal, left, right)
 
   @impl true
   def neq(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_neq, [right.data])
 
-  def neq(%Series{} = left, right), do: neq(left, scalar_rhs(right, left))
-  def neq(left, %Series{} = right), do: neq(scalar_rhs(left, right), right)
+  def neq(%Series{} = left, right), do: apply_scalar_on_rhs(:not_equal, left, right)
+  def neq(left, %Series{} = right), do: apply_scalar_on_lhs(:not_equal, left, right)
 
   @impl true
   def gt(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_gt, [right.data])
 
-  def gt(%Series{} = left, right), do: gt(left, scalar_rhs(right, left))
-  def gt(left, %Series{} = right), do: gt(scalar_rhs(left, right), right)
+  def gt(%Series{} = left, right), do: apply_scalar_on_rhs(:greater, left, right)
+  def gt(left, %Series{} = right), do: apply_scalar_on_lhs(:greater, left, right)
 
   @impl true
   def gt_eq(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_gt_eq, [right.data])
 
-  def gt_eq(%Series{} = left, right), do: gt_eq(left, scalar_rhs(right, left))
-  def gt_eq(left, %Series{} = right), do: gt_eq(scalar_rhs(left, right), right)
+  def gt_eq(%Series{} = left, right), do: apply_scalar_on_rhs(:greater_equal, left, right)
+  def gt_eq(left, %Series{} = right), do: apply_scalar_on_lhs(:greater_equal, left, right)
 
   @impl true
   def lt(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_lt, [right.data])
 
-  def lt(%Series{} = left, right), do: lt(left, scalar_rhs(right, left))
-  def lt(left, %Series{} = right), do: lt(scalar_rhs(left, right), right)
+  def lt(%Series{} = left, right), do: apply_scalar_on_rhs(:less, left, right)
+  def lt(left, %Series{} = right), do: apply_scalar_on_lhs(:less, left, right)
 
   @impl true
   def lt_eq(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_lt_eq, [right.data])
 
-  def lt_eq(%Series{} = left, right), do: lt_eq(left, scalar_rhs(right, left))
-  def lt_eq(left, %Series{} = right), do: lt_eq(scalar_rhs(left, right), right)
+  def lt_eq(%Series{} = left, right), do: apply_scalar_on_rhs(:less_equal, left, right)
+  def lt_eq(left, %Series{} = right), do: apply_scalar_on_lhs(:less_equal, left, right)
 
   @impl true
   def all_equal(%Series{} = left, %Series{} = right),
@@ -379,11 +382,23 @@ defmodule Explorer.PolarsBackend.Series do
 
   # Helpers
 
-  defp scalar_rhs(scalar, lhs),
-    do:
-      scalar
-      |> List.duplicate(PolarsSeries.size(lhs))
-      |> Series.from_list()
+  defp apply_scalar_on_rhs(fun_name, %Series{} = left, scalar) when is_atom(fun_name) do
+    df =
+      DataFrame.mutate_with(DataFrame.new(left: left), fn ldf ->
+        [result: apply(Explorer.Series, fun_name, [ldf["left"], scalar])]
+      end)
+
+    df["result"]
+  end
+
+  defp apply_scalar_on_lhs(fun_name, scalar, %Series{} = right) when is_atom(fun_name) do
+    df =
+      DataFrame.mutate_with(DataFrame.new(right: right), fn ldf ->
+        [result: apply(Explorer.Series, fun_name, [scalar, ldf["right"]])]
+      end)
+
+    df["result"]
+  end
 end
 
 defimpl Inspect, for: Explorer.PolarsBackend.Series do


### PR DESCRIPTION
This is a refactor in the PolarsBackend.Series to reduce memory usage by avoiding the need to create series for scalar values. Instead it is using the lazy backend and expressions (lazy series) to pass down the literal value to Rust.

### Benchmark (using main)

```elixir
small = Explorer.Series.from_list(for _i <- 0..100, do: :random.uniform(1_000))
medium = Explorer.Series.from_list(for _i <- 0..1_000, do: :random.uniform(1_000))
big = Explorer.Series.from_list(for _i <- 0..10_000, do: :random.uniform(1_000))
biggest = Explorer.Series.from_list(for _i <- 0..100_000, do: :random.uniform(1_000))

Benchee.run(
  %{
    "add w/ list duplicated" => fn input -> Explorer.Series.add(input, 42) end,
    "add using expressions" => fn input ->
      df = Explorer.DataFrame.mutate_with(Explorer.DataFrame.new(left: input), fn ldf ->
        [result: Explorer.Series.add(ldf["left"], 42)]
      end)

      df["result"]
    end
  },
  memory_time: 2,
  inputs: %{
    "small" => small,
    "medium" => medium,
    "big" => big,
    "biggest" => biggest
  }
)
```

### Benchmark results

```
Operating System: Linux
CPU Information: AMD Ryzen 9 5950X 16-Core Processor
Number of Available Cores: 32
Available memory: 15.52 GB
Elixir 1.14.0
Erlang 25.1

Benchmark suite executing with the following configuration:
warmup: 2 s
time: 5 s
memory time: 2 s
reduction time: 0 ns
parallel: 1
inputs: big, biggest, medium, small
Estimated total run time: 1.20 min

Benchmarking add using expressions with input big ...
Benchmarking add using expressions with input biggest ...
Benchmarking add using expressions with input medium ...
Benchmarking add using expressions with input small ...
Benchmarking add w/ list duplicated with input big ...
Benchmarking add w/ list duplicated with input biggest ...
Benchmarking add w/ list duplicated with input medium ...
Benchmarking add w/ list duplicated with input small ...

##### With input big #####
Name                             ips        average  deviation         median         99th %
add using expressions         2.41 K        0.41 ms     ±4.53%        0.41 ms        0.46 ms
add w/ list duplicated        0.62 K        1.60 ms     ±0.64%        1.60 ms        1.63 ms

Comparison:
add using expressions         2.41 K
add w/ list duplicated        0.62 K - 3.87x slower +1.19 ms

Memory usage statistics:

Name                      Memory usage
add using expressions          5.04 KB
add w/ list duplicated       157.30 KB - 31.22x memory usage +152.26 KB

**All measurements for memory usage were the same**

##### With input biggest #####
Name                             ips        average  deviation         median         99th %
add using expressions         430.01        2.33 ms     ±1.08%        2.32 ms        2.40 ms
add w/ list duplicated         64.69       15.46 ms     ±1.53%       15.48 ms       15.76 ms

Comparison:
add using expressions         430.01
add w/ list duplicated         64.69 - 6.65x slower +13.13 ms

Memory usage statistics:

Name                      Memory usage
add using expressions       0.00492 MB
add w/ list duplicated         1.53 MB - 310.28x memory usage +1.52 MB

**All measurements for memory usage were the same**

##### With input medium #####
Name                             ips        average  deviation         median         99th %
add w/ list duplicated        6.14 K      162.83 μs     ±5.05%      163.79 μs      180.28 μs
add using expressions         4.75 K      210.32 μs     ±8.18%      206.90 μs      259.20 μs

Comparison:
add w/ list duplicated        6.14 K
add using expressions         4.75 K - 1.29x slower +47.49 μs

Memory usage statistics:

Name                      Memory usage
add w/ list duplicated        16.67 KB
add using expressions          5.04 KB - 0.30x memory usage -11.63281 KB

**All measurements for memory usage were the same**

##### With input small #####
Name                             ips        average  deviation         median         99th %
add w/ list duplicated       30.52 K       32.77 μs    ±68.29%       29.75 μs       98.42 μs
add using expressions         5.07 K      197.28 μs     ±9.70%      193.42 μs      261.05 μs

Comparison:
add w/ list duplicated       30.52 K
add using expressions         5.07 K - 6.02x slower +164.51 μs

Memory usage statistics:

Name                      Memory usage
add w/ list duplicated         2.61 KB
add using expressions          5.04 KB - 1.93x memory usage +2.43 KB

**All measurements for memory usage were the same**
```

Closes #368 