### PR TITLE
Fix pivot operations to work with groups

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -110,6 +110,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback drop_nil(df, columns :: [column_name()]) :: df
   @callback pivot_wider(
               df,
+              out_df :: df(),
               id_columns :: [column_name()],
               names_from :: column_name(),
               values_from :: column_name(),

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -984,6 +984,76 @@ defmodule Explorer.DataFrame.GroupedTest do
     end
   end
 
+  describe "pivot_longer/3" do
+    test "keep the groups if they are not in the list of pivoting" do
+      df = Datasets.iris()
+      grouped = DF.group_by(df, "species")
+      pivoted = DF.pivot_longer(grouped, ["sepal_length"])
+
+      assert DF.groups(pivoted) == ["species"]
+    end
+
+    test "remove groups that are in the list of pivoting" do
+      df = Datasets.iris()
+      grouped = DF.group_by(df, "species")
+      pivoted = DF.pivot_longer(grouped, ["species"])
+
+      assert DF.groups(pivoted) == []
+    end
+  end
+
+  describe "pivot_wider/4" do
+    test "keep the groups if they are not in the list of pivoting" do
+      df =
+        DF.new(
+          weekday: [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday"
+          ],
+          team: ["A", "B", "C", "A", "B", "C", "A", "B", "C", "A"],
+          hour: [10, 9, 10, 10, 11, 15, 14, 16, 14, 16]
+        )
+
+      grouped = DF.group_by(df, "team")
+      pivoted = DF.pivot_wider(grouped, "weekday", "hour")
+
+      assert DF.groups(pivoted) == ["team"]
+    end
+
+    test "remove groups that are in the list of pivoting" do
+      df =
+        DF.new(
+          weekday: [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday"
+          ],
+          team: ["A", "B", "C", "A", "B", "C", "A", "B", "C", "A"],
+          hour: [10, 9, 10, 10, 11, 15, 14, 16, 14, 16]
+        )
+
+      grouped = DF.group_by(df, "weekday")
+      pivoted = DF.pivot_wider(grouped, "weekday", "hour")
+
+      assert DF.groups(pivoted) == []
+    end
+  end
+
   test "to_lazy/1", %{df: df} do
     grouped = DF.group_by(df, ["country", "year"])
     assert ["country", "year"] = DF.to_lazy(grouped).groups

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2035,6 +2035,19 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "with a single id column and repeated values with names prefix" do
+      df = DF.new(id: [1, 1, 2, 2], variable: ["a", "b", "a", "b"], value: [1, 2, 3, 4])
+
+      df2 = DF.pivot_wider(df, "variable", "value", id_columns: [:id], names_prefix: "prefix_")
+      assert DF.names(df2) == ["id", "prefix_a", "prefix_b"]
+
+      assert DF.to_columns(df2, atom_keys: true) == %{
+               id: [1, 2],
+               prefix_a: [1, 3],
+               prefix_b: [2, 4]
+             }
+    end
+
     test "with a filter function for id columns" do
       df = DF.new(id_main: [1, 1], variable: ["a", "b"], value: [1, 2], other: [4, 5])
 


### PR DESCRIPTION
This also adds documentation for both operations when using groups.

The behaviour is inspired in what is described in the Tidyr article about pivoting: https://tidyr.tidyverse.org/articles/pivot.html 
There is no explicit mention about groups, but the examples shows how they behave.