### PR TITLE
Remove build of precompiled NIFs for OTP 21

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nif: ["2.16", "2.15", "2.14"]
+        nif: ["2.16", "2.15"]
         job:
           - {
               target: arm-unknown-linux-gnueabihf,


### PR DESCRIPTION
Since we support Elixir ~> 1.13 and this version requires OTP 22, we don't need to generate the precompiled NIFs for NIF version 2.14 that works on OTP 21.