### PR TITLE
WIP: initial work to add support for list dtypes

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -182,10 +182,16 @@ defmodule Explorer.Backend.DataFrame do
 
         data = container_doc(open, values, close, inspect_opts, &Explorer.Shared.to_string/2)
 
+        dtype =
+          case Series.dtype(series) do
+            {:list, dtype} -> color("list(#{dtype})", :atom, inspect_opts)
+            dtype -> color("#{dtype}", :atom, inspect_opts)
+          end
+
         concat([
           line(),
           color("#{name} ", :map, inspect_opts),
-          color("#{Series.dtype(series)}", :atom, inspect_opts),
+          dtype,
           " ",
           data
         ])

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -60,6 +60,7 @@ defmodule Explorer.Backend.LazySeries do
     head: 2,
     tail: 2,
     peaks: 2,
+    to_list: 1,
     # Aggregations
     sum: 1,
     min: 1,
@@ -425,6 +426,14 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
+  def to_list(%Series{} = s) do
+    args = [lazy_series!(s)]
+    data = new(:to_list, args, true, window_functions?(args))
+
+    Backend.Series.new(data, s.dtype)
+  end
+
+  @impl true
   def inspect(series, opts) do
     import Inspect.Algebra
 
@@ -474,7 +483,6 @@ defmodule Explorer.Backend.LazySeries do
     slice: 2,
     take_every: 2,
     to_enum: 1,
-    to_list: 1,
     transform: 2
   ]
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Backend.Series do
   The behaviour for series backends.
   """
 
-  @valid_dtypes [:integer, :float, :boolean, :string, :date, :datetime, :list]
+  @valid_dtypes [:integer, :float, :boolean, :string, :date, :datetime, {:list, :integer}]
 
   @type t :: struct()
 
@@ -16,7 +16,7 @@ defmodule Explorer.Backend.Series do
   # Conversion
 
   @callback from_list(list(), dtype()) :: s
-  @callback to_list(s) :: list()
+  @callback to_list(s) :: list() | lazy_s()
   @callback to_enum(s) :: Enumerable.t()
   @callback cast(s, dtype) :: s
 
@@ -145,7 +145,12 @@ defmodule Explorer.Backend.Series do
       when is_binary(backend) and (is_integer(n_rows) or is_nil(n_rows)) and is_list(opts) do
     open = color("[", :list, inspect_opts)
     close = color("]", :list, inspect_opts)
-    dtype = color("#{Series.dtype(series)} ", :atom, inspect_opts)
+
+    dtype =
+      case Series.dtype(series) do
+        {:list, dtype} -> color("list(#{dtype}) ", :atom, inspect_opts)
+        dtype -> color("#{dtype} ", :atom, inspect_opts)
+      end
 
     data =
       container_doc(

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -117,7 +117,9 @@ defmodule Explorer.PolarsBackend.Shared do
   def normalise_dtype("datetime[ms]"), do: :datetime
   def normalise_dtype("datetime[μs]"), do: :datetime
   def normalise_dtype("datetime[ns]"), do: :datetime
-  def normalise_dtype("list[u32]"), do: :integer
+  def normalise_dtype("list[u32]"), do: {:list, :integer}
+  def normalise_dtype("list[i32]"), do: {:list, :integer}
+  def normalise_dtype("list[i64]"), do: {:list, :integer}
 
   def internal_from_dtype(:integer), do: "i64"
   def internal_from_dtype(:float), do: "f64"

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -27,7 +27,7 @@ defmodule Explorer.Series do
 
   @valid_dtypes Explorer.Shared.dtypes()
 
-  @type dtype :: :integer | :float | :boolean | :string | :date | :datetime
+  @type dtype :: :integer | :float | :boolean | :string | :date | :datetime | {:list, :integer}
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}
   @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
 
@@ -154,7 +154,7 @@ defmodule Explorer.Series do
   """
   @doc type: :transformation
   @spec from_list(list :: list(), opts :: Keyword.t()) :: Series.t()
-  def from_list(list, opts \\ []) do
+  def from_list(list, opts \\ []) when is_list(list) do
     backend = backend_from_options!(opts)
     type = Shared.check_types!(list)
     {list, type} = Shared.cast_numerics(list, type)
@@ -2369,12 +2369,12 @@ defmodule Explorer.Series do
   defimpl Inspect do
     import Inspect.Algebra
 
-    def inspect(df, opts) do
+    def inspect(series, opts) do
       force_unfit(
         concat([
           color("#Explorer.Series<", :map, opts),
           nest(
-            concat([line(), Shared.apply_impl(df, :inspect, [opts])]),
+            concat([line(), Shared.apply_impl(series, :inspect, [opts])]),
             2
           ),
           line(),

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -156,5 +156,9 @@ defmodule Explorer.Shared do
   """
   def to_string(i, _opts) when is_nil(i), do: "nil"
   def to_string(i, _opts) when is_binary(i), do: "\"#{i}\""
+
+  def to_string(i, opts) when is_list(i),
+    do: "[ " <> Enum.map_join(i, ", ", &to_string(&1, opts)) <> " ]"
+
   def to_string(i, _opts), do: Kernel.to_string(i)
 end

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -337,6 +337,12 @@ pub fn list_from_series(data: ExSeries, env: Env) -> Term {
         DataType::List(t) if t as &DataType == &DataType::UInt32 => {
             encode_list!(s, env, u32, u32)
         }
+        DataType::List(t) if t as &DataType == &DataType::Int32 => {
+            encode_list!(s, env, i32, i32)
+        }
+        DataType::List(t) if t as &DataType == &DataType::Int64 => {
+            encode_list!(s, env, i64, i64)
+        }
         dt => panic!("to_list/1 not implemented for {:?}", dt),
     }
 }

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -501,6 +501,13 @@ pub fn expr_unordered_distinct(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_to_list(expr: ExExpr) -> ExExpr {
+    let expr: Expr = expr.resource.0.clone();
+
+    ExExpr::new(expr.list())
+}
+
+#[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
     let df: DataFrame = data.resource.0.clone();
     let expressions: Expr = expr.resource.0.clone();

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -128,6 +128,7 @@ rustler::init!(
         expr_peaks,
         expr_fill_missing,
         expr_fill_missing_with_value,
+        expr_to_list,
         // sort
         expr_argsort,
         expr_distinct,


### PR DESCRIPTION
This is work-in-progress and adds the bases of "list" dtypes.

It also adds the `to_list/1` lazy operation that takes a series and creates a list series with the elements of that series. This is useful for aggregations, when you want to capture the elements of a given group. Eg.:

```elixir
df = Explorer.DataFrame.new(a: [1, 1, 2, 2], b: [9, 8, 7, 6])

grouped = Explorer.DataFrame.group_by(df, :a)

Explorer.DataFrame.summarise_with(grouped, fn df -> [b_merged: Explorer.Series.to_list(df["b"])] end)
```

The result is going to be something like this:

      #Explorer.DataFrame<
        Polars[2 x 2]
        a integer [1, 2]
        b_merged list(integer) [[ 9, 8 ], [ 7, 6 ]]
      >

Related to:
- https://github.com/elixir-nx/explorer/issues/296
- https://github.com/elixir-nx/explorer/issues/400