### PR TITLE
Add IO operations "from/load" to the LazyFrame implementation

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -394,6 +394,8 @@ defmodule Explorer.DataFrame do
   @spec from_csv(filename :: String.t(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}
   def from_csv(filename, opts \\ []) do
+    {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
+
     opts =
       Keyword.validate!(opts,
         delimiter: ",",
@@ -408,7 +410,7 @@ defmodule Explorer.DataFrame do
         parse_dates: false
       )
 
-    backend = backend_from_options!(opts)
+    backend = backend_from_options!(backend_opts)
 
     backend.from_csv(
       filename,
@@ -459,6 +461,8 @@ defmodule Explorer.DataFrame do
   @spec load_csv(contents :: String.t(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}
   def load_csv(contents, opts \\ []) do
+    {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
+
     opts =
       Keyword.validate!(opts,
         delimiter: ",",
@@ -473,7 +477,7 @@ defmodule Explorer.DataFrame do
         parse_dates: false
       )
 
-    backend = backend_from_options!(opts)
+    backend = backend_from_options!(backend_opts)
 
     backend.load_csv(
       contents,
@@ -660,12 +664,14 @@ defmodule Explorer.DataFrame do
   @spec from_ipc(filename :: String.t(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}
   def from_ipc(filename, opts \\ []) do
+    {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
+
     opts =
       Keyword.validate!(opts,
         columns: nil
       )
 
-    backend = backend_from_options!(opts)
+    backend = backend_from_options!(backend_opts)
 
     backend.from_ipc(
       filename,
@@ -780,12 +786,14 @@ defmodule Explorer.DataFrame do
   @spec load_ipc(contents :: binary(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}
   def load_ipc(contents, opts \\ []) do
+    {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
+
     opts =
       Keyword.validate!(opts,
         columns: nil
       )
 
-    backend = backend_from_options!(opts)
+    backend = backend_from_options!(backend_opts)
 
     backend.load_ipc(
       contents,
@@ -815,8 +823,10 @@ defmodule Explorer.DataFrame do
   @doc type: :io
   @spec from_ipc_stream(filename :: String.t()) :: {:ok, DataFrame.t()} | {:error, term()}
   def from_ipc_stream(filename, opts \\ []) do
+    {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
+
     opts = Keyword.validate!(opts, columns: nil)
-    backend = backend_from_options!(opts)
+    backend = backend_from_options!(backend_opts)
 
     backend.from_ipc_stream(filename, to_columns_for_io(opts[:columns]))
   end
@@ -909,12 +919,14 @@ defmodule Explorer.DataFrame do
   @spec load_ipc_stream(contents :: binary(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}
   def load_ipc_stream(contents, opts \\ []) do
+    {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
+
     opts =
       Keyword.validate!(opts,
         columns: nil
       )
 
-    backend = backend_from_options!(opts)
+    backend = backend_from_options!(backend_opts)
 
     backend.load_ipc_stream(
       contents,
@@ -1012,13 +1024,15 @@ defmodule Explorer.DataFrame do
   @spec from_ndjson(filename :: String.t(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}
   def from_ndjson(filename, opts \\ []) do
+    {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
+
     opts =
       Keyword.validate!(opts,
         batch_size: 1000,
         infer_schema_length: @default_infer_schema_length
       )
 
-    backend = backend_from_options!(opts)
+    backend = backend_from_options!(backend_opts)
 
     backend.from_ndjson(
       filename,
@@ -1100,13 +1114,15 @@ defmodule Explorer.DataFrame do
   @spec load_ndjson(contents :: String.t(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}
   def load_ndjson(contents, opts \\ []) do
+    {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
+
     opts =
       Keyword.validate!(opts,
         batch_size: 1000,
         infer_schema_length: @default_infer_schema_length
       )
 
-    backend = backend_from_options!(opts)
+    backend = backend_from_options!(backend_opts)
 
     backend.load_ndjson(
       contents,
@@ -4423,7 +4439,12 @@ defmodule Explorer.DataFrame do
 
   defp backend_from_options!(opts) do
     backend = Explorer.Shared.backend_from_options!(opts) || Explorer.Backend.get()
-    :"#{backend}.DataFrame"
+
+    if opts[:lazy] do
+      :"#{backend}.LazyFrame"
+    else
+      :"#{backend}.DataFrame"
+    end
   end
 
   defp maybe_raise_column_not_found(df, name) do

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -549,7 +549,8 @@ defmodule Explorer.DataFrame do
 
   """
   @doc type: :io
-  @spec to_parquet(df :: DataFrame.t(), filename :: String.t()) :: :ok | {:error, term()}
+  @spec to_parquet(df :: DataFrame.t(), filename :: String.t(), opts :: Keyword.t()) ::
+          :ok | {:error, term()}
   def to_parquet(df, filename, opts \\ []) do
     opts = Keyword.validate!(opts, compression: nil)
     compression = parquet_compression(opts[:compression])
@@ -1063,9 +1064,22 @@ defmodule Explorer.DataFrame do
   They are often used as structured logs.
   """
   @doc type: :io
-  @spec to_ndjson(df :: DataFrame.t(), filename :: String.t()) :: :ok | {:error, term()}
-  def to_ndjson(df, filename) do
+  @spec to_ndjson(df :: DataFrame.t(), filename :: String.t(), opts :: Keyword.t()) ::
+          :ok | {:error, term()}
+  def to_ndjson(df, filename, _opts \\ []) do
     Shared.apply_impl(df, :to_ndjson, [filename])
+  end
+
+  @doc """
+  Similar to `to_ndjson/3`, but raises in case of error.
+  """
+  @doc type: :io
+  @spec to_ndjson!(df :: DataFrame.t(), filename :: String.t(), opts :: Keyword.t()) :: :ok
+  def to_ndjson!(df, filename, opts \\ []) do
+    case to_ndjson(df, filename, opts) do
+      :ok -> :ok
+      {:error, error} -> raise "to_ndjson failed: #{inspect(error)}"
+    end
   end
 
   @doc """

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -1,6 +1,7 @@
 defmodule Explorer.PolarsBackend.LazyFrame do
   @moduledoc false
 
+  alias Explorer.PolarsBackend.Native
   alias Explorer.PolarsBackend.Shared
 
   @type t :: %__MODULE__{resource: binary(), reference: reference()}
@@ -42,6 +43,69 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   @impl true
   def slice(ldf, offset, length),
     do: Shared.apply_dataframe(ldf, ldf, :lf_slice, [offset, length])
+
+  # IO
+
+  @default_infer_schema_length 1000
+
+  @impl true
+  def from_csv(
+        filename,
+        dtypes,
+        <<delimiter::utf8>>,
+        null_character,
+        skip_rows,
+        header?,
+        encoding,
+        max_rows,
+        columns,
+        infer_schema_length,
+        parse_dates
+      ) do
+    if columns do
+      raise ArgumentError,
+            "`columns` is not supported by Polars' lazy backend. " <>
+              "Consider using `select/2` after reading the CSV"
+    end
+
+    infer_schema_length =
+      if infer_schema_length == nil,
+        do: max_rows || @default_infer_schema_length,
+        else: infer_schema_length
+
+    dtypes =
+      Enum.map(dtypes, fn {column_name, dtype} ->
+        {column_name, Shared.internal_from_dtype(dtype)}
+      end)
+
+    df =
+      Native.lf_from_csv(
+        filename,
+        infer_schema_length,
+        header?,
+        max_rows,
+        skip_rows,
+        delimiter,
+        true,
+        dtypes,
+        encoding,
+        null_character,
+        parse_dates
+      )
+
+    case df do
+      {:ok, df} -> {:ok, Shared.create_dataframe(df)}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  @impl true
+  def from_parquet(filename) do
+    case Native.lf_from_parquet(filename) do
+      {:ok, df} -> {:ok, Shared.create_dataframe(df)}
+      {:error, error} -> {:error, error}
+    end
+  end
 
   # Groups
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -136,6 +136,24 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_select(_df, _columns), do: err()
   def lf_tail(_df, _n_rows), do: err()
   def lf_slice(_df, _offset, _length), do: err()
+  def lf_from_ipc(_filename), do: err()
+  def lf_from_ndjson(_filename, _infer_schema_length, _batch_size), do: err()
+  def lf_from_parquet(_filename), do: err()
+
+  def lf_from_csv(
+        _filename,
+        _infer_schema_length,
+        _has_header,
+        _stop_after_n_rows,
+        _skip_rows,
+        _sep,
+        _rechunk,
+        _dtypes,
+        _encoding,
+        _null_char,
+        _parse_dates
+      ),
+      do: err()
 
   # Series
   def s_add(_s, _other), do: err()

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -31,6 +31,7 @@ features = [
   "checked_arithmetic",
   "cross_join",
   "cum_agg",
+  "csv-file",
   "decompress",
   "describe",
   "dtype-date",

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -66,7 +66,7 @@ pub fn df_from_csv(
     Ok(ExDataFrame::new(df))
 }
 
-fn schema_from_dtypes_pairs(dtypes: Vec<(&str, &str)>) -> Result<Schema, ExplorerError> {
+pub fn schema_from_dtypes_pairs(dtypes: Vec<(&str, &str)>) -> Result<Schema, ExplorerError> {
     let mut schema = Schema::new();
     for (name, dtype_str) in dtypes {
         let dtype = dtype_from_str(dtype_str)?;

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -1,7 +1,9 @@
+use crate::{ExDataFrame, ExLazyFrame, ExplorerError};
 use polars::prelude::*;
 use std::result::Result;
 
-use crate::{ExDataFrame, ExLazyFrame, ExplorerError};
+// Loads the IO functions for read/writing CSV, NDJSON, Parquet, etc.
+pub mod io;
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn lf_collect(data: ExLazyFrame) -> Result<ExDataFrame, ExplorerError> {

--- a/native/explorer/src/lazyframe/io.rs
+++ b/native/explorer/src/lazyframe/io.rs
@@ -1,0 +1,87 @@
+use polars::prelude::*;
+use std::result::Result;
+
+use crate::dataframe::io::schema_from_dtypes_pairs;
+use crate::{ExLazyFrame, ExplorerError};
+
+#[rustler::nif]
+pub fn lf_from_parquet(filename: &str) -> Result<ExLazyFrame, ExplorerError> {
+    let lf = LazyFrame::scan_parquet(filename, Default::default())?;
+    Ok(ExLazyFrame::new(lf))
+}
+
+#[rustler::nif]
+pub fn lf_from_ipc(filename: &str) -> Result<ExLazyFrame, ExplorerError> {
+    let lf = LazyFrame::scan_ipc(filename, Default::default())?;
+
+    Ok(ExLazyFrame::new(lf))
+}
+
+#[rustler::nif]
+#[allow(clippy::too_many_arguments)]
+pub fn lf_from_csv(
+    filename: &str,
+    infer_schema_length: Option<usize>,
+    has_header: bool,
+    stop_after_n_rows: Option<usize>,
+    skip_rows: usize,
+    delimiter_as_byte: u8,
+    do_rechunk: bool,
+    dtypes: Option<Vec<(&str, &str)>>,
+    encoding: &str,
+    null_char: String,
+    parse_dates: bool,
+) -> Result<ExLazyFrame, ExplorerError> {
+    let encoding = match encoding {
+        "utf8-lossy" => CsvEncoding::LossyUtf8,
+        _ => CsvEncoding::Utf8,
+    };
+
+    let schema: Option<Schema> = match dtypes {
+        Some(dtypes) => Some(schema_from_dtypes_pairs(dtypes)?),
+
+        None => None,
+    };
+
+    let df = LazyCsvReader::new(filename)
+        .with_infer_schema_length(infer_schema_length)
+        .has_header(has_header)
+        .with_parse_dates(parse_dates)
+        .with_n_rows(stop_after_n_rows)
+        .with_delimiter(delimiter_as_byte)
+        .with_skip_rows(skip_rows)
+        .with_rechunk(do_rechunk)
+        .with_encoding(encoding)
+        .with_dtype_overwrite(schema.as_ref())
+        .with_null_values(Some(NullValues::AllColumns(vec![null_char])))
+        .finish()?;
+
+    Ok(ExLazyFrame::new(df))
+}
+
+#[cfg(not(target_arch = "arm"))]
+#[rustler::nif]
+pub fn lf_from_ndjson(
+    filename: String,
+    infer_schema_length: Option<usize>,
+    batch_size: Option<usize>,
+) -> Result<ExLazyFrame, ExplorerError> {
+    let lf = LazyJsonLineReader::new(filename)
+        .with_infer_schema_length(infer_schema_length)
+        .with_batch_size(batch_size)
+        .finish()?;
+
+    Ok(ExLazyFrame::new(lf))
+}
+
+#[cfg(target_arch = "arm")]
+#[rustler::nif]
+pub fn df_from_ndjson(
+    _filename: &str,
+    _infer_schema_length: Option<usize>,
+    _batch_size: usize,
+) -> Result<ExDataFrame, ExplorerError> {
+    Err(ExplorerError::Other(format!(
+        "NDJSON parsing is not enabled for this machine"
+    )))
+}

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -30,6 +30,7 @@ pub use datatypes::{
 };
 pub use error::ExplorerError;
 use expressions::*;
+use lazyframe::io::*;
 use lazyframe::*;
 use series::*;
 
@@ -214,6 +215,10 @@ rustler::init!(
         lf_select,
         lf_tail,
         lf_slice,
+        lf_from_csv,
+        lf_from_ipc,
+        lf_from_parquet,
+        lf_from_ndjson,
         // series
         s_add,
         s_and,

--- a/test/explorer/data_frame/csv_test.exs
+++ b/test/explorer/data_frame/csv_test.exs
@@ -125,13 +125,13 @@ defmodule Explorer.DataFrame.CSVTest do
     end
   end
 
-  describe "from_csv/2 options" do
-    defp tmp_csv(tmp_dir, contents) do
-      path = Path.join(tmp_dir, "tmp.csv")
-      :ok = File.write!(path, contents)
-      path
-    end
+  defp tmp_csv(tmp_dir, contents) do
+    path = Path.join(tmp_dir, "tmp.csv")
+    :ok = File.write!(path, contents)
+    path
+  end
 
+  describe "from_csv/2 options" do
     @tag :tmp_dir
     test "delimiter", config do
       csv =

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -145,4 +145,105 @@ defmodule Explorer.DataFrame.LazyTest do
 
     assert DF.to_columns(df1) == DF.to_columns(df)
   end
+
+  @tag :tmp_dir
+  test "from_ndjson/2 - with defaults", %{df: df, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.ndjson"])
+    df = DF.slice(df, 0, 10)
+    DF.to_ndjson!(df, path)
+
+    ldf = DF.from_ndjson!(path, lazy: true)
+
+    # no-op 
+    assert DF.to_lazy(ldf) == ldf
+
+    df1 = DF.collect(ldf)
+
+    assert DF.to_columns(df1) == DF.to_columns(df)
+  end
+
+  @tag :tmp_dir
+  test "from_ipc/2 - with defaults", %{df: df, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.ipc"])
+    df = DF.slice(df, 0, 10)
+    DF.to_ipc!(df, path)
+
+    ldf = DF.from_ipc!(path, lazy: true)
+
+    # no-op 
+    assert DF.to_lazy(ldf) == ldf
+
+    df1 = DF.collect(ldf)
+
+    assert DF.to_columns(df1) == DF.to_columns(df)
+  end
+
+  @tag :tmp_dir
+  test "from_ipc/2 - passing columns", %{df: df, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.ipc"])
+    df = DF.slice(df, 0, 10)
+    DF.to_ipc!(df, path)
+
+    assert_raise ArgumentError,
+                 "`columns` is not supported by Polars' lazy backend. Consider using `select/2` after reading the IPC file",
+                 fn ->
+                   DF.from_ipc!(path, lazy: true, columns: ["country", "year", "total"])
+                 end
+  end
+
+  test "load_csv/2 - with defaults", %{df: df} do
+    df = DF.slice(df, 0, 10)
+    contents = DF.dump_csv!(df)
+
+    ldf = DF.load_csv!(contents, lazy: true)
+
+    # no-op 
+    assert DF.to_lazy(ldf) == ldf
+
+    df1 = DF.collect(ldf)
+
+    assert DF.to_columns(df1) == DF.to_columns(df)
+  end
+
+  test "load_parquet/2 - with defaults", %{df: df} do
+    df = DF.slice(df, 0, 10)
+    contents = DF.dump_parquet!(df)
+
+    ldf = DF.load_parquet!(contents, lazy: true)
+
+    # no-op 
+    assert DF.to_lazy(ldf) == ldf
+
+    df1 = DF.collect(ldf)
+
+    assert DF.to_columns(df1) == DF.to_columns(df)
+  end
+
+  test "load_ndjson/2 - with defaults", %{df: df} do
+    df = DF.slice(df, 0, 10)
+    contents = DF.dump_ndjson!(df)
+
+    ldf = DF.load_ndjson!(contents, lazy: true)
+
+    # no-op 
+    assert DF.to_lazy(ldf) == ldf
+
+    df1 = DF.collect(ldf)
+
+    assert DF.to_columns(df1) == DF.to_columns(df)
+  end
+
+  test "load_ipc/2 - with defaults", %{df: df} do
+    df = DF.slice(df, 0, 10)
+    contents = DF.dump_ipc!(df)
+
+    ldf = DF.load_ipc!(contents, lazy: true)
+
+    # no-op 
+    assert DF.to_lazy(ldf) == ldf
+
+    df1 = DF.collect(ldf)
+
+    assert DF.to_columns(df1) == DF.to_columns(df)
+  end
 end

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -100,4 +100,49 @@ defmodule Explorer.DataFrame.LazyTest do
   bunker_fuels integer [9, 7, 663, 0, 321, ...]
 >)
   end
+
+  @tag :tmp_dir
+  test "from_csv/2 - with defaults", %{df: df, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.csv"])
+    df = DF.slice(df, 0, 10)
+    DF.to_csv!(df, path)
+
+    ldf = DF.from_csv!(path, lazy: true)
+
+    # no-op 
+    assert DF.to_lazy(ldf) == ldf
+
+    df1 = DF.collect(ldf)
+
+    assert DF.to_columns(df1) == DF.to_columns(df)
+  end
+
+  @tag :tmp_dir
+  test "from_csv/2 - passing columns", %{df: df, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.csv"])
+    df = DF.slice(df, 0, 10)
+    DF.to_csv!(df, path)
+
+    assert_raise ArgumentError,
+                 "`columns` is not supported by Polars' lazy backend. Consider using `select/2` after reading the CSV",
+                 fn ->
+                   DF.from_csv!(path, lazy: true, columns: ["country", "year", "total"])
+                 end
+  end
+
+  @tag :tmp_dir
+  test "from_parquet/2 - with defaults", %{df: df, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.parquet"])
+    df = DF.slice(df, 0, 10)
+    DF.to_parquet!(df, path)
+
+    ldf = DF.from_parquet!(path, lazy: true)
+
+    # no-op 
+    assert DF.to_lazy(ldf) == ldf
+
+    df1 = DF.collect(ldf)
+
+    assert DF.to_columns(df1) == DF.to_columns(df)
+  end
 end


### PR DESCRIPTION
This is related to #227 

In the first PR for that issue, #202, we [discussed](https://github.com/elixir-nx/explorer/pull/202#discussion_r876379528) a possible `lazy: true` option to control which backend to use. I end up using both `:backend` and `:lazy` to make it easier for clients to choose the backend. This adds the possibility for a backend to be implemented both using an eager (the default) and lazy version. WDYT?

I also choose to "delegate" the load of binaries to the eager implementation, and then converting it to lazy. This is mostly for convenience, because there is not such loaders in the Polars backend.