### PR TITLE
Simplify target section of release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,55 +26,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        nif: ["2.16", "2.15", "2.14"]
         job:
-          # NIF version 2.16
           - {
               target: arm-unknown-linux-gnueabihf,
               os: ubuntu-20.04,
-              nif: "2.16",
               use-cross: true,
               disable-polars-json-feature: true,
             }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16", use-cross: true }
-          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.16" }
-          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.16" }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.16" }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.16", use-cross: true }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.16" }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.16" }
-          # NIF version 2.15
-          - {
-              target: arm-unknown-linux-gnueabihf,
-              os: ubuntu-20.04,
-              nif: "2.15",
-              use-cross: true,
-              disable-polars-json-feature: true,
-            }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15", use-cross: true }
-          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.15" }
-          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.15" }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.15" }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.15", use-cross: true }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.15" }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.15" }
-          # # NIF version 2.14
-          - {
-              target: arm-unknown-linux-gnueabihf,
-              os: ubuntu-20.04,
-              nif: "2.14",
-              use-cross: true,
-              disable-polars-json-feature: true,
-            }
-          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14", use-cross: true }
-          - { target: aarch64-apple-darwin, os: macos-11, nif: "2.14" }
-          - { target: x86_64-apple-darwin, os: macos-11, nif: "2.14" }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04, nif: "2.14" }
-          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, nif: "2.14", use-cross: true }
-          - { target: x86_64-pc-windows-gnu, os: windows-2019, nif: "2.14" }
-          - { target: x86_64-pc-windows-msvc, os: windows-2019, nif: "2.14" }
+          - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
+          - { target: aarch64-apple-darwin, os: macos-11 }
+          - { target: x86_64-apple-darwin, os: macos-11 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
+          - { target: x86_64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
+          - { target: x86_64-pc-windows-gnu, os: windows-2019 }
+          - { target: x86_64-pc-windows-msvc, os: windows-2019 }
 
     env:
-      RUSTLER_NIF_VERSION: ${{ matrix.job.nif }}
+      RUSTLER_NIF_VERSION: ${{ matrix.nif }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2


### PR DESCRIPTION
Update the matrix in `release.yml` to have a list of `nifs` and `jobs`. This allows the targets to be re-used across different `nif` versions, avoiding the need to list the same targets for each `nif` version.

Suggesting this in the hopes that it makes maintaining the file a bit easier. 

This was inspired by:

- https://github.com/philss/rustler_precompilation_example/blob/6a2baafc1995448bdd70dcb9c799bf85d2368df3/.github/workflows/release.yml#L25-L35
- https://github.com/kloeckner-i/mail_parser/blob/fe20dc953ea10f86b1ff3ad8532866a733a406ea/.github/workflows/release.yml#L29-L40