### PR TITLE
Allow DataFrame.new/1 to receive the dtypes option

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -120,7 +120,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback lazy() :: module()
   @callback to_lazy(df) :: df
   @callback collect(df) :: df
-  @callback from_tabular(Table.Reader.t()) :: df
+  @callback from_tabular(Table.Reader.t(), dtypes :: list({column_name(), dtype()})) :: df
   @callback from_series(map() | Keyword.t()) :: df
   @callback to_rows(df, atom_keys? :: boolean()) :: [map()]
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1201,6 +1201,7 @@ defmodule Explorer.DataFrame do
   ## Options
 
     * `:backend` - The Explorer backend to use. Defaults to the value returned by `Explorer.Backend.get/0`.
+    * `:dtypes` - A list/map of `{column_name, dtype}` tuples. (default: `[]`)
 
   ## Examples
 
@@ -1225,6 +1226,14 @@ defmodule Explorer.DataFrame do
       iex> Explorer.DataFrame.new(floats: [1.0, 2.0], ints: [1, nil])
       #Explorer.DataFrame<
         Polars[2 x 2]
+        floats float [1.0, 2.0]
+        ints integer [1, nil]
+      >
+
+      iex> Explorer.DataFrame.new(%{floats: [1.0, 2.0], ints: [1, nil], binaries: [<<239, 191, 19>>, nil]}, dtypes: [{:binaries, :binary}])
+      #Explorer.DataFrame<
+        Polars[2 x 3]
+        binaries binary [<<239, 191, 19>>, nil]
         floats float [1.0, 2.0]
         ints integer [1, nil]
       >
@@ -1257,6 +1266,8 @@ defmodule Explorer.DataFrame do
         ) :: DataFrame.t()
         when series_pairs: %{column_name() => Series.t()} | [{column_name(), Series.t()}]
   def new(data, opts \\ []) do
+    opts = Keyword.validate!(opts, lazy: false, backend: nil, dtypes: [])
+
     backend = backend_from_options!(opts)
 
     case data do
@@ -1266,7 +1277,7 @@ defmodule Explorer.DataFrame do
       data ->
         case classify_data(data) do
           {:series, series} -> backend.from_series(series)
-          {:other, tabular} -> backend.from_tabular(tabular)
+          {:other, tabular} -> backend.from_tabular(tabular, opts[:dtypes])
         end
     end
   end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -283,10 +283,11 @@ defmodule Explorer.PolarsBackend.DataFrame do
   def from_tabular(tabular, dtypes) do
     {_, %{columns: keys}, _} = reader = init_reader!(tabular)
     columns = Table.to_columns(reader)
+    dtypes = Map.new(dtypes)
 
     keys
     |> Enum.map(fn key ->
-      dtype = dtypes |> Map.new() |> Map.get(key)
+      dtype = Map.get(dtypes, key)
       column_name = to_column_name!(key)
       values = Enum.to_list(columns[key])
       series_from_list!(column_name, values, dtype)

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -280,15 +280,16 @@ defmodule Explorer.PolarsBackend.DataFrame do
   def collect(df), do: df
 
   @impl true
-  def from_tabular(tabular) do
+  def from_tabular(tabular, dtypes) do
     {_, %{columns: keys}, _} = reader = init_reader!(tabular)
     columns = Table.to_columns(reader)
 
     keys
     |> Enum.map(fn key ->
+      dtype = dtypes |> Map.new() |> Map.get(key)
       column_name = to_column_name!(key)
       values = Enum.to_list(columns[key])
-      series_from_list!(column_name, values)
+      series_from_list!(column_name, values, dtype)
     end)
     |> from_series_list()
   end
@@ -325,8 +326,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   # Like `Explorer.Series.from_list/2`, but gives a better error message with the series name.
-  defp series_from_list!(name, list) do
-    type = Explorer.Shared.check_types!(list)
+  defp series_from_list!(name, list, dtype) do
+    type = Explorer.Shared.check_types!(list, dtype)
     {list, type} = Explorer.Shared.cast_numerics(list, type)
     series = Shared.from_list(list, type, name)
     Explorer.Backend.Series.new(series, type)

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -23,7 +23,8 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   def collect(ldf), do: Shared.apply_dataframe(ldf, ldf, :lf_collect, [])
 
   @impl true
-  def from_tabular(tabular), do: Eager.from_tabular(tabular) |> Eager.to_lazy()
+  def from_tabular(tabular, dtypes),
+    do: Eager.from_tabular(tabular, dtypes) |> Eager.to_lazy()
 
   @impl true
   def from_series(pairs), do: Eager.from_series(pairs) |> Eager.to_lazy()

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -117,6 +117,9 @@ defmodule Explorer.Shared do
           new_type == :numeric and type in [:float, :integer] ->
             new_type
 
+          new_type == type and type == :binary ->
+            new_type
+
           new_type != type and type != nil ->
             raise ArgumentError,
                   "the value #{inspect(el)} does not match the inferred series dtype #{inspect(type)}"


### PR DESCRIPTION
This PR resolves https://github.com/elixir-nx/explorer/issues/458.