### PR TITLE
Improve `DF.dummies/2` docs and fix it with groups

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -102,7 +102,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback arrange_with(df, out_df :: df(), directions :: [{:asc | :desc, lazy_series()}]) :: df
   @callback distinct(df, out_df :: df(), columns :: [column_name()], keep_all :: boolean()) :: df
   @callback rename(df, out_df :: df(), [{old :: column_name(), new :: column_name()}]) :: df
-  @callback dummies(df, columns :: [column_name()]) :: df
+  @callback dummies(df, out_df :: df(), columns :: [column_name()]) :: df
   @callback sample(df, n_or_frac :: number(), replacement :: boolean(), seed :: integer()) :: df
   @callback pull(df, column :: column_name()) :: series
   @callback slice(df, indices :: list(integer()) | %Range{}) :: df

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -412,8 +412,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
     do: Shared.apply_dataframe(df, out_df, :df_rename_columns, [pairs])
 
   @impl true
-  def dummies(df, names),
-    do: Shared.apply_dataframe(df, :df_to_dummies, [names])
+  def dummies(df, out_df, names),
+    do: Shared.apply_dataframe(df, out_df, :df_to_dummies, [names])
 
   @impl true
   def sample(df, n, replacement, seed) when is_integer(n) do

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -1054,6 +1054,16 @@ defmodule Explorer.DataFrame.GroupedTest do
     end
   end
 
+  describe "dummies/2" do
+    test "drops the groups" do
+      df = DF.new(col_x: ["a", "b", "a", "c"], col_y: ["b", "a", "b", "d"])
+      grouped = DF.group_by(df, "col_x")
+      dummies = DF.dummies(grouped, "col_x")
+
+      assert DF.groups(dummies) == []
+    end
+  end
+
   test "to_lazy/1", %{df: df} do
     grouped = DF.group_by(df, ["country", "year"])
     assert ["country", "year"] = DF.to_lazy(grouped).groups


### PR DESCRIPTION
This is a small improvement in the docs of `dummies/2` to make more clear which columns and values are used.
It also adds the detail about groups that are removed, and add a test for it.