### PR TITLE
Add  as possible return type of aggregate functions (#411)

### DIFF
--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -44,14 +44,14 @@ defmodule Explorer.Backend.Series do
 
   # Aggregation
 
-  @callback sum(s) :: number() | lazy_s()
-  @callback min(s) :: number() | Date.t() | NaiveDateTime.t() | lazy_s()
-  @callback max(s) :: number() | Date.t() | NaiveDateTime.t() | lazy_s()
-  @callback mean(s) :: float() | lazy_s()
-  @callback median(s) :: float() | lazy_s()
-  @callback variance(s) :: float() | lazy_s()
-  @callback standard_deviation(s) :: float() | lazy_s()
-  @callback quantile(s, float()) :: number | Date.t() | NaiveDateTime.t() | lazy_s()
+  @callback sum(s) :: number() | lazy_s() | nil
+  @callback min(s) :: number() | Date.t() | NaiveDateTime.t() | lazy_s() | nil
+  @callback max(s) :: number() | Date.t() | NaiveDateTime.t() | lazy_s() | nil
+  @callback mean(s) :: float() | lazy_s() | nil
+  @callback median(s) :: float() | lazy_s() | nil
+  @callback variance(s) :: float() | lazy_s() | nil
+  @callback standard_deviation(s) :: float() | lazy_s() | nil
+  @callback quantile(s, float()) :: number | Date.t() | NaiveDateTime.t() | lazy_s() | nil
 
   # Cumulative
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -808,7 +808,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.sum/1 not implemented for dtype :date. Valid dtypes are [:integer, :float, :boolean].
   """
   @doc type: :aggregation
-  @spec sum(series :: Series.t()) :: number()
+  @spec sum(series :: Series.t()) :: number() | nil
   def sum(%Series{dtype: dtype} = series) when numeric_or_bool_dtype?(dtype),
     do: Shared.apply_impl(series, :sum)
 
@@ -847,7 +847,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.min/1 not implemented for dtype :string. Valid dtypes are [:integer, :float, :date, :datetime].
   """
   @doc type: :aggregation
-  @spec min(series :: Series.t()) :: number() | Date.t() | NaiveDateTime.t()
+  @spec min(series :: Series.t()) :: number() | Date.t() | NaiveDateTime.t() | nil
   def min(%Series{dtype: dtype} = series) when numeric_or_date_dtype?(dtype),
     do: Shared.apply_impl(series, :min)
 
@@ -887,7 +887,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.max/1 not implemented for dtype :string. Valid dtypes are [:integer, :float, :date, :datetime].
   """
   @doc type: :aggregation
-  @spec max(series :: Series.t()) :: number() | Date.t() | NaiveDateTime.t()
+  @spec max(series :: Series.t()) :: number() | Date.t() | NaiveDateTime.t() | nil
   def max(%Series{dtype: dtype} = series) when numeric_or_date_dtype?(dtype),
     do: Shared.apply_impl(series, :max)
 
@@ -917,7 +917,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.mean/1 not implemented for dtype :date. Valid dtypes are [:integer, :float].
   """
   @doc type: :aggregation
-  @spec mean(series :: Series.t()) :: float()
+  @spec mean(series :: Series.t()) :: float() | nil
   def mean(%Series{dtype: dtype} = series) when numeric_dtype?(dtype),
     do: Shared.apply_impl(series, :mean)
 
@@ -946,7 +946,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.median/1 not implemented for dtype :date. Valid dtypes are [:integer, :float].
   """
   @doc type: :aggregation
-  @spec median(series :: Series.t()) :: float()
+  @spec median(series :: Series.t()) :: float() | nil
   def median(%Series{dtype: dtype} = series) when numeric_dtype?(dtype),
     do: Shared.apply_impl(series, :median)
 
@@ -975,7 +975,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.variance/1 not implemented for dtype :datetime. Valid dtypes are [:integer, :float].
   """
   @doc type: :aggregation
-  @spec variance(series :: Series.t()) :: float()
+  @spec variance(series :: Series.t()) :: float() | nil
   def variance(%Series{dtype: dtype} = series) when numeric_dtype?(dtype),
     do: Shared.apply_impl(series, :variance)
 
@@ -1004,7 +1004,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.standard_deviation/1 not implemented for dtype :string. Valid dtypes are [:integer, :float].
   """
   @doc type: :aggregation
-  @spec standard_deviation(series :: Series.t()) :: float()
+  @spec standard_deviation(series :: Series.t()) :: float() | nil
   def standard_deviation(%Series{dtype: dtype} = series) when numeric_dtype?(dtype),
     do: Shared.apply_impl(series, :standard_deviation)
 


### PR DESCRIPTION
Add `nil` as possible return type ofo aggregate functions:
- sum
- min
- max
- mean
- median
- variance
- standard_deviation
- quantile

Each one of these functions can return `nil` when invoked with an empty Series.