### PR TITLE
Add Series.categories/1

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -617,6 +617,7 @@ defmodule Explorer.Backend.LazySeries do
     at: 2,
     at_every: 2,
     bintype: 1,
+    categories: 1,
     frequencies: 1,
     mask: 2,
     slice: 2,

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -37,6 +37,7 @@ defmodule Explorer.Backend.Series do
   @callback size(s) :: non_neg_integer() | lazy_s()
   @callback inspect(s, opts :: Inspect.Opts.t()) :: Inspect.Algebra.t()
   @callback bintype(s) :: :uft8 | :binary | {:s | :u | :f, non_neg_integer}
+  @callback categories(s) :: s
 
   # Slice and dice
 

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -175,6 +175,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_argsort(_s, _descending?, _nils_last?), do: err()
   def s_as_str(_s), do: err()
   def s_cast(_s, _dtype), do: err()
+  def s_categories(_s), do: err()
   def s_coalesce(_s, _other), do: err()
   def s_concat(_s, _other), do: err()
   def s_contains(_s, _pattern), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -61,6 +61,10 @@ defmodule Explorer.PolarsBackend.Series do
     end
   end
 
+  @impl true
+  def categories(%Series{dtype: :category} = series),
+    do: Shared.apply_series(series, :s_categories)
+
   # Slice and dice
 
   @impl true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -689,6 +689,33 @@ defmodule Explorer.Series do
   @spec bintype(series :: Series.t()) :: {:s | :u | :f, non_neg_integer()}
   def bintype(series), do: Shared.apply_impl(series, :bintype)
 
+  @doc """
+  Return a series with the category names of a categorical series.
+
+  Each category has the index equal to its position.
+
+  ## Examples
+
+      iex> s = Explorer.Series.from_list(["a", "b", "c", nil, "a", "c"], dtype: :category)
+      iex> Explorer.Series.categories(s)
+      #Explorer.Series<
+        Polars[3]
+        string ["a", "b", "c"]
+      >
+
+      iex> s = Explorer.Series.from_list(["c", "a", "b"], dtype: :category)
+      iex> Explorer.Series.categories(s)
+      #Explorer.Series<
+        Polars[3]
+        string ["c", "a", "b"]
+      >
+
+  """
+  @doc type: :introspection
+  @spec categories(series :: Series.t()) :: Series.t()
+  def categories(%Series{dtype: :category} = series), do: Shared.apply_impl(series, :categories)
+  def categories(%Series{dtype: dtype}), do: dtype_error("categories/1", dtype, [:category])
+
   # Slice and dice
 
   @doc """

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -693,6 +693,7 @@ defmodule Explorer.Series do
   Return a series with the category names of a categorical series.
 
   Each category has the index equal to its position.
+  No order for the categories is guaranteed.
 
   ## Examples
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -230,6 +230,7 @@ rustler::init!(
         s_argsort,
         s_as_str,
         s_cast,
+        s_categories,
         s_coalesce,
         s_concat,
         s_contains,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -780,6 +780,22 @@ pub fn cast_str_to_dtype(str_type: &str) -> Result<DataType, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_categories(data: ExSeries) -> Result<ExSeries, ExplorerError> {
+    let s: &Series = &data.resource.0;
+    match s.dtype() {
+        DataType::Categorical(Some(mapping)) => {
+            let size = mapping.len() as u32;
+            let categories: Vec<&str> = (0..size).map(|id| mapping.get(id)).collect();
+            let series = Series::new("categories".into(), &categories);
+            Ok(ExSeries::new(series))
+        }
+        _ => Err(ExplorerError::Other(
+            "Cannot get categories from non categorical series".into(),
+        )),
+    }
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_seedable_random_indices(
     length: usize,
     n_samples: usize,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -789,9 +789,7 @@ pub fn s_categories(data: ExSeries) -> Result<ExSeries, ExplorerError> {
             let series = Series::new("categories", &categories);
             Ok(ExSeries::new(series))
         }
-        _ => Err(ExplorerError::Other(
-            "Cannot get categories from non categorical series".into(),
-        )),
+        _ => panic!("Cannot get categories from non categorical series"),
     }
 }
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -786,7 +786,7 @@ pub fn s_categories(data: ExSeries) -> Result<ExSeries, ExplorerError> {
         DataType::Categorical(Some(mapping)) => {
             let size = mapping.len() as u32;
             let categories: Vec<&str> = (0..size).map(|id| mapping.get(id)).collect();
-            let series = Series::new("categories".into(), &categories);
+            let series = Series::new("categories", &categories);
             Ok(ExSeries::new(series))
         }
         _ => Err(ExplorerError::Other(

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -832,4 +832,11 @@ defmodule Explorer.SeriesTest do
     assert Series.nil_count(s2) == 4
     assert Series.nil_count(s3) == 0
   end
+
+  test "categories/1" do
+    s = Series.from_list(["a", "b", "c", nil, "a"], dtype: :category)
+    categories = Series.categories(s)
+    assert Series.to_list(categories) === ["a", "b", "c"]
+    assert Series.dtype(categories) == :string
+  end
 end


### PR DESCRIPTION
This function is useful to retrieve only the categories from a categorical series.
The resultant series is of ":string" dtype.