### PR TITLE
Allow arithmetic ops on (series, lazy series)

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -240,21 +240,10 @@ defmodule Explorer.Backend.LazySeries do
 
   for op <- @arithmetic_operations do
     @impl true
-    def unquote(op)(%Series{} = left, value_or_series) do
-      dtype = resolve_numeric_dtype([left, value_or_series])
-
-      value = with %Series{} <- value_or_series, do: series_or_lazy_series!(value_or_series)
-
-      args = [lazy_series!(left), value]
-      data = new(unquote(op), args, aggregations?(args), window_functions?(args))
-
-      Backend.Series.new(data, dtype)
-    end
-
-    def unquote(op)(left, %Series{} = right) when is_number(left) do
+    def unquote(op)(left, right) do
       dtype = resolve_numeric_dtype([left, right])
 
-      args = [left, lazy_series!(right)]
+      args = has_lazy_series!([left, right])
       data = new(unquote(op), args, aggregations?(args), window_functions?(args))
 
       Backend.Series.new(data, dtype)
@@ -376,15 +365,36 @@ defmodule Explorer.Backend.LazySeries do
   # Returns the inner `data` if it's a lazy series. Otherwise raises an error.
   defp lazy_series!(series) do
     case series do
-      %Series{data: %__MODULE__{} = lazy} ->
-        lazy
+      %Series{data: %__MODULE__{}} ->
+        data!(series)
 
       %Series{} ->
         raise ArgumentError, "expecting a LazySeries, but instead got #{inspect(series)}"
     end
   end
 
