### PR TITLE
Refactor encoding of ExplorerError for better context

### DIFF
--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -126,9 +126,6 @@ defmodule Explorer.PolarsBackend.Shared do
   def internal_from_dtype(:date), do: "date"
   def internal_from_dtype(:datetime), do: "datetime[μs]"
 
-  defp error_message(error) when is_binary(error) do
-    Regex.replace(~r/\w+\((.+)\)/, error, "\\1")
-  end
-
-  defp error_message(error), do: "#{error}"
+  defp error_message({_err_type, error}) when is_binary(error), do: error
+  defp error_message(error), do: inspect(error)
 end

--- a/native/explorer/src/error.rs
+++ b/native/explorer/src/error.rs
@@ -1,10 +1,17 @@
-use rustler::{Encoder, Env, Term};
+use rustler::{Atom, Encoder, Env, Term};
 use std::io;
 use thiserror::Error;
 
+// Defines the atoms for each value of ExplorerError.
 rustler::atoms! {
-    ok,
-    error
+    io,
+    utf8,
+    polars,
+    internal,
+    other,
+    try_from_int,
+    parquet,
+    unknown
 }
 
 #[derive(Error, Debug)]
@@ -29,6 +36,26 @@ pub enum ExplorerError {
 
 impl Encoder for ExplorerError {
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
-        format!("{:?}", self).encode(env)
+        match self {
+            ExplorerError::Io(ref value) => error_tuple(env, io(), format!("{}", value)),
+            ExplorerError::Utf8(ref value) => error_tuple(env, utf8(), format!("{}", value)),
+            ExplorerError::Polars(ref value) => error_tuple(env, polars(), format!("{}", value)),
+
+            ExplorerError::Internal(ref value) => {
+                error_tuple(env, internal(), format!("{}", value))
+            }
+
+            ExplorerError::Other(ref value) => error_tuple(env, other(), format!("{}", value)),
+            ExplorerError::TryFromInt(ref value) => {
+                error_tuple(env, try_from_int(), format!("{}", value))
+            }
+            ExplorerError::Parquet(ref value) => error_tuple(env, parquet(), format!("{}", value)),
+            ExplorerError::Unknown(ref value) => error_tuple(env, unknown(), format!("{}", value)),
+        }
     }
+}
+
+// Encode an error tuple for better context at the Elixir side.
+fn error_tuple(env: Env, atom: Atom, error_str: String) -> Term {
+    (atom.encode(env), error_str.encode(env)).encode(env)
 }

--- a/native/explorer/src/error.rs
+++ b/native/explorer/src/error.rs
@@ -37,20 +37,18 @@ pub enum ExplorerError {
 impl Encoder for ExplorerError {
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
         match self {
-            ExplorerError::Io(ref value) => error_tuple(env, io(), format!("{}", value)),
-            ExplorerError::Utf8(ref value) => error_tuple(env, utf8(), format!("{}", value)),
-            ExplorerError::Polars(ref value) => error_tuple(env, polars(), format!("{}", value)),
+            ExplorerError::Io(ref value) => error_tuple(env, io(), value.to_string()),
+            ExplorerError::Utf8(ref value) => error_tuple(env, utf8(), value.to_string()),
+            ExplorerError::Polars(ref value) => error_tuple(env, polars(), value.to_string()),
 
-            ExplorerError::Internal(ref value) => {
-                error_tuple(env, internal(), format!("{}", value))
-            }
+            ExplorerError::Internal(ref value) => error_tuple(env, internal(), value.to_string()),
 
-            ExplorerError::Other(ref value) => error_tuple(env, other(), format!("{}", value)),
+            ExplorerError::Other(ref value) => error_tuple(env, other(), value.to_string()),
             ExplorerError::TryFromInt(ref value) => {
-                error_tuple(env, try_from_int(), format!("{}", value))
+                error_tuple(env, try_from_int(), value.to_string())
             }
-            ExplorerError::Parquet(ref value) => error_tuple(env, parquet(), format!("{}", value)),
-            ExplorerError::Unknown(ref value) => error_tuple(env, unknown(), format!("{}", value)),
+            ExplorerError::Parquet(ref value) => error_tuple(env, parquet(), value.to_string()),
+            ExplorerError::Unknown(ref value) => error_tuple(env, unknown(), value.to_string()),
         }
     }
 }

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -686,7 +686,7 @@ pub fn s_pow_i_lhs(data: ExSeries, base: u32) -> Result<ExSeries, ExplorerError>
             Ok(ExSeries::new(s))
         }
         Err(_) => Err(ExplorerError::Other(String::from(
-            "negative exponent with integer base",
+            "negative exponent with an integer base",
         ))),
     }
 }

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -512,6 +512,14 @@ defmodule Explorer.SeriesTest do
       assert result.dtype == :float
       assert Series.to_list(result) == [2.0, 4.0, 8.0]
     end
+
+    test "pow of a scalar value on the left-hand side to a series with a negative integer" do
+      s1 = Series.from_list([1, -2, 3])
+
+      assert_raise RuntimeError, "negative exponent with an integer base", fn ->
+        Series.pow(2, s1)
+      end
+    end
   end
 
   describe "sample/2" do


### PR DESCRIPTION
This the error be a tuple with the `{type, message}` shape, which can help to make it more flexible at the Elixir side.