### PR TITLE
Add the `:binary` dtype for Series

### DIFF
--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -3,7 +3,7 @@ defmodule Explorer.Backend.Series do
   The behaviour for series backends.
   """
 
-  @valid_dtypes [:integer, :float, :boolean, :string, :date, :datetime, :list]
+  @valid_dtypes [:integer, :float, :boolean, :string, :date, :datetime, :list, :binary]
 
   @type t :: struct()
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -26,7 +26,7 @@ defmodule Explorer.Backend.Series do
   @callback dtype(s) :: dtype()
   @callback size(s) :: non_neg_integer() | lazy_s()
   @callback inspect(s, opts :: Inspect.Opts.t()) :: Inspect.Algebra.t()
-  @callback bintype(s) :: :uft8 | {:s | :u | :f, non_neg_integer}
+  @callback bintype(s) :: :uft8 | :binary | {:s | :u | :f, non_neg_integer}
 
   # Slice and dice
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -178,6 +178,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_from_list_i64(_name, _val), do: err()
   def s_from_list_u32(_name, _val), do: err()
   def s_from_list_str(_name, _val), do: err()
+  def s_from_list_binary(_name, _val), do: err()
   def s_from_binary_f64(_name, _val), do: err()
   def s_from_binary_i32(_name, _val), do: err()
   def s_from_binary_i64(_name, _val), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -55,6 +55,7 @@ defmodule Explorer.PolarsBackend.Series do
       "f64" -> {:f, 64}
       "bool" -> {:u, 8}
       "str" -> :utf8
+      "binary" -> :binary
       "date" -> {:s, 32}
       "datetime[ms]" -> {:s, 64}
       "datetime[μs]" -> {:s, 64}

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -107,6 +107,7 @@ defmodule Explorer.PolarsBackend.Shared do
       :string -> Native.s_from_list_str(name, list)
       :date -> Native.s_from_list_date(name, list)
       :datetime -> Native.s_from_list_datetime(name, list)
+      :binary -> Native.s_from_list_binary(name, list)
     end
   end
 
@@ -129,6 +130,7 @@ defmodule Explorer.PolarsBackend.Shared do
   def normalise_dtype("f64"), do: :float
   def normalise_dtype("bool"), do: :boolean
   def normalise_dtype("str"), do: :string
+  def normalise_dtype("binary"), do: :binary
   def normalise_dtype("date"), do: :date
   def normalise_dtype("datetime[ms]"), do: :datetime
   def normalise_dtype("datetime[μs]"), do: :datetime

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -407,6 +407,12 @@ defmodule Explorer.Series do
       iex> Explorer.Series.to_iovec(series)
       [<<"foobarbazbat">>]
 
+  The same principle from strings applies to binaries:
+
+      iex> series = Explorer.Series.from_list([<<228, 146, 51>>, <<42, 209, 236>>])
+      iex> Explorer.Series.to_iovec(series)
+      [<<228, 146, 51, 42, 209, 236>>]
+
   """
   @doc type: :conversion
   @spec to_iovec(series :: Series.t()) :: [binary]
@@ -606,9 +612,13 @@ defmodule Explorer.Series do
       iex> Explorer.Series.bintype(s)
       {:u, 8}
 
+      iex> s = Explorer.Series.from_list([<<228, 146, 51>>, <<42, 209, 236>>])
+      iex> Explorer.Series.bintype(s)
+      :binary
+
   """
   @doc type: :introspection
-  @spec bintype(series :: Series.t()) :: :utf8 | {:s | :u | :f, non_neg_integer()}
+  @spec bintype(series :: Series.t()) :: :utf8 | :binary | {:s | :u | :f, non_neg_integer()}
   def bintype(series), do: Shared.apply_impl(series, :bintype)
 
   # Slice and dice

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -8,6 +8,7 @@ defmodule Explorer.Series do
     * `:integer` - 64-bit signed integer
     * `:boolean` - Boolean
     * `:string` - UTF-8 encoded binary
+    * `:binary` - Binary
     * `:date` - Date type that unwraps to `Elixir.Date`
     * `:datetime` - DateTime type that unwraps to `Elixir.NaiveDateTime`
 
@@ -27,7 +28,7 @@ defmodule Explorer.Series do
 
   @valid_dtypes Explorer.Shared.dtypes()
 
-  @type dtype :: :integer | :float | :boolean | :string | :date | :datetime
+  @type dtype :: :integer | :float | :boolean | :string | :date | :datetime | :binary
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}
   @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
 
@@ -98,7 +99,7 @@ defmodule Explorer.Series do
 
     * `:backend` - The backend to allocate the series on.
     * `:dtype` - Cast the series to a given `:dtype`. By default this is `nil`, which means
-    that Explorer will infer the type from the values in the list.
+      that Explorer will infer the type from the values in the list.
 
   ## Examples
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -162,15 +162,7 @@ defmodule Explorer.Shared do
   Helper for shared behaviour in inspect.
   """
   def to_string(i, _opts) when is_nil(i), do: "nil"
