### PR TITLE
Add docs about DF operations when using groups - part 2

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1773,8 +1773,8 @@ defmodule Explorer.DataFrame do
   ## Grouped examples
 
   When used in a grouped dataframe, `arrange_with/2` is going to sort each group individually
-  and then return the entire dataframe with the existing groups. If one of the arrange columns
-  is also a group, the sorting for that column is not going to work. It is necessary to
+  and then return the entire dataframe with the existing groups. Therefore, if you attempt
+  to arrange a grouped column, it won't have any effect and work as no-op. It is necessary to
   first summarise the desired column and then arrange it.
 
   Here is an example using the Iris dataset. We group by species and then we try to sort

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -870,6 +870,9 @@ defmodule Explorer.DataFrame do
   @doc """
   Gets the shape of the dataframe as a `{height, width}` tuple.
 
+  This function works the same way for grouped dataframes, considering the entire
+  dataframe in the counting of rows.
+
   ## Examples
 
       iex> df = Explorer.DataFrame.new(floats: [1.0, 2.0, 3.0], ints: [1, 2, 3])
@@ -883,6 +886,9 @@ defmodule Explorer.DataFrame do
   @doc """
   Returns the number of rows in the dataframe.
 
+  This function works the same way for grouped dataframes, considering the entire
+  dataframe in the counting of rows.
+
   ## Examples
 
       iex> df = Explorer.Datasets.fossil_fuels()
@@ -895,6 +901,8 @@ defmodule Explorer.DataFrame do
 
   @doc """
   Returns the number of columns in the dataframe.
+
+  This function works the same way for grouped dataframes.
 
   ## Examples
 
@@ -1661,9 +1669,9 @@ defmodule Explorer.DataFrame do
   is also a group, the sorting for that column is not going to work. It is necessary to
   first summarise the desired column and then arrange it.
 
-  Here is an example using the Iris dataset. We group by species and try to sort the dataframe 
-  by species and petal length, but only "petal length" is taken into account because "species"
-  is a group.
+  Here is an example using the Iris dataset. We group by species and then we try to sort
+  the dataframe by species and petal length, but only "petal length" is taken into account
+  because "species" is a group.
 
       iex> df = Explorer.Datasets.iris()
       iex> grouped = Explorer.DataFrame.group_by(df, "species")
@@ -1743,6 +1751,30 @@ defmodule Explorer.DataFrame do
         Polars[3 x 2]
         a integer [3, 3, 1]
         b integer [2, 3, 1]
+      >
+
+  ## Grouped examples
+
+  When used in a grouped dataframe, `arrange_with/2` is going to sort each group individually
+  and then return the entire dataframe with the existing groups. If one of the arrange columns
+  is also a group, the sorting for that column is not going to work. It is necessary to
+  first summarise the desired column and then arrange it.
+
+  Here is an example using the Iris dataset. We group by species and then we try to sort
+  the dataframe by species and petal length, but only "petal length" is taken into account
+  because "species" is a group.
+
+      iex> df = Explorer.Datasets.iris()
+      iex> grouped = Explorer.DataFrame.group_by(df, "species")
+      iex> Explorer.DataFrame.arrange_with(grouped, &[desc: &1["species"], asc: &1["sepal_width"]])
+      #Explorer.DataFrame<
+        Polars[150 x 5]
+        Groups: ["species"]
+        sepal_length float [4.5, 4.4, 4.9, 4.8, 4.3, ...]
+        sepal_width float [2.3, 2.9, 3.0, 3.0, 3.0, ...]
+        petal_length float [1.3, 1.4, 1.4, 1.4, 1.1, ...]
+        petal_width float [0.3, 0.2, 0.2, 0.1, 0.1, ...]
+        species string ["Iris-setosa", "Iris-setosa", "Iris-setosa", "Iris-setosa", "Iris-setosa", ...]
       >
   """
   @doc type: :single
