### PR TITLE
Disable NDJSON feature for ARM 32 targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,12 +28,13 @@ jobs:
       matrix:
         job:
           # NIF version 2.16
-          # - {
-          #     target: arm-unknown-linux-gnueabihf,
-          #     os: ubuntu-20.04,
-          #     nif: "2.16",
-          #     use-cross: true,
-          #   }
+          - {
+              target: arm-unknown-linux-gnueabihf,
+              os: ubuntu-20.04,
+              nif: "2.16",
+              use-cross: true,
+              disable-polars-json-feature: true,
+            }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16", use-cross: true }
           - { target: aarch64-apple-darwin, os: macos-11, nif: "2.16" }
           - { target: x86_64-apple-darwin, os: macos-11, nif: "2.16" }
@@ -42,12 +43,13 @@ jobs:
           - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.16" }
           - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.16" }
           # NIF version 2.15
-          # - {
-          #     target: arm-unknown-linux-gnueabihf,
-          #     os: ubuntu-20.04,
-          #     nif: "2.15",
-          #     use-cross: true,
-          #   }
+          - {
+              target: arm-unknown-linux-gnueabihf,
+              os: ubuntu-20.04,
+              nif: "2.15",
+              use-cross: true,
+              disable-polars-json-feature: true,
+            }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15", use-cross: true }
           - { target: aarch64-apple-darwin, os: macos-11, nif: "2.15" }
           - { target: x86_64-apple-darwin, os: macos-11, nif: "2.15" }
@@ -56,12 +58,13 @@ jobs:
           - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.15" }
           - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.15" }
           # # NIF version 2.14
-          # - {
-          #     target: arm-unknown-linux-gnueabihf,
-          #     os: ubuntu-20.04,
-          #     nif: "2.14",
-          #     use-cross: true,
-          #   }
+          - {
+              target: arm-unknown-linux-gnueabihf,
+              os: ubuntu-20.04,
+              nif: "2.14",
+              use-cross: true,
+              disable-polars-json-feature: true,
+            }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14", use-cross: true }
           - { target: aarch64-apple-darwin, os: macos-11, nif: "2.14" }
           - { target: x86_64-apple-darwin, os: macos-11, nif: "2.14" }
@@ -109,6 +112,13 @@ jobs:
           cargo -V
           rustc -V
           rustc --print=cfg
+
+      - name: Disable JSON feature from Polars that won't compile on certain targets
+        if: ${{ matrix.job.disable-polars-json-feature }}
+        shell: bash
+        run: |
+          cargo install cargo-feature
+          cargo feature polars ^json
 
       - name: Download cross from GitHub releases
         uses: giantswarm/install-binary-action@v1.0.0

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -36,6 +36,7 @@ features = [
   "dtype-datetime",
   "ipc",
   "ipc_streaming",
+  # JSON won't compile on ARM 32 bits targets, so we disable in the "release" workflow.
   "json",
   "lazy",
   "parquet",

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -237,6 +237,7 @@ pub fn df_write_ipc_stream(
     Ok(())
 }
 
+#[cfg(not(target_arch = "arm"))]
 #[rustler::nif(schedule = "DirtyIo")]
 pub fn df_read_ndjson(
     filename: &str,
@@ -254,6 +255,7 @@ pub fn df_read_ndjson(
     Ok(ExDataFrame::new(df))
 }
 
+#[cfg(not(target_arch = "arm"))]
 #[rustler::nif(schedule = "DirtyIo")]
 pub fn df_write_ndjson(data: ExDataFrame, filename: &str) -> Result<(), ExplorerError> {
     let df = &data.resource.0;
@@ -261,6 +263,26 @@ pub fn df_write_ndjson(data: ExDataFrame, filename: &str) -> Result<(), Explorer
     let mut buf_writer = BufWriter::new(file);
     JsonWriter::new(&mut buf_writer).finish(&mut df.clone())?;
     Ok(())
+}
+
+#[cfg(target_arch = "arm")]
+#[rustler::nif]
+pub fn df_read_ndjson(
+    _filename: &str,
+    _infer_schema_length: Option<usize>,
+    _batch_size: usize,
+) -> Result<ExDataFrame, ExplorerError> {
+    Err(ExplorerError::Other(format!(
+        "NDJSON parsing is not enabled for this machine"
+    )))
+}
+
+#[cfg(target_arch = "arm")]
+#[rustler::nif]
+pub fn df_write_ndjson(_data: ExDataFrame, _filename: &str) -> Result<(), ExplorerError> {
+    Err(ExplorerError::Other(format!(
+        "NDJSON writing is not enabled for this machine"
+    )))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]


### PR DESCRIPTION
This is necessary because simd-json, which is a dependency of polars when the "json" feature is enabled, does not compile on ARM 32 bits targets.

A proposal for a feature flag disabling simd-json was made: https://github.com/pola-rs/polars/issues/5021#issuecomment-1286441153