-
-  def to_string(i, _opts) when is_binary(i) do
-    if String.valid?(i) do
-      "\"#{i}\""
-    else
-      bin_as_list = :binary.bin_to_list(i)
-      "<<#{Enum.join(bin_as_list, ", ")}>>"
-    end
-  end
+  def to_string(i, _opts) when is_binary(i), do: inspect(i)
 
   def to_string(i, _opts), do: Kernel.to_string(i)
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -101,17 +101,20 @@ defmodule Explorer.Shared do
 
   @doc """
   Gets the `dtype` of a list or raise error if not possible.
+
+  It's possible to override the initial type by passing a preferable type.
+  This is useful in cases where you want to build the series in a target type,
+  without the need to cast it later.
   """
-  def check_types!(list) do
+  def check_types!(list, preferable_type \\ nil) do
+    initial_type = if preferable_type in [:binary, :float, :integer], do: preferable_type
+
     type =
-      Enum.reduce(list, nil, fn el, type ->
+      Enum.reduce(list, initial_type, fn el, type ->
         new_type = type(el, type) || type
 
         cond do
           new_type == :numeric and type in [:float, :integer] ->
-            new_type
-
-          new_type == :binary and type == :string ->
             new_type
 
           new_type != type and type != nil ->
@@ -133,10 +136,9 @@ defmodule Explorer.Shared do
   defp type(item, _type) when is_integer(item), do: :integer
   defp type(item, _type) when is_float(item), do: :float
   defp type(item, _type) when is_boolean(item), do: :boolean
-  defp type(item, :binary) when is_binary(item), do: :binary
 
-  defp type(item, _type) when is_binary(item),
-    do: if(String.valid?(item), do: :string, else: :binary)
+  defp type(item, :binary) when is_binary(item), do: :binary
+  defp type(item, _type) when is_binary(item), do: :string
 
   defp type(%Date{} = _item, _type), do: :date
   defp type(%NaiveDateTime{} = _item, _type), do: :datetime

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -34,6 +34,7 @@ features = [
   "decompress",
   "dtype-date",
   "dtype-datetime",
+  "dtype-binary",
   "ipc",
   "ipc_streaming",
   # JSON won't compile on ARM 32 bits targets, so we disable in the "release" workflow.

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -365,7 +365,7 @@ pub fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Result<Term<'b>, Explor
         AnyValue::Utf8(v) => Ok(Some(v).encode(env)),
         AnyValue::Binary(v) => {
             let mut bin = NewBinary::new(env, v.len());
-            bin.copy_from_slice(&v);
+            bin.copy_from_slice(v);
 
             Ok(Some(Binary::from(bin)).encode(env))
         }

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -334,7 +334,7 @@ pub fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Result<Term<'b>, Explor
         AnyValue::Float64(v) => Ok(Some(v).encode(env)),
         AnyValue::Date(v) => encode_date(v, env),
         AnyValue::Datetime(v, time_unit, None) => encode_datetime(v, time_unit, env),
-        dt => panic!("get/2 not implemented for {:?}", dt),
+        dt => panic!("cannot encode value {:?} to term", dt),
     }
 }
 

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -246,6 +246,56 @@ fn utf8_series_to_list<'b>(
     Ok(unsafe { Term::new(env, list) })
 }
 
