### PR TITLE
Avoid leaking UInt32 types to Elixir

### DIFF
--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -440,7 +440,7 @@ pub fn df_mutate_with_exprs(
             .apply(|df| df.lazy().with_columns(&mutations).collect())?
     };
 
-    Ok(ExDataFrame::new(maybe_cast_numeric_columns(new_df)?))
+    Ok(ExDataFrame::new(cast_uint32_columns_to_int64(new_df)?))
 }
 
 #[rustler::nif]
@@ -501,26 +501,22 @@ pub fn df_summarise_with_exprs(
     let aggs = ex_expr_to_exprs(aggs);
 
     let new_df = df.lazy().groupby_stable(groups).agg(aggs).collect()?;
-    Ok(ExDataFrame::new(maybe_cast_numeric_columns(new_df)?))
+    Ok(ExDataFrame::new(cast_uint32_columns_to_int64(new_df)?))
 }
 
 // We don't want to leak numeric dtypes that we don't support at the Elixir side.
-fn maybe_cast_numeric_columns(df: DataFrame) -> Result<DataFrame, ExplorerError> {
+// This is necessary for functions that mutate the DF with lazy expressions, since
+// other places are covered.
+fn cast_uint32_columns_to_int64(df: DataFrame) -> Result<DataFrame, ExplorerError> {
     let dtypes = df.dtypes();
     let mut df = df;
 
-    for (idx, dtype) in dtypes.iter().enumerate() {
-        match dtype {
-            DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32 => df.try_apply_at_idx(idx, |s| s.cast(&DataType::Int64)),
-            DataType::Float32 => df.try_apply_at_idx(idx, |s| s.cast(&DataType::Float64)),
-            _ => Ok(&mut df),
-        }?;
+    for (idx, _dtype) in dtypes
+        .iter()
+        .enumerate()
+        .filter(|(_idx, dtype)| *dtype == &DataType::UInt32)
+    {
+        df.try_apply_at_idx(idx, |s| s.cast(&DataType::Int64))?;
     }
 
     Ok(df)

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -330,7 +330,6 @@ pub fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Result<Term<'b>, Explor
         AnyValue::Boolean(v) => Ok(Some(v).encode(env)),
         AnyValue::Utf8(v) => Ok(Some(v).encode(env)),
         AnyValue::Int64(v) => Ok(Some(v).encode(env)),
-        AnyValue::UInt32(v) => Ok(Some(v).encode(env)),
         AnyValue::Float64(v) => Ok(Some(v).encode(env)),
         AnyValue::Date(v) => encode_date(v, env),
         AnyValue::Datetime(v, time_unit, None) => encode_datetime(v, time_unit, env),
@@ -344,7 +343,6 @@ pub fn list_from_series(data: ExSeries, env: Env) -> Result<Term, ExplorerError>
     match s.dtype() {
         DataType::Boolean => series_to_list!(s, env, bool),
         DataType::Int64 => series_to_list!(s, env, i64),
-        DataType::UInt32 => series_to_list!(s, env, u32),
         DataType::Float64 => float64_series_to_list(s, env),
         DataType::Date => date_series_to_list(s, env),
         DataType::Datetime(time_unit, None) => datetime_series_to_list(s, *time_unit, env),
@@ -373,7 +371,6 @@ pub fn iovec_from_series(data: ExSeries, env: Env) -> Result<Term, ExplorerError
             Ok([bin.release(env)].encode(env))
         }
         DataType::Int64 => series_to_iovec!(resource, s, env, i64, i64),
-        DataType::UInt32 => series_to_iovec!(resource, s, env, u32, u32),
         DataType::Float64 => series_to_iovec!(resource, s, env, f64, f64),
         DataType::Utf8 => series_to_iovec!(resource, s, env, utf8, u8),
         DataType::Binary => series_to_iovec!(resource, s, env, binary, u8),

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -6,7 +6,7 @@
 
 use chrono::{NaiveDate, NaiveDateTime};
 use polars::prelude::{col, when, DataFrame, IntoLazy, LiteralValue, SortOptions};
-use polars::prelude::{DataType, Expr, Literal, Series};
+use polars::prelude::{Expr, Literal, Series};
 
 use crate::datatypes::{ExDate, ExDateTime};
 use crate::series::{cast_str_to_dtype, rolling_opts};
@@ -388,7 +388,7 @@ pub fn expr_nil_count(expr: ExExpr) -> ExExpr {
 pub fn expr_n_distinct(expr: ExExpr) -> ExExpr {
     let expr: Expr = expr.resource.0.clone();
 
-    ExExpr::new(expr.n_unique().cast(DataType::Int64))
+    ExExpr::new(expr.n_unique())
 }
 
 #[rustler::nif]
@@ -504,7 +504,7 @@ pub fn expr_argsort(expr: ExExpr, descending: bool, nulls_last: bool) -> ExExpr 
         nulls_last,
     };
 
-    ExExpr::new(expr.arg_sort(opts).cast(DataType::Int64))
+    ExExpr::new(expr.arg_sort(opts))
 }
 
 #[rustler::nif]


### PR DESCRIPTION
We do a cast to `Int64`.

Closes https://github.com/elixir-nx/explorer/issues/431