-  defp series_or_lazy_series!(%Series{data: data}), do: data
+  defp series_or_lazy_series!(%Series{} = series), do: data!(series)
+
+  defp has_lazy_series!(items) do
+    has_lazy_series =
+      items
+      |> Enum.any?(fn
+        %Series{data: %__MODULE__{}} -> true
+        _ -> false
+      end)
+
+    case has_lazy_series do
+      true ->
+        items |> Enum.map(&data!/1)
+
+      false ->
+        raise ArgumentError,
+              "expecting at least one LazySeries, but instead got #{inspect(items)}"
+    end
+  end
+
+  defp data!(%Series{data: data}), do: data
+  defp data!(value), do: value
 
   defp aggregations?(args) do
     Enum.any?(args, fn

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -243,7 +243,7 @@ defmodule Explorer.Backend.LazySeries do
     def unquote(op)(left, right) do
       dtype = resolve_numeric_dtype([left, right])
 
-      args = has_lazy_series!([left, right])
+      args = [data!(left), data!(right)]
       data = new(unquote(op), args, aggregations?(args), window_functions?(args))
 
       Backend.Series.new(data, dtype)
@@ -374,24 +374,6 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   defp series_or_lazy_series!(%Series{} = series), do: data!(series)
-
-  defp has_lazy_series!(items) do
-    has_lazy_series =
-      items
-      |> Enum.any?(fn
-        %Series{data: %__MODULE__{}} -> true
-        _ -> false
-      end)
-
-    case has_lazy_series do
-      true ->
-        items |> Enum.map(&data!/1)
-
-      false ->
-        raise ArgumentError,
-              "expecting at least one LazySeries, but instead got #{inspect(items)}"
-    end
-  end
 
   defp data!(%Series{data: data}), do: data
   defp data!(value), do: value

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1384,6 +1384,55 @@ defmodule Explorer.Series do
   end
 
   @doc """
+  Raises a numeric series to the power of the exponent.
+
+  ## Supported dtypes
+
+    * `:integer`
+    * `:float`
+
+  ## Examples
+
+      iex> s = [8, 16, 32] |> Explorer.Series.from_list()
+      iex> Explorer.Series.pow(s, 2.0)
+      #Explorer.Series<
+        float[3]
+        [64.0, 256.0, 1024.0]
+      >
+
+      iex> s = [2, 4, 6] |> Explorer.Series.from_list()
+      iex> Explorer.Series.pow(s, 3)
+      #Explorer.Series<
+        integer[3]
+        [8, 64, 216]
+      >
+
+      iex> s = [2, 4, 6] |> Explorer.Series.from_list()
+      iex> Explorer.Series.pow(s, -3.0)
+      #Explorer.Series<
+        float[3]
+        [0.125, 0.015625, 0.004629629629629629]
+      >
+
+      iex> s = [1.0, 2.0, 3.0] |> Explorer.Series.from_list()
+      iex> s |> Explorer.Series.pow(3.0)
+      #Explorer.Series<
+        float[3]
+        [1.0, 8.0, 27.0]
+      >
+
+      iex> s = [2.0, 4.0, 6.0] |> Explorer.Series.from_list()
+      iex> s |> Explorer.Series.pow(2)
+      #Explorer.Series<
+        float[3]
+        [4.0, 16.0, 36.0]
+      >
+  """
+  @doc type: :element_wise
+  @spec pow(series :: Series.t(), right :: Series.t() | number()) :: Series.t()
+  def pow(%Series{} = series, right), do: basic_numeric_operation(:pow, series, right)
+
+  @doc """
   Element-wise integer division.
 
   ## Supported dtype
@@ -1499,55 +1548,6 @@ defmodule Explorer.Series do
 
   defp basic_numeric_operation(operation, %Series{dtype: dtype}, _),
     do: dtype_error("#{operation}/2", dtype, [:integer, :float])
-
-  @doc """
-  Raises a numeric series to the power of the exponent.
-
-  ## Supported dtypes
-
-    * `:integer`
-    * `:float`
-
-  ## Examples
-
-      iex> s = [8, 16, 32] |> Explorer.Series.from_list()
-      iex> Explorer.Series.pow(s, 2.0)
-      #Explorer.Series<
-        float[3]
-        [64.0, 256.0, 1024.0]
-      >
-
-      iex> s = [2, 4, 6] |> Explorer.Series.from_list()
-      iex> Explorer.Series.pow(s, 3)
-      #Explorer.Series<
-        integer[3]
-        [8, 64, 216]
-      >
-
-      iex> s = [2, 4, 6] |> Explorer.Series.from_list()
-      iex> Explorer.Series.pow(s, -3.0)
-      #Explorer.Series<
-        float[3]
-        [0.125, 0.015625, 0.004629629629629629]
-      >
-
-      iex> s = [1.0, 2.0, 3.0] |> Explorer.Series.from_list()
-      iex> s |> Explorer.Series.pow(3.0)
-      #Explorer.Series<
-        float[3]
-        [1.0, 8.0, 27.0]
-      >
-
-      iex> s = [2.0, 4.0, 6.0] |> Explorer.Series.from_list()
-      iex> s |> Explorer.Series.pow(2)
-      #Explorer.Series<
-        float[3]
-        [4.0, 16.0, 36.0]
-      >
-  """
-  @doc type: :element_wise
-  @spec pow(series :: Series.t(), right :: Series.t() | number()) :: Series.t()
-  def pow(%Series{} = series, right), do: basic_numeric_operation(:pow, series, right)
 
   # Comparisons
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1421,13 +1421,13 @@ defmodule Explorer.Series do
   @doc type: :element_wise
   @spec quotient(left :: Series.t(), right :: Series.t() | integer()) :: Series.t()
   def quotient(%Series{dtype: :integer} = left, %Series{dtype: :integer} = right),
-    do: Shared.apply_binary_op_impl(:quotient, left, right)
+    do: Shared.apply_series_impl(:quotient, [left, right])
 
   def quotient(%Series{dtype: :integer} = left, right) when is_integer(right),
-    do: Shared.apply_binary_op_impl(:quotient, left, right)
+    do: Shared.apply_series_impl(:quotient, [left, right])
 
   def quotient(left, %Series{dtype: :integer} = right) when is_integer(left),
-    do: Shared.apply_binary_op_impl(:quotient, left, right)
+    do: Shared.apply_series_impl(:quotient, [left, right])
 
   @doc """
   Computes the remainder of an element-wise integer division.
@@ -1467,13 +1467,13 @@ defmodule Explorer.Series do
   @doc type: :element_wise
   @spec remainder(left :: Series.t(), right :: Series.t() | integer()) :: Series.t()
   def remainder(%Series{dtype: :integer} = left, %Series{dtype: :integer} = right),
-    do: Shared.apply_binary_op_impl(:remainder, left, right)
+    do: Shared.apply_series_impl(:remainder, [left, right])
 
   def remainder(%Series{dtype: :integer} = left, right) when is_integer(right),
-    do: Shared.apply_binary_op_impl(:remainder, left, right)
+    do: Shared.apply_series_impl(:remainder, [left, right])
 
   def remainder(left, %Series{dtype: :integer} = right) when is_integer(left),
-    do: Shared.apply_binary_op_impl(:remainder, left, right)
+    do: Shared.apply_series_impl(:remainder, [left, right])
 
   defp basic_numeric_operation(
          operation,
@@ -1481,18 +1481,18 @@ defmodule Explorer.Series do
          %Series{dtype: right_dtype} = right
        )
        when K.and(numeric_dtype?(left_dtype), numeric_dtype?(right_dtype)),
-       do: Shared.apply_binary_op_impl(operation, left, right)
+       do: Shared.apply_series_impl(operation, [left, right])
 
   defp basic_numeric_operation(operation, %Series{dtype: left_dtype}, %Series{dtype: right_dtype}),
     do: dtype_mismatch_error("#{operation}/2", left_dtype, right_dtype)
 
   defp basic_numeric_operation(operation, %Series{dtype: dtype} = left, right)
        when K.and(numeric_dtype?(dtype), is_number(right)),
-       do: Shared.apply_binary_op_impl(operation, left, right)
+       do: Shared.apply_series_impl(operation, [left, right])
 
   defp basic_numeric_operation(operation, left, %Series{dtype: dtype} = right)
        when K.and(numeric_dtype?(dtype), is_number(left)),
-       do: Shared.apply_binary_op_impl(operation, left, right)
+       do: Shared.apply_series_impl(operation, [left, right])
 
   defp basic_numeric_operation(operation, _, %Series{dtype: dtype}),
     do: dtype_error("#{operation}/2", dtype, [:integer, :float])
@@ -1546,11 +1546,8 @@ defmodule Explorer.Series do
       >
   """
   @doc type: :element_wise
-  @spec pow(series :: Series.t(), exponent :: number()) :: Series.t()
-  def pow(%Series{dtype: dtype} = series, exponent) when numeric_dtype?(dtype),
-    do: Shared.apply_impl(series, :pow, [exponent])
-
-  def pow(%Series{dtype: dtype}, _), do: dtype_error("pow/2", dtype, [:integer, :float])
+  @spec pow(series :: Series.t(), right :: Series.t() | number()) :: Series.t()
+  def pow(%Series{} = series, right), do: basic_numeric_operation(:pow, series, right)
 
   # Comparisons
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -49,7 +49,8 @@ defmodule Explorer.Shared do
       end)
 
     if impl == nil do
-      raise ArgumentError, "could not find a implementation for: #{inspect(series_or_scalars)}"
+      raise ArgumentError,
+            "expected at least one series to be given as argument, got: #{inspect(series_or_scalars)}"
     end
 
     impl

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -2,6 +2,8 @@ defmodule Explorer.Shared do
   # A collection of **private** helpers shared in Explorer.
   @moduledoc false
 
+  alias Explorer.Backend.LazySeries
+
   @doc """
   All supported dtypes.
   """
@@ -36,11 +38,38 @@ defmodule Explorer.Shared do
     do: pick_struct(struct1, struct2)
 
   @doc """
+  Gets the implementation of maybe series.
+  """
+  def series_impl!(series_or_scalars) when is_list(series_or_scalars) do
+    impl =
+      Enum.reduce(series_or_scalars, nil, fn
+        %{data: %struct{}}, nil -> struct
+        %{data: %struct{}}, impl -> pick_series_impl(impl, struct)
+        _scalar, impl -> impl
+      end)
+
+    if impl == nil do
+      raise ArgumentError, "could not find a implementation for: #{inspect(series_or_scalars)}"
+    end
+
+    impl
+  end
+
+  @doc """
   Applies a function with args using the implementation of a dataframe or series.
   """
   def apply_impl(df_or_series, fun, args \\ []) do
     impl = impl!(df_or_series)
     apply(impl, fun, [df_or_series | args])
+  end
+
+  @doc """
+  Applies a function using the implementation of maybe series.
+  """
+  def apply_series_impl(fun, series_or_scalars) when is_list(series_or_scalars) do
+    impl = series_impl!(series_or_scalars)
+
+    apply(impl, fun, series_or_scalars)
   end
 
   @doc """
@@ -85,6 +114,15 @@ defmodule Explorer.Shared do
     raise "cannot invoke Explorer function because it relies on two incompatible implementations: " <>
             "#{inspect(struct1)} and #{inspect(struct2)}. You may need to call Explorer.backend_transfer/1 " <>
             "(or Explorer.backend_copy/1) on one or both of them to transfer them to a common implementation"
+  end
+
+  defp pick_series_impl(struct, struct), do: struct
+  defp pick_series_impl(LazySeries, _), do: LazySeries
+  defp pick_series_impl(_, LazySeries), do: LazySeries
+
+  defp pick_series_impl(struct1, struct2) do
+    raise "cannot invoke Explorer function because it relies on two incompatible implementations: " <>
+            "#{inspect(struct1)} and #{inspect(struct2)}."
   end
 
   @doc """

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -468,21 +468,177 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
-    test "adds some columns with arithmetic operations" do
+    test "adds some columns with arithmetic operations on (lazy series, number)" do
+      df = DF.new(a: [1, 2, 4])
+
+      df1 =
+        DF.mutate_with(df, fn ldf ->
+          [
+            calc1: Series.add(ldf["a"], 2),
+            calc2: Series.subtract(ldf["a"], 2),
+            calc3: Series.multiply(ldf["a"], 2),
+            calc4: Series.divide(ldf["a"], 2),
+            calc5: Series.pow(ldf["a"], 2),
+            calc6: Series.quotient(ldf["a"], 2),
+            calc7: Series.remainder(ldf["a"], 2)
+          ]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 2, 4],
+               calc1: [3, 4, 6],
+               calc2: [-1, 0, 2],
+               calc3: [2, 4, 8],
+               calc4: [0.5, 1.0, 2.0],
+               calc5: [1.0, 4.0, 16.0],
+               calc6: [0, 1, 2],
+               calc7: [1, 0, 0]
+             }
+
+      assert DF.dtypes(df1) == %{
+               "a" => :integer,
+               "calc1" => :integer,
+               "calc2" => :integer,
+               "calc3" => :integer,
+               "calc4" => :float,
+               "calc5" => :integer,
+               "calc6" => :integer,
+               "calc7" => :integer
+             }
+    end
+
+    test "adds some columns with arithmetic operations on (number, lazy series)" do
+      df = DF.new(a: [1, 2, 4])
+
+      df1 =
+        DF.mutate_with(df, fn ldf ->
+          [
+            calc1: Series.add(2, ldf["a"]),
+            calc2: Series.subtract(2, ldf["a"]),
+            calc3: Series.multiply(2, ldf["a"]),
+            calc4: Series.divide(2, ldf["a"]),
+            # calc5: Series.pow(2, ldf["a"]),
+            calc6: Series.quotient(2, ldf["a"]),
+            calc7: Series.remainder(2, ldf["a"])
+          ]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 2, 4],
+               calc1: [3, 4, 6],
+               calc2: [1, 0, -2],
+               calc3: [2, 4, 8],
+               calc4: [2.0, 1.0, 0.5],
+               #  calc5: [2.0, 4.0, 16.0],
+               calc6: [2, 1, 0],
+               calc7: [0, 0, 2]
+             }
+
+      assert DF.dtypes(df1) == %{
+               "a" => :integer,
+               "calc1" => :integer,
+               "calc2" => :integer,
+               "calc3" => :integer,
+               "calc4" => :float,
+               #  "calc5" => :integer,
+               "calc6" => :integer,
+               "calc7" => :integer
+             }
+    end
+
+    test "adds some columns with arithmetic operations on (lazy series, series)" do
+      df = DF.new(a: [1, 2, 4])
+      series = Explorer.Series.from_list([2, 1, 2])
+
+      df1 =
+        DF.mutate_with(df, fn ldf ->
+          [
+            calc1: Series.add(ldf["a"], series),
+            calc2: Series.subtract(ldf["a"], series),
+            calc3: Series.multiply(ldf["a"], series),
+            calc4: Series.divide(ldf["a"], series),
+            calc5: Series.pow(ldf["a"], series),
+            calc6: Series.quotient(ldf["a"], series),
+            calc7: Series.remainder(ldf["a"], series)
+          ]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1, 2, 4],
+               calc1: [3, 3, 6],
+               calc2: [-1, 1, 2],
+               calc3: [2, 2, 8],
+               calc4: [0.5, 2.0, 2.0],
+               calc5: [1.0, 2.0, 16.0],
+               calc6: [0, 2, 2],
+               calc7: [1, 0, 0]
+             }
+
+      assert DF.dtypes(df1) == %{
+               "a" => :integer,
+               "calc1" => :integer,
+               "calc2" => :integer,
+               "calc3" => :integer,
+               "calc4" => :float,
+               "calc5" => :integer,
+               "calc6" => :integer,
+               "calc7" => :integer
+             }
+    end
+
+    test "adds some columns with arithmetic operations on (series, lazy series)" do
+      df = DF.new(a: [2, 1, 2])
+      series = Explorer.Series.from_list([1, 2, 4])
+
+      df1 =
+        DF.mutate_with(df, fn ldf ->
+          [
+            calc1: Series.add(series, ldf["a"]),
+            calc2: Series.subtract(series, ldf["a"]),
+            calc3: Series.multiply(series, ldf["a"]),
+            calc4: Series.divide(series, ldf["a"]),
+            calc5: Series.pow(series, ldf["a"]),
+            calc6: Series.quotient(series, ldf["a"]),
+            calc7: Series.remainder(series, ldf["a"])
+          ]
+        end)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [2, 1, 2],
+               calc1: [3, 3, 6],
+               calc2: [-1, 1, 2],
+               calc3: [2, 2, 8],
+               calc4: [0.5, 2.0, 2.0],
+               calc5: [1.0, 2.0, 16.0],
+               calc6: [0, 2, 2],
+               calc7: [1, 0, 0]
+             }
+
+      assert DF.dtypes(df1) == %{
+               "a" => :integer,
+               "calc1" => :integer,
+               "calc2" => :integer,
+               "calc3" => :integer,
+               "calc4" => :float,
+               "calc5" => :integer,
+               "calc6" => :integer,
+               "calc7" => :integer
+             }
+    end
+
+    test "adds some columns with arithmetic operations on (lazy series, lazy series)" do
       df = DF.new(a: [1, 2, 3], b: [20, 40, 60], c: [10, 0, 8], d: [3, 2, 1])
 
       df1 =
         DF.mutate_with(df, fn ldf ->
           [
-            calc1: Series.divide(ldf["a"], 10) |> Series.multiply(2),
-            calc2: Series.add(ldf["a"], ldf["b"]),
-            calc3: Series.subtract(ldf["b"], ldf["a"]),
+            calc1: Series.add(ldf["a"], ldf["b"]),
+            calc2: Series.subtract(ldf["b"], ldf["a"]),
+            calc3: Series.multiply(ldf["a"], ldf["d"]),
             calc4: Series.divide(ldf["b"], ldf["c"]),
             calc5: Series.pow(ldf["a"], ldf["d"]),
             calc6: Series.quotient(ldf["b"], ldf["c"]),
-            calc7: Series.remainder(ldf["b"], ldf["c"]),
-            calc8: Series.add(ldf["a"], Series.from_list([20, 40, 60])),
-            calc9: Series.add(Series.from_list([20, 40, 60]), ldf["a"])
+            calc7: Series.remainder(ldf["b"], ldf["c"])
           ]
         end)
 
@@ -491,15 +647,13 @@ defmodule Explorer.DataFrameTest do
                b: [20, 40, 60],
                c: [10, 0, 8],
                d: [3, 2, 1],
-               calc1: [0.2, 0.4, 0.6],
-               calc2: [21, 42, 63],
-               calc3: [19, 38, 57],
+               calc1: [21, 42, 63],
+               calc2: [19, 38, 57],
+               calc3: [3, 4, 3],
                calc4: [2.0, :infinity, 7.5],
-               calc5: [1, 4, 3],
+               calc5: [1.0, 4.0, 3.0],
                calc6: [2, nil, 7],
-               calc7: [0, nil, 4],
-               calc8: [21, 42, 63],
-               calc9: [21, 42, 63]
+               calc7: [0, nil, 4]
              }
 
       assert DF.dtypes(df1) == %{
@@ -507,15 +661,13 @@ defmodule Explorer.DataFrameTest do
                "b" => :integer,
                "c" => :integer,
                "d" => :integer,
-               "calc1" => :float,
+               "calc1" => :integer,
                "calc2" => :integer,
                "calc3" => :integer,
                "calc4" => :float,
                "calc5" => :integer,
                "calc6" => :integer,
-               "calc7" => :integer,
-               "calc8" => :integer,
-               "calc9" => :integer
+               "calc7" => :integer
              }
     end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -481,7 +481,8 @@ defmodule Explorer.DataFrameTest do
             calc5: Series.pow(ldf["a"], ldf["d"]),
             calc6: Series.quotient(ldf["b"], ldf["c"]),
             calc7: Series.remainder(ldf["b"], ldf["c"]),
-            calc8: Series.add(ldf["a"], Series.from_list([20, 40, 60]))
+            calc8: Series.add(ldf["a"], Series.from_list([20, 40, 60])),
+            calc9: Series.add(Series.from_list([20, 40, 60]), ldf["a"])
           ]
         end)
 
@@ -497,7 +498,8 @@ defmodule Explorer.DataFrameTest do
                calc5: [1, 4, 3],
                calc6: [2, nil, 7],
                calc7: [0, nil, 4],
-               calc8: [21, 42, 63]
+               calc8: [21, 42, 63],
+               calc9: [21, 42, 63]
              }
 
       assert DF.dtypes(df1) == %{
@@ -512,7 +514,8 @@ defmodule Explorer.DataFrameTest do
                "calc5" => :integer,
                "calc6" => :integer,
                "calc7" => :integer,
-               "calc8" => :integer
+               "calc8" => :integer,
+               "calc9" => :integer
              }
     end
 

--- a/test/explorer/shared_test.exs
+++ b/test/explorer/shared_test.exs
@@ -11,6 +11,44 @@ defmodule Explorer.SharedTest do
     end
   end
 
+  describe "impl!/1" do
+    test "with a series" do
+      assert Shared.impl!(series()) == Explorer.PolarsBackend.Series
+    end
+
+    test "with a lazy series" do
+      assert Shared.impl!(lazy_series()) == Explorer.Backend.LazySeries
+    end
+
+    test "with list of series" do
+      assert Shared.impl!([series(), series()]) == Explorer.PolarsBackend.Series
+    end
+
+    test "with list of lazy series" do
+      assert Shared.impl!([lazy_series(), lazy_series()]) == Explorer.Backend.LazySeries
+    end
+
+    test "with list of series and lazy series" do
+      assert_raise RuntimeError, fn -> Shared.impl!([series(), lazy_series()]) end
+      assert_raise RuntimeError, fn -> Shared.impl!([lazy_series(), series()]) end
+    end
+  end
+
+  describe "impl!/2" do
+    test "with two series" do
+      assert Shared.impl!(series(), series()) == Explorer.PolarsBackend.Series
+    end
+
+    test "with two lazy series" do
+      assert Shared.impl!(lazy_series(), lazy_series()) == Explorer.Backend.LazySeries
+    end
+
+    test "with a series and a lazy series" do
+      assert_raise RuntimeError, fn -> Shared.impl!(series(), lazy_series()) end
+      assert_raise RuntimeError, fn -> Shared.impl!(lazy_series(), series()) end
+    end
+  end
+
   describe "apply_binary_op_impl/1" do
     test "applies when series is on the left-hand side" do
       :ok = Shared.apply_binary_op_impl(:ping, %{data: %FakeImpl{}}, 42)
@@ -34,5 +72,14 @@ defmodule Explorer.SharedTest do
         Shared.apply_binary_op_impl(:ping, 42, 13)
       end
     end
+  end
+
+  defp series(data \\ [1]) do
+    Explorer.Series.from_list(data, backend: Explorer.PolarsBackend)
+  end
+
+  defp lazy_series() do
+    data = Explorer.Backend.LazySeries.new(:column, ["col_a"])
+    Explorer.Backend.Series.new(data, :integer)
   end
 end

--- a/test/explorer/shared_test.exs
+++ b/test/explorer/shared_test.exs
@@ -49,6 +49,25 @@ defmodule Explorer.SharedTest do
     end
   end
 
+  describe "series_impl!/1" do
+    test "with series" do
+      assert Shared.series_impl!([series(), series()]) == Explorer.PolarsBackend.Series
+    end
+
+    test "with lazy sereis" do
+      assert Shared.series_impl!([lazy_series(), lazy_series()]) == Explorer.Backend.LazySeries
+    end
+
+    test "with a series and a lazy series" do
+      assert Shared.series_impl!([1, series(), lazy_series()]) == Explorer.Backend.LazySeries
+      assert Shared.series_impl!([lazy_series(), 2, series()]) == Explorer.Backend.LazySeries
+    end
+
+    test "without a series nor a lazy series" do
+      assert_raise ArgumentError, fn -> Shared.series_impl!([1, 2]) end
+    end
+  end
+
   describe "apply_binary_op_impl/1" do
     test "applies when series is on the left-hand side" do
       :ok = Shared.apply_binary_op_impl(:ping, %{data: %FakeImpl{}}, 42)


### PR DESCRIPTION
#367

This PR allows arithmetic ops on (series, lazy series).

I made `Explorer.Shared.apply_series_impl/2`.

It determines impl following rules below
- if `series_or_scalars` contain at least one lazy series -> lazy series
- else if `series_or_scalars` contain at least one series -> series
- else if `series_or_scalars` don't contain any series or lazy series -> raise

Remain tasks

- Apply it to comparison ops and slice and dice ops
- Replace `Explorer.Shared.apply_binary_op_impl/3` with it
- Merge it into `Explorer.Shared.apply_impl/2`