+// Same as `utf8_series_to_list`, but with binary series.
+#[inline]
+fn binary_series_to_list<'b>(
+    resource: &ResourceArc<ExSeriesRef>,
+    s: &Series,
+    env: Env<'b>,
+) -> Result<Term<'b>, ExplorerError> {
+    let binary = s.binary()?;
+    let env_as_c_arg = env.as_c_arg();
+    let nil_as_c_arg = atom::nil().to_term(env).as_c_arg();
+    let acc = unsafe { list::make_list(env_as_c_arg, &[]) };
+
+    let list = binary.downcast_iter().rfold(acc, |acc, array| {
+        // Create a binary per array buffer
+        let values = array.values();
+
+        let binary = unsafe { resource.make_binary_unsafe(env, |_| values) }
+            .to_term(env)
+            .as_c_arg();
+
+        // Offsets have one more element than values and validity,
+        // so we read the last one as the initial accumulator and skip it.
+        let len = array.offsets().len();
+        let iter = array.offsets()[0..len - 1].iter();
+        let mut last_offset = array.offsets()[len - 1] as NIF_TERM;
+
+        let mut validity_iter = match array.validity() {
+            Some(validity) => validity.iter(),
+            None => polars::export::arrow::bitmap::utils::BitmapIter::new(&[], 0, 0),
+        };
+
+        iter.rfold(acc, |acc, uncast_offset| {
+            let offset = *uncast_offset as NIF_TERM;
+
+            let term_as_c_arg = if validity_iter.next_back().unwrap_or(true) {
+                unsafe {
+                    binary::make_subbinary(env_as_c_arg, binary, offset, last_offset - offset)
+                }
+            } else {
+                nil_as_c_arg
+            };
+
+            last_offset = offset;
+            unsafe { list::make_list_cell(env_as_c_arg, term_as_c_arg, acc) }
+        })
+    });
+
+    Ok(unsafe { Term::new(env, list) })
+}
+
 // Convert f64 series taking into account NaN and Infinity floats (they are encoded as atoms).
 #[inline]
 fn float64_series_to_list<'b>(s: &Series, env: Env<'b>) -> Result<Term<'b>, ExplorerError> {
@@ -330,6 +380,7 @@ pub fn list_from_series(data: ExSeries, env: Env) -> Result<Term, ExplorerError>
         DataType::Int64 => series_to_list!(s, env, i64),
         DataType::UInt32 => series_to_list!(s, env, u32),
         DataType::Utf8 => utf8_series_to_list(&data.resource, s, env),
