### PR TITLE
Implement `arrange/2` as a macro using `Explorer.Query`

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -97,7 +97,6 @@ defmodule Explorer.Backend.DataFrame do
   @callback mask(df, mask :: series) :: df
   @callback filter_with(df, out_df :: df(), lazy_series()) :: df
   @callback mutate_with(df, out_df :: df(), mutations :: [{column_name(), lazy_series()}]) :: df
-  @callback arrange(df, columns :: [{:asc | :desc, column_name()}]) :: df
   @callback arrange_with(df, out_df :: df(), directions :: [{:asc | :desc, lazy_series()}]) :: df
   @callback distinct(df, out_df :: df(), columns :: [column_name()], keep_all :: boolean()) :: df
   @callback rename(df, out_df :: df(), [{old :: column_name(), new :: column_name()}]) :: df

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -296,18 +296,6 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def arrange(%DataFrame{groups: groups} = df, columns) do
-    {directions, columns} =
-      columns
-      |> Enum.map(fn {dir, col} ->
-        {dir == :desc, col}
-      end)
-      |> Enum.unzip()
-
-    Shared.apply_dataframe(df, df, :df_arrange, [columns, directions, groups])
-  end
-
-  @impl true
   def arrange_with(%DataFrame{} = df, out_df, column_pairs) do
     {directions, expressions} =
       column_pairs
@@ -347,7 +335,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
     end)
     |> then(fn [head | _tail] = dfs -> concat_rows(dfs, head) end)
     |> DataFrame.ungroup()
-    |> arrange([{:asc, idx_column}])
+    |> DataFrame.arrange_with(fn ldf -> [asc: ldf[idx_column]] end)
     |> select(out_df)
   end
 

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -163,7 +163,7 @@ defmodule Explorer.DataFrame.GroupedTest do
           total_min: min(total),
           cement_median: median(cement)
         )
-        |> DF.arrange(:country)
+        |> DF.arrange(country)
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                country: [
@@ -436,8 +436,8 @@ defmodule Explorer.DataFrame.GroupedTest do
 
   describe "arrange/2" do
     test "sorts by group", %{df: df} do
-      df = DF.arrange(df, "total")
-      grouped_df = df |> DF.group_by("country") |> DF.arrange("total")
+      df = DF.arrange(df, total)
+      grouped_df = df |> DF.group_by("country") |> DF.arrange(total)
 
       assert df["total"][0] == Series.min(df["total"])
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -855,7 +855,7 @@ defmodule Explorer.DataFrameTest do
     test "raises with invalid column names", %{df: df} do
       assert_raise ArgumentError,
                    "could not find column name \"test\"",
-                   fn -> DF.arrange(df, ["test"]) end
+                   fn -> DF.arrange(df, test) end
     end
   end
 


### PR DESCRIPTION
This is part of https://github.com/elixir-nx/explorer/issues/402

This change also removed the feature of passing a callback to `arrange/2` that selected names.