### PR TITLE
Allow Explorer.PolarsBackend.Series.pow/2 on (series, series)

### DIFF
--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -188,6 +188,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_peak_max(_s), do: err()
   def s_peak_min(_s), do: err()
   def s_select(_pred, _on_true, _on_false), do: err()
+  def s_pow(_s, _other), do: err()
   def s_pow_f_lhs(_s, _exponent), do: err()
   def s_pow_f_rhs(_s, _exponent), do: err()
   def s_pow_i_lhs(_s, _exponent), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -227,6 +227,9 @@ defmodule Explorer.PolarsBackend.Series do
     do: apply_scalar_on_lhs(:remainder, left, right)
 
   @impl true
+  def pow(%Series{} = left, %Series{} = right),
+    do: Shared.apply_series(left, :s_pow, [right.data])
+
   def pow(left, exponent) when is_float(exponent),
     do: Shared.apply_series(left, :s_pow_f_rhs, [exponent])
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -254,6 +254,7 @@ rustler::init!(
         s_peak_max,
         s_peak_min,
         s_select,
+        s_pow,
         s_pow_f_lhs,
         s_pow_f_rhs,
         s_pow_i_lhs,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -662,6 +662,29 @@ pub fn s_n_distinct(data: ExSeries) -> Result<usize, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_pow(data: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
+    let s = &data.resource.0;
+    let s1 = &other.resource.0;
+
+    let iter1 = s.i64()?.into_iter();
+    match s1.strict_cast(&DataType::UInt32) {
+        Ok(s1) => {
+            let iter2 = s1.u32()?.into_iter();
+
+            let s = iter1
+                .zip(iter2)
+                .map(|(v1, v2)| v1.unwrap().pow(v2.unwrap()))
+                .collect();
+
+            Ok(ExSeries::new(s))
+        }
+        Err(_) => Err(ExplorerError::Other(String::from(
+            "negative exponent with an integer base",
+        ))),
+    }
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_pow_f_rhs(data: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
     let s = &data.resource.0;
     let s = s

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -544,6 +544,15 @@ defmodule Explorer.SeriesTest do
   end
 
   describe "pow/2" do
+    test "pow of a series with a series" do
+      s1 = Series.from_list([1, 2, 3])
+      s2 = Series.from_list([3, 2, 1])
+
+      result = Series.pow(s1, s2)
+
+      assert Series.to_list(result) == [1, 4, 3]
+    end
+
     test "pow of a series with an integer scalar value on the right-hand side" do
       s1 = Series.from_list([1, 2, 3])
 


### PR DESCRIPTION
This PR resolves #375.

Because of my lack of Rust knowledge, I need feedback for the `s_pow/2` code.