+        DataType::Binary => binary_series_to_list(&data.resource, s, env),
         DataType::Float64 => float64_series_to_list(s, env),
         DataType::Date => date_series_to_list(s, env),
         DataType::Datetime(time_unit, None) => datetime_series_to_list(s, *time_unit, env),

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -244,6 +244,7 @@ rustler::init!(
         s_from_list_i64,
         s_from_list_u32,
         s_from_list_str,
+        s_from_list_binary,
         s_from_binary_f64,
         s_from_binary_i64,
         s_from_binary_i32,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -586,7 +586,7 @@ pub fn s_standard_deviation(env: Env, data: ExSeries) -> Result<Term, ExplorerEr
 #[rustler::nif]
 pub fn s_at(env: Env, data: ExSeries, idx: usize) -> Result<Term, ExplorerError> {
     let s = &data.resource.0;
-    encoding::term_from_value(s.get(idx), env)
+    encoding::resource_term_from_value(&data.resource, s.get(idx), env)
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -60,9 +60,12 @@ pub fn s_from_list_datetime(name: &str, val: Vec<Option<ExDateTime>>) -> ExSerie
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_from_list_binary(name: &str, val: Vec<Option<Binary>>) -> ExSeries {
-    let results: Vec<Option<&[u8]>> = val.iter().map(|dt| dt.map(|dt| dt.as_slice())).collect();
-
-    ExSeries::new(Series::new(name, results))
+    ExSeries::new(Series::new(
+        name,
+        val.iter()
+            .map(|bin| bin.map(|bin| bin.as_slice()))
+            .collect::<Vec<Option<&[u8]>>>(),
+    ))
 }
 
 macro_rules! from_binary {

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -58,6 +58,13 @@ pub fn s_from_list_datetime(name: &str, val: Vec<Option<ExDateTime>>) -> ExSerie
     )
 }
 
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_from_list_binary(name: &str, val: Vec<Option<Binary>>) -> ExSeries {
+    let results: Vec<Option<&[u8]>> = val.iter().map(|dt| dt.map(|dt| dt.as_slice())).collect();
+
+    ExSeries::new(Series::new(name, results))
+}
+
 macro_rules! from_binary {
     ($name:ident, $type:ty, $bytes:expr) => {
         #[rustler::nif(schedule = "DirtyCpu")]
@@ -712,6 +719,7 @@ pub fn cast_str_to_dtype(str_type: &str) -> Result<DataType, ExplorerError> {
         "datetime" => Ok(DataType::Datetime(TimeUnit::Microseconds, None)),
         "boolean" => Ok(DataType::Boolean),
         "string" => Ok(DataType::Utf8),
+        "binary" => Ok(DataType::Binary),
         _ => Err(ExplorerError::Other(String::from("Cannot cast to type"))),
     }
 }

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -274,6 +274,11 @@ defmodule Explorer.SeriesTest do
       s = Series.from_list([~N[2022-09-12 22:21:46.250899]])
       assert Series.bintype(s) == {:s, 64}
     end
+
+    test "binary series" do
+      s = Series.from_list([<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>])
+      assert Series.bintype(s) == :binary
+    end
   end
 
   describe "add/2" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -28,11 +28,31 @@ defmodule Explorer.SeriesTest do
       s = Series.from_list([1, 2, 3])
 
       assert Series.to_list(s) === [1, 2, 3]
+      assert Series.dtype(s) == :integer
     end
 
     test "with floats" do
       s = Series.from_list([1, 2.4, 3])
       assert Series.to_list(s) === [1.0, 2.4, 3.0]
+      assert Series.dtype(s) == :float
+    end
+
+    test "with binaries" do
+      s = Series.from_list([<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>])
+      assert Series.to_list(s) === [<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>]
+      assert Series.dtype(s) == :binary
+    end
+
+    test "with strings" do
+      s = Series.from_list(["a", "b", "c"])
+      assert Series.to_list(s) === ["a", "b", "c"]
+      assert Series.dtype(s) == :string
+    end
+
+    test "with binaries from strings" do
+      s = Series.from_list(["a", "b", "c"], dtype: :binary)
+      assert Series.to_list(s) === ["a", "b", "c"]
+      assert Series.dtype(s) == :binary
     end
 
     test "mixing types" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -38,7 +38,7 @@ defmodule Explorer.SeriesTest do
     end
 
     test "with binaries" do
-      s = Series.from_list([<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>])
+      s = Series.from_list([<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>], dtype: :binary)
       assert Series.to_list(s) === [<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>]
       assert Series.dtype(s) == :binary
     end
@@ -55,10 +55,22 @@ defmodule Explorer.SeriesTest do
       assert Series.dtype(s) == :binary
     end
 
+    test "mixing binaries and strings" do
+      s = Series.from_list([<<228, 146, 51>>, "hello", <<42, 209, 236>>], dtype: :binary)
+      assert Series.to_list(s) === [<<228, 146, 51>>, <<"hello">>, <<42, 209, 236>>]
+      assert Series.dtype(s) == :binary
+    end
+
     test "mixing types" do
       assert_raise ArgumentError, fn ->
         s = Series.from_list([1, "foo", 3])
         Series.to_list(s)
+      end
+    end
+
+    test "with binaries without passing the dtype" do
+      assert_raise ArgumentError, fn ->
+        Series.from_list([<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>])
       end
     end
   end
@@ -276,7 +288,7 @@ defmodule Explorer.SeriesTest do
     end
 
     test "binary series" do
-      s = Series.from_list([<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>])
+      s = Series.from_list([<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>], dtype: :binary)
       assert Series.bintype(s) == :binary
     end
   end
@@ -745,6 +757,37 @@ defmodule Explorer.SeriesTest do
       result = Series.argsort(s1, nils: :first)
 
       assert Series.to_list(result) == [2, 1, 3, 0]
+    end
+  end
+
+  describe "at/2" do
+    test "fetch an item from a given position in the series - integer" do
+      s1 = Series.from_list([9, 4, nil, 5])
+
+      assert Series.at(s1, 1) == 4
+      assert Series.at(s1, 3) == 5
+    end
+
+    test "fetch an item from a given position in the series - float" do
+      s1 = Series.from_list([9.1, 4.2, 3.6, 5.9])
+
+      assert Series.at(s1, 1) == 4.2
+      assert Series.at(s1, 2) == 3.6
+    end
+
+    test "fetch an item from a given position in the series - string" do
+      s1 = Series.from_list(["a", "b", "c", "d"])
+
+      assert Series.at(s1, 0) == "a"
+      assert Series.at(s1, 3) == "d"
+    end
+
+    test "fetch an item from a given position in the series - binary" do
+      s1 =
+        Series.from_list([<<114, 231, 242>>, <<181, 43, 48>>, <<89, 155, 216>>], dtype: :binary)
+
+      assert Series.at(s1, 1) == <<181, 43, 48>>
+      assert Series.at(s1, 2) == <<89, 155, 216>>
     end
   end
 end


### PR DESCRIPTION
This enables the creation of dataframes with binary columns. Useful to work with blob/raw data.

Closes https://github.com/elixir-nx/explorer/issues/182