@@ -2163,6 +2195,8 @@ defmodule Explorer.DataFrame do
 
   @doc """
   Extracts a single column as a series.
+
+  This function is not going to consider groups when pulling series.
 
   ## Examples
 

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -468,7 +468,7 @@ pub fn df_arrange_with(
             .sort_by_exprs(exprs, directions, false)
             .collect()?
     } else {
-        df.groupby(groups)?.apply(|df| {
+        df.groupby_stable(groups)?.apply(|df| {
             df.lazy()
                 .sort_by_exprs(&exprs, &directions, false)
                 .collect()

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -811,4 +811,9 @@ defmodule Explorer.DataFrame.GroupedTest do
       assert DF.dump_csv(grouped_df) == dumped_csv
     end
   end
+
+  test "to_lazy/1", %{df: df} do
+    grouped = DF.group_by(df, ["country", "year"])
+    assert ["country", "year"] = DF.to_lazy(grouped).groups
+  end
 end

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -737,4 +737,78 @@ defmodule Explorer.DataFrame.GroupedTest do
       assert Series.to_list(DF.pull(df1, "country")) == Series.to_list(DF.pull(df, "country"))
     end
   end
+
+  describe "to_csv/2" do
+    @tag :tmp_dir
+    test "does not consider groups when saving file", %{df: df, tmp_dir: tmp_dir} do
+      ungrouped_file_path = Path.join(tmp_dir, "ungrouped-tmp.csv")
+      :ok = DF.to_csv(df, ungrouped_file_path)
+
+      grouped_df = DF.group_by(df, "year")
+      grouped_file_path = Path.join(tmp_dir, "grouped-tmp.csv")
+
+      assert :ok = DF.to_csv(grouped_df, grouped_file_path)
+
+      # Files with the same content
+      assert File.read!(ungrouped_file_path) == File.read!(grouped_file_path)
+    end
+  end
+
+  describe "to_ipc/2" do
+    @tag :tmp_dir
+    test "does not consider groups when saving file", %{df: df, tmp_dir: tmp_dir} do
+      ungrouped_file_path = Path.join(tmp_dir, "ungrouped-tmp.ipc")
+      :ok = DF.to_ipc(df, ungrouped_file_path)
+
+      grouped_df = DF.group_by(df, "year")
+      grouped_file_path = Path.join(tmp_dir, "grouped-tmp.ipc")
+
+      assert :ok = DF.to_ipc(grouped_df, grouped_file_path)
+
+      # Files with the same content
+      assert File.read!(ungrouped_file_path) == File.read!(grouped_file_path)
+    end
+  end
+
+  describe "to_ndjson/2" do
+    @tag :tmp_dir
+    test "does not consider groups when saving file", %{df: df, tmp_dir: tmp_dir} do
+      ungrouped_file_path = Path.join(tmp_dir, "ungrouped-tmp.ndjson")
+      :ok = DF.to_ndjson(df, ungrouped_file_path)
+
+      grouped_df = DF.group_by(df, "year")
+      grouped_file_path = Path.join(tmp_dir, "grouped-tmp.ndjson")
+
+      assert :ok = DF.to_ndjson(grouped_df, grouped_file_path)
+
+      # Files with the same content
+      assert File.read!(ungrouped_file_path) == File.read!(grouped_file_path)
+    end
+  end
+
+  describe "to_parquet/2" do
+    @tag :tmp_dir
+    test "does not consider groups when saving file", %{df: df, tmp_dir: tmp_dir} do
+      ungrouped_file_path = Path.join(tmp_dir, "ungrouped-tmp.parquet")
+      :ok = DF.to_parquet(df, ungrouped_file_path)
+
+      grouped_df = DF.group_by(df, "year")
+      grouped_file_path = Path.join(tmp_dir, "grouped-tmp.parquet")
+
+      assert :ok = DF.to_parquet(grouped_df, grouped_file_path)
+
+      # Files with the same content
+      assert File.read!(ungrouped_file_path) == File.read!(grouped_file_path)
+    end
+  end
+
+  describe "dump_csv/2" do
+    test "does not consider groups when dumping DF", %{df: df} do
+      dumped_csv = DF.dump_csv(df)
+
+      grouped_df = DF.group_by(df, "year")
+
+      assert DF.dump_csv(grouped_df) == dumped_csv
+    end
+  end
 end

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -702,4 +702,39 @@ defmodule Explorer.DataFrame.GroupedTest do
       assert DF.shape(df2) == {10, 10}
     end
   end
+
+  describe "shape/1" do
+    test "does not consider groups when counting rows", %{df: df} do
+      df1 = DF.group_by(df, ["year"])
+
+      assert DF.shape(df1) == {1094, 10}
+      assert DF.shape(df) == DF.shape(df1)
+    end
+  end
+
+  describe "n_columns/1" do
+    test "groups don't affect counting of columns", %{df: df} do
+      df1 = DF.group_by(df, ["year"])
+
+      assert DF.n_columns(df1) == 10
+      assert DF.n_columns(df) == DF.n_columns(df1)
+    end
+  end
+
+  describe "n_rows/1" do
+    test "does not consider groups when counting rows", %{df: df} do
+      df1 = DF.group_by(df, ["year"])
+
+      assert DF.n_rows(df1) == 1094
+      assert DF.n_rows(df) == DF.n_rows(df1)
+    end
+  end
+
+  describe "pull/2" do
+    test "does not consider groups when counting rows", %{df: df} do
+      df1 = DF.group_by(df, ["year"])
+
+      assert Series.to_list(DF.pull(df1, "country")) == Series.to_list(DF.pull(df, "country"))
+    end
+  end
 end


### PR DESCRIPTION
This is related to https://github.com/elixir-nx/explorer/issues/245 and a continuation of https://github.com/elixir-nx/explorer/pull/349

It includes the following:

- `to_{csv, ipc, ndjson, parquet}` (IO operations)
- `arrange_with` (with a fix for stable grouping)
- `to_lazy`
- `to_columns`
- `to_series`
- `shape` / `n_columns` / `n_rows`

I should open more PRs this week related to this.