### PR TITLE
Fix mutate using a boolean scalar value

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2149,6 +2149,11 @@ defmodule Explorer.DataFrame do
 
             Explorer.Backend.Series.new(lazy_s, :string)
 
+          boolean when is_boolean(boolean) ->
+            lazy_s = LazySeries.new(:to_lazy, [boolean])
+
+            Explorer.Backend.Series.new(lazy_s, :boolean)
+
           other ->
             raise ArgumentError,
                   "expecting a lazy series or scalar value, but instead got #{inspect(other)}"

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -369,7 +369,7 @@ defmodule Explorer.DataFrameTest do
     test "adds new columns" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
-      df1 = DF.mutate(df, c: a + 5, d: 2 + a, e: 42, f: 842.1, g: "Elixir")
+      df1 = DF.mutate(df, c: a + 5, d: 2 + a, e: 42, f: 842.1, g: "Elixir", h: true)
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                a: [1, 2, 3],
@@ -378,10 +378,11 @@ defmodule Explorer.DataFrameTest do
                d: [3, 4, 5],
                e: [42, 42, 42],
                f: [842.1, 842.1, 842.1],
-               g: ["Elixir", "Elixir", "Elixir"]
+               g: ["Elixir", "Elixir", "Elixir"],
+               h: [true, true, true]
              }
 
-      assert df1.names == ["a", "b", "c", "d", "e", "f", "g"]
+      assert df1.names == ["a", "b", "c", "d", "e", "f", "g", "h"]
 
       assert df1.dtypes == %{
                "a" => :integer,
@@ -390,7 +391,8 @@ defmodule Explorer.DataFrameTest do
                "d" => :integer,
                "e" => :integer,
                "f" => :float,
-               "g" => :string
+               "g" => :string,
+               "h" => :boolean
              }
     end
 


### PR DESCRIPTION
This allows adding a new column with a repeating boolean scalar value using `mutate`.

This used to work in `0.3.1`:
```elixir
df = Explorer.DataFrame.new(a: [1, 2, 3])
Explorer.DataFrame.mutate(df, b: false)
```

But in `0.4.0` errors:
```text
** (ArgumentError) expecting a lazy series or scalar value, but instead got false
    (explorer 0.4.0) lib/explorer/data_frame.ex:2153: anonymous fn/1 in Explorer.DataFrame.mutate_with/2
    (explorer 0.4.0) lib/explorer/data_frame.ex:217: anonymous fn/4 in Explorer.DataFrame.to_column_pairs/3
    (elixir 1.14.0) lib/enum.ex:1780: Enum."-map_reduce/3-lists^mapfoldl/2-0-"/3
    (explorer 0.4.0) lib/explorer/data_frame.ex:206: Explorer.DataFrame.to_column_pairs/3
    (explorer 0.4.0) lib/explorer/data_frame.ex:2125: Explorer.DataFrame.mutate_with/2
```


Was this left out on purpose/did I miss something? If so, apologies for the noise! :laughing: 

