### PR TITLE
Add `clone_inner()` to Ex structs

### DIFF
--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -172,7 +172,6 @@ defmodule Explorer.PolarsBackend.Native do
   def s_add(_s, _other), do: err()
   def s_and(_s, _s2), do: err()
   def s_argsort(_s, _descending?, _nils_last?), do: err()
-  def s_as_str(_s), do: err()
   def s_cast(_s, _dtype), do: err()
   def s_categories(_s), do: err()
   def s_categorise(_s, _s_categories), do: err()

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -109,13 +109,12 @@ pub fn df_to_csv(
     has_headers: bool,
     delimiter: u8,
 ) -> Result<(), ExplorerError> {
-    let df = &data.resource.0;
     let file = File::create(filename)?;
     let mut buf_writer = BufWriter::new(file);
     CsvWriter::new(&mut buf_writer)
         .has_header(has_headers)
         .with_delimiter(delimiter)
-        .finish(&mut df.clone())?;
+        .finish(&mut data.clone_inner())?;
     Ok(())
 }
 
@@ -126,13 +125,12 @@ pub fn df_dump_csv(
     has_headers: bool,
     delimiter: u8,
 ) -> Result<Binary, ExplorerError> {
-    let df = &data.resource.0;
     let mut buf = vec![];
 
     CsvWriter::new(&mut buf)
         .has_header(has_headers)
         .with_delimiter(delimiter)
-        .finish(&mut df.clone())?;
+        .finish(&mut data.clone_inner())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
     values_binary.copy_from_slice(&buf);
@@ -205,14 +203,13 @@ pub fn df_to_parquet(
     compression: Option<&str>,
     compression_level: Option<i32>,
 ) -> Result<(), ExplorerError> {
-    let df = &data.resource.0;
     let file = File::create(filename)?;
     let mut buf_writer = BufWriter::new(file);
     let compression = parquet_compression(compression, compression_level)?;
 
     ParquetWriter::new(&mut buf_writer)
         .with_compression(compression)
-        .finish(&mut df.clone())?;
+        .finish(&mut data.clone_inner())?;
     Ok(())
 }
 
@@ -257,14 +254,13 @@ pub fn df_dump_parquet<'a>(
     compression: Option<&str>,
     compression_level: Option<i32>,
 ) -> Result<Binary<'a>, ExplorerError> {
-    let df = &data.resource.0;
     let mut buf = vec![];
 
     let compression = parquet_compression(compression, compression_level)?;
 
     ParquetWriter::new(&mut buf)
         .with_compression(compression)
-        .finish(&mut df.clone())?;
+        .finish(&mut data.clone_inner())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
     values_binary.copy_from_slice(&buf);
@@ -303,8 +299,6 @@ pub fn df_to_ipc(
     filename: &str,
     compression: Option<&str>,
 ) -> Result<(), ExplorerError> {
-    let df = &data.resource.0;
-
     // Select the compression algorithm.
     let compression = match compression {
         Some("lz4") => Some(IpcCompression::LZ4),
@@ -316,7 +310,7 @@ pub fn df_to_ipc(
     let mut buf_writer = BufWriter::new(file);
     IpcWriter::new(&mut buf_writer)
         .with_compression(compression)
-        .finish(&mut df.clone())?;
+        .finish(&mut data.clone_inner())?;
     Ok(())
 }
 
@@ -326,7 +320,6 @@ pub fn df_dump_ipc<'a>(
     data: ExDataFrame,
     compression: Option<&str>,
 ) -> Result<Binary<'a>, ExplorerError> {
-    let df = &data.resource.0;
     let mut buf = vec![];
 
     // Select the compression algorithm.
@@ -338,7 +331,7 @@ pub fn df_dump_ipc<'a>(
 
     IpcWriter::new(&mut buf)
         .with_compression(compression)
-        .finish(&mut df.clone())?;
+        .finish(&mut data.clone_inner())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
     values_binary.copy_from_slice(&buf);
@@ -383,8 +376,6 @@ pub fn df_to_ipc_stream(
     filename: &str,
     compression: Option<&str>,
 ) -> Result<(), ExplorerError> {
-    let df = &data.resource.0;
-
     // Select the compression algorithm.
     let compression = match compression {
         Some("lz4") => Some(IpcCompression::LZ4),
@@ -395,7 +386,7 @@ pub fn df_to_ipc_stream(
     let mut file = File::create(filename).expect("could not create file");
     IpcStreamWriter::new(&mut file)
         .with_compression(compression)
-        .finish(&mut df.clone())?;
+        .finish(&mut data.clone_inner())?;
     Ok(())
 }
 
@@ -405,7 +396,6 @@ pub fn df_dump_ipc_stream<'a>(
     data: ExDataFrame,
     compression: Option<&str>,
 ) -> Result<Binary<'a>, ExplorerError> {
-    let df = &data.resource.0;
     let mut buf = vec![];
 
     // Select the compression algorithm.
@@ -417,7 +407,7 @@ pub fn df_dump_ipc_stream<'a>(
 
     IpcStreamWriter::new(&mut buf)
         .with_compression(compression)
-        .finish(&mut df.clone())?;
+        .finish(&mut data.clone_inner())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
     values_binary.copy_from_slice(&buf);
@@ -461,25 +451,23 @@ pub fn df_from_ndjson(
 #[cfg(not(any(target_arch = "arm", target_arch = "riscv64")))]
 #[rustler::nif(schedule = "DirtyIo")]
 pub fn df_to_ndjson(data: ExDataFrame, filename: &str) -> Result<(), ExplorerError> {
-    let df = &data.resource.0;
     let file = File::create(filename)?;
     let mut buf_writer = BufWriter::new(file);
 
     JsonWriter::new(&mut buf_writer)
         .with_json_format(JsonFormat::JsonLines)
-        .finish(&mut df.clone())?;
+        .finish(&mut data.clone_inner())?;
     Ok(())
 }
 
 #[cfg(not(any(target_arch = "arm", target_arch = "riscv64")))]
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_dump_ndjson(env: Env, data: ExDataFrame) -> Result<Binary, ExplorerError> {
-    let df = &data.resource.0;
     let mut buf = vec![];
 
     JsonWriter::new(&mut buf)
         .with_json_format(JsonFormat::JsonLines)
-        .finish(&mut df.clone())?;
+        .finish(&mut data.clone_inner())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
     values_binary.copy_from_slice(&buf);

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -63,6 +63,11 @@ impl ExDataFrame {
             resource: ResourceArc::new(ExDataFrameRef::new(df)),
         }
     }
+
+    // Returns a clone of the DataFrame inside the ResourceArc container.
+    pub fn clone_inner(&self) -> DataFrame {
+        self.resource.0.clone()
+    }
 }
 
 impl ExExpr {
@@ -70,6 +75,11 @@ impl ExExpr {
         Self {
             resource: ResourceArc::new(ExExprRef::new(expr)),
         }
+    }
+
+    // Returns a clone of the Expr inside the ResourceArc container.
+    pub fn clone_inner(&self) -> Expr {
+        self.resource.0.clone()
     }
 }
 
@@ -79,6 +89,11 @@ impl ExLazyFrame {
             resource: ResourceArc::new(ExLazyFrameRef::new(df)),
         }
     }
+
+    // Returns a clone of the LazyFrame inside the ResourceArc container.
+    pub fn clone_inner(&self) -> LazyFrame {
+        self.resource.0.clone()
+    }
 }
 
 impl ExSeries {
@@ -86,6 +101,19 @@ impl ExSeries {
         Self {
             resource: ResourceArc::new(ExSeriesRef::new(s)),
         }
+    }
+
+    // Returns a clone of the Series inside the ResourceArc container.
+    pub fn clone_inner(&self) -> Series {
+        self.resource.0.clone()
+    }
+
+    pub fn name(&self) -> &str {
+        self.resource.0.name()
+    }
+
+    pub fn dtype(&self) -> &DataType {
+        self.resource.0.dtype()
     }
 }
 

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -393,28 +393,28 @@ pub fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Result<Term<'b>, Explor
 }
 
 pub fn list_from_series(data: ExSeries, env: Env) -> Result<Term, ExplorerError> {
-    let s = &data.resource.0;
+    let s = data.clone_inner();
 
     match s.dtype() {
         DataType::Boolean => series_to_list!(s, env, bool),
         DataType::Int64 => series_to_list!(s, env, i64),
-        DataType::Float64 => float64_series_to_list(s, env),
-        DataType::Date => date_series_to_list(s, env),
-        DataType::Datetime(time_unit, None) => datetime_series_to_list(s, *time_unit, env),
+        DataType::Float64 => float64_series_to_list(&s, env),
+        DataType::Date => date_series_to_list(&s, env),
+        DataType::Datetime(time_unit, None) => datetime_series_to_list(&s, *time_unit, env),
         DataType::Utf8 => {
             generic_binary_series_to_list(&data.resource, s.utf8()?.downcast_iter(), env)
         }
         DataType::Binary => {
             generic_binary_series_to_list(&data.resource, s.binary()?.downcast_iter(), env)
         }
-        DataType::Categorical(Some(mapping)) => categorical_series_to_list(s, env, mapping),
+        DataType::Categorical(Some(mapping)) => categorical_series_to_list(&s, env, mapping),
         dt => panic!("to_list/1 not implemented for {dt:?}"),
     }
 }
 
 #[allow(clippy::size_of_in_element_count)]
 pub fn iovec_from_series(data: ExSeries, env: Env) -> Result<Term, ExplorerError> {
-    let s = &data.resource.0;
+    let s = data.clone_inner();
     let resource = &data.resource;
 
     match s.dtype() {

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -6,7 +6,7 @@
 
 use chrono::{NaiveDate, NaiveDateTime};
 use polars::prelude::{col, when, DataFrame, IntoLazy, LiteralValue, SortOptions};
-use polars::prelude::{DataType, Expr, Literal, Series};
+use polars::prelude::{DataType, Expr, Literal};
 
 use crate::datatypes::{ExDate, ExDateTime};
 use crate::series::{cast_str_to_dtype, cast_str_to_f64, rolling_opts};
@@ -58,14 +58,14 @@ pub fn expr_datetime(datetime: ExDateTime) -> ExExpr {
 
 #[rustler::nif]
 pub fn expr_series(series: ExSeries) -> ExExpr {
-    let series: Series = series.resource.0.clone();
+    let series = series.clone_inner();
     let expr = series.lit();
     ExExpr::new(expr)
 }
 
 #[rustler::nif]
 pub fn expr_cast(data: ExExpr, to_dtype: &str) -> ExExpr {
-    let expr: Expr = data.resource.0.clone();
+    let expr = data.clone_inner();
     let to_dtype = cast_str_to_dtype(to_dtype).expect("dtype is not valid");
 
     ExExpr::new(expr.cast(to_dtype))
@@ -79,150 +79,150 @@ pub fn expr_column(name: &str) -> ExExpr {
 
 #[rustler::nif]
 pub fn expr_equal(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.eq(right_expr))
 }
 
 #[rustler::nif]
 pub fn expr_not_equal(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.neq(right_expr))
 }
 
 #[rustler::nif]
 pub fn expr_greater(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.gt(right_expr))
 }
 
 #[rustler::nif]
 pub fn expr_greater_equal(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.gt_eq(right_expr))
 }
 
 #[rustler::nif]
 pub fn expr_less(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.lt(right_expr))
 }
 
 #[rustler::nif]
 pub fn expr_less_equal(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.lt_eq(right_expr))
 }
 
 #[rustler::nif]
 pub fn expr_binary_and(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.and(right_expr))
 }
 
 #[rustler::nif]
 pub fn expr_binary_or(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.or(right_expr))
 }
 
 #[rustler::nif]
 pub fn expr_binary_in(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.is_in(right_expr))
 }
 
 #[rustler::nif]
 pub fn expr_is_nil(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.is_null())
 }
 
 #[rustler::nif]
 pub fn expr_is_not_nil(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.is_not_null())
 }
 
 #[rustler::nif]
 pub fn expr_is_finite(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.is_finite())
 }
 
 #[rustler::nif]
 pub fn expr_is_infinite(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.is_infinite())
 }
 
 #[rustler::nif]
 pub fn expr_is_nan(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.is_nan())
 }
 
 #[rustler::nif]
 pub fn expr_all_equal(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.eq(right_expr).all())
 }
 
 #[rustler::nif]
 pub fn expr_slice(expr: ExExpr, offset: i64, length: u32) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.slice(offset, length))
 }
 
 #[rustler::nif]
 pub fn expr_head(expr: ExExpr, length: usize) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.head(Some(length)))
 }
 
 #[rustler::nif]
 pub fn expr_tail(expr: ExExpr, length: usize) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.tail(Some(length)))
 }
 
 #[rustler::nif]
 pub fn expr_shift(expr: ExExpr, offset: i64, _default: Option<ExExpr>) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.shift(offset))
 }
 
 #[rustler::nif]
 pub fn expr_sample_n(expr: ExExpr, n: usize, with_replacement: bool, seed: Option<u64>) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.sample_n(n, with_replacement, true, seed))
 }
@@ -234,33 +234,32 @@ pub fn expr_sample_frac(
     with_replacement: bool,
     seed: Option<u64>,
 ) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.sample_frac(frac, with_replacement, true, seed))
 }
 
 #[rustler::nif]
 pub fn expr_peaks(data: ExExpr, min_or_max: &str) -> ExExpr {
-    let expr: Expr = data.resource.0.clone();
+    let expr = data.clone_inner();
     let type_expr = if min_or_max == "min" {
         expr.min()
     } else {
         expr.max()
     };
 
-    ExExpr::new(data.resource.0.clone().eq(type_expr))
+    ExExpr::new(data.clone_inner().eq(type_expr))
 }
 
 #[rustler::nif]
 pub fn expr_fill_missing_with_strategy(data: ExExpr, strategy: &str) -> ExExpr {
-    let orig_expr = &data.resource.0;
-    let expr: Expr = orig_expr.clone();
+    let expr = data.clone_inner();
     let result_expr = match strategy {
         "backward" => expr.backward_fill(None),
         "forward" => expr.forward_fill(None),
-        "min" => expr.fill_null(orig_expr.clone().min()),
-        "max" => expr.fill_null(orig_expr.clone().max()),
-        "mean" => expr.fill_null(orig_expr.clone().mean()),
+        "min" => expr.clone().fill_null(expr.min()),
+        "max" => expr.clone().fill_null(expr.max()),
+        "mean" => expr.clone().fill_null(expr.mean()),
         _other => panic!("unknown strategy {strategy:?}"),
     };
     ExExpr::new(result_expr)
@@ -268,39 +267,39 @@ pub fn expr_fill_missing_with_strategy(data: ExExpr, strategy: &str) -> ExExpr {
 
 #[rustler::nif]
 pub fn expr_fill_missing_with_value(data: ExExpr, value: ExExpr) -> ExExpr {
-    let expr: Expr = data.resource.0.clone();
-    let value: Expr = value.resource.0.clone();
+    let expr = data.clone_inner();
+    let value = value.clone_inner();
     ExExpr::new(expr.fill_null(value))
 }
 
 #[rustler::nif]
 pub fn expr_add(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr + right_expr)
 }
 
 #[rustler::nif]
 pub fn expr_subtract(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr - right_expr)
 }
 
 #[rustler::nif]
 pub fn expr_divide(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr / right_expr)
 }
 
 #[rustler::nif]
 pub fn expr_quotient(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     let quotient = left_expr
         / when(right_expr.clone().eq(0))
@@ -312,8 +311,8 @@ pub fn expr_quotient(left: ExExpr, right: ExExpr) -> ExExpr {
 
 #[rustler::nif]
 pub fn expr_remainder(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     let quotient = left_expr.clone()
         / when(right_expr.clone().eq(0))
@@ -328,86 +327,86 @@ pub fn expr_remainder(left: ExExpr, right: ExExpr) -> ExExpr {
 
 #[rustler::nif]
 pub fn expr_multiply(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr * right_expr)
 }
 
 #[rustler::nif]
 pub fn expr_pow(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.pow(right_expr))
 }
 
 #[rustler::nif]
 pub fn expr_sum(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.sum())
 }
 
 #[rustler::nif]
 pub fn expr_min(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.min())
 }
 
 #[rustler::nif]
 pub fn expr_max(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.max())
 }
 
 #[rustler::nif]
 pub fn expr_mean(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.mean())
 }
 
 #[rustler::nif]
 pub fn expr_median(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.median())
 }
 
 #[rustler::nif]
 pub fn expr_variance(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.var(1))
 }
 
 #[rustler::nif]
 pub fn expr_standard_deviation(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.std(1))
 }
 
 #[rustler::nif]
 pub fn expr_quantile(expr: ExExpr, quantile: f64) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     let strategy = crate::parse_quantile_interpol_options("nearest");
     ExExpr::new(expr.quantile(quantile.into(), strategy))
 }
 
 #[rustler::nif]
 pub fn expr_alias(expr: ExExpr, name: &str) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.alias(name))
 }
 
 #[rustler::nif]
 pub fn expr_count(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     // We need to add zero to work around a Polars bug
     // where casting a count returns the wrong result
@@ -416,45 +415,45 @@ pub fn expr_count(expr: ExExpr) -> ExExpr {
 
 #[rustler::nif]
 pub fn expr_nil_count(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.null_count().cast(DataType::Int64))
 }
 
 #[rustler::nif]
 pub fn expr_n_distinct(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.n_unique().cast(DataType::Int64))
 }
 
 #[rustler::nif]
 pub fn expr_first(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.first())
 }
 
 #[rustler::nif]
 pub fn expr_last(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.last())
 }
 
 #[rustler::nif]
 pub fn expr_concat(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     ExExpr::new(left_expr.append(right_expr, false))
 }
 
 #[rustler::nif]
 pub fn expr_coalesce(left: ExExpr, right: ExExpr) -> ExExpr {
-    let predicate: Expr = left.resource.0.clone().is_not_null();
-    let left_expr: Expr = left.resource.0.clone();
-    let right_expr: Expr = right.resource.0.clone();
+    let predicate = left.clone_inner().is_not_null();
+    let left_expr = left.clone_inner();
+    let right_expr = right.clone_inner();
 
     let condition = when(predicate).then(left_expr).otherwise(right_expr);
 
@@ -463,9 +462,9 @@ pub fn expr_coalesce(left: ExExpr, right: ExExpr) -> ExExpr {
 
 #[rustler::nif]
 pub fn expr_select(predicate: ExExpr, on_true: ExExpr, on_false: ExExpr) -> ExExpr {
-    let predicate_expr: Expr = predicate.resource.0.clone();
-    let on_true_expr: Expr = on_true.resource.0.clone();
-    let on_false_expr: Expr = on_false.resource.0.clone();
+    let predicate_expr = predicate.clone_inner();
+    let on_true_expr = on_true.clone_inner();
+    let on_false_expr = on_false.clone_inner();
 
     let condition = when(predicate_expr)
         .then(on_true_expr)
@@ -485,7 +484,7 @@ macro_rules! init_window_expr_fun {
             min_periods: Option<usize>,
             center: bool,
         ) -> ExExpr {
-            let expr: Expr = data.resource.0.clone();
+            let expr = data.clone_inner();
             let opts = rolling_opts(window_size, weights, min_periods, center);
             ExExpr::new(expr.$fun(opts))
         }
@@ -499,32 +498,32 @@ init_window_expr_fun!(expr_window_mean, rolling_mean);
 
 #[rustler::nif]
 pub fn expr_cumulative_min(data: ExExpr, reverse: bool) -> ExExpr {
-    let expr: Expr = data.resource.0.clone();
+    let expr = data.clone_inner();
     ExExpr::new(expr.cummin(reverse))
 }
 
 #[rustler::nif]
 pub fn expr_cumulative_max(data: ExExpr, reverse: bool) -> ExExpr {
-    let expr: Expr = data.resource.0.clone();
+    let expr = data.clone_inner();
     ExExpr::new(expr.cummax(reverse))
 }
 
 #[rustler::nif]
 pub fn expr_cumulative_sum(data: ExExpr, reverse: bool) -> ExExpr {
-    let expr: Expr = data.resource.0.clone();
+    let expr = data.clone_inner();
     ExExpr::new(expr.cumsum(reverse))
 }
 
 #[rustler::nif]
 pub fn expr_reverse(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.reverse())
 }
 
 #[rustler::nif]
 pub fn expr_sort(expr: ExExpr, descending: bool, nulls_last: bool) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     let opts = SortOptions {
         descending,
         nulls_last,
@@ -535,7 +534,7 @@ pub fn expr_sort(expr: ExExpr, descending: bool, nulls_last: bool) -> ExExpr {
 
 #[rustler::nif]
 pub fn expr_argsort(expr: ExExpr, descending: bool, nulls_last: bool) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     let opts = SortOptions {
         descending,
         nulls_last,
@@ -546,81 +545,81 @@ pub fn expr_argsort(expr: ExExpr, descending: bool, nulls_last: bool) -> ExExpr 
 
 #[rustler::nif]
 pub fn expr_distinct(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.unique_stable())
 }
 
 #[rustler::nif]
 pub fn expr_unordered_distinct(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
 
     ExExpr::new(expr.unique())
 }
 
 #[rustler::nif]
 pub fn expr_unary_not(expr: ExExpr) -> ExExpr {
-    let predicate: Expr = expr.resource.0.clone();
+    let predicate = expr.clone_inner();
     ExExpr::new(predicate.not())
 }
 
 #[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
-    let df: DataFrame = data.resource.0.clone();
-    let expressions: Expr = expr.resource.0.clone();
+    let df: DataFrame = data.clone_inner();
+    let expressions = expr.clone_inner();
     df.lazy().filter(expressions).describe_plan()
 }
 
 #[rustler::nif]
 pub fn expr_contains(expr: ExExpr, pattern: &str) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     ExExpr::new(expr.str().contains(pattern))
 }
 
 #[rustler::nif]
 pub fn expr_upcase(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     ExExpr::new(expr.str().to_uppercase())
 }
 
 #[rustler::nif]
 pub fn expr_downcase(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     ExExpr::new(expr.str().to_lowercase())
 }
 
 #[rustler::nif]
 pub fn expr_trim(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     ExExpr::new(expr.str().strip(None))
 }
 
 #[rustler::nif]
 pub fn expr_trim_leading(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     ExExpr::new(expr.str().lstrip(None))
 }
 
 #[rustler::nif]
 pub fn expr_trim_trailing(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     ExExpr::new(expr.str().rstrip(None))
 }
 
 #[rustler::nif]
 pub fn expr_round(expr: ExExpr, decimals: u32) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     ExExpr::new(expr.round(decimals))
 }
 
 #[rustler::nif]
 pub fn expr_floor(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     ExExpr::new(expr.floor())
 }
 
 #[rustler::nif]
 pub fn expr_ceil(expr: ExExpr) -> ExExpr {
-    let expr: Expr = expr.resource.0.clone();
+    let expr = expr.clone_inner();
     ExExpr::new(expr.ceil())
 }

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -7,19 +7,19 @@ pub mod io;
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn lf_collect(data: ExLazyFrame) -> Result<ExDataFrame, ExplorerError> {
-    let df = data.resource.0.clone().collect()?;
+    let df = data.clone_inner().collect()?;
 
     Ok(ExDataFrame::new(df))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn lf_fetch(data: ExLazyFrame, n_rows: usize) -> Result<ExDataFrame, ExplorerError> {
-    Ok(ExDataFrame::new(data.resource.0.clone().fetch(n_rows)?))
+    Ok(ExDataFrame::new(data.clone_inner().fetch(n_rows)?))
 }
 
 #[rustler::nif]
 pub fn lf_describe_plan(data: ExLazyFrame, optimized: bool) -> Result<String, ExplorerError> {
-    let lf = &data.resource.0;
+    let lf = data.clone_inner();
     let plan = match optimized {
         true => lf.describe_optimized_plan()?,
         false => lf.describe_plan(),
@@ -29,25 +29,25 @@ pub fn lf_describe_plan(data: ExLazyFrame, optimized: bool) -> Result<String, Ex
 
 #[rustler::nif]
 pub fn lf_head(data: ExLazyFrame, length: u32) -> Result<ExLazyFrame, ExplorerError> {
-    let lf = &data.resource.0;
-    Ok(ExLazyFrame::new(lf.clone().limit(length)))
+    let lf = data.clone_inner();
+    Ok(ExLazyFrame::new(lf.limit(length)))
 }
 
 #[rustler::nif]
 pub fn lf_tail(data: ExLazyFrame, length: u32) -> Result<ExLazyFrame, ExplorerError> {
-    let lf = &data.resource.0;
-    Ok(ExLazyFrame::new(lf.clone().tail(length)))
+    let lf = data.clone_inner();
+    Ok(ExLazyFrame::new(lf.tail(length)))
 }
 
 #[rustler::nif]
 pub fn lf_names(data: ExLazyFrame) -> Result<Vec<String>, ExplorerError> {
-    let lf = &data.resource.0;
+    let lf = data.clone_inner();
     Ok(lf.schema()?.iter_names().cloned().collect())
 }
 
 #[rustler::nif]
 pub fn lf_dtypes(data: ExLazyFrame) -> Result<Vec<String>, ExplorerError> {
-    let lf = &data.resource.0;
+    let lf = data.clone_inner();
     Ok(lf
         .schema()?
         .iter_dtypes()
@@ -57,18 +57,18 @@ pub fn lf_dtypes(data: ExLazyFrame) -> Result<Vec<String>, ExplorerError> {
 
 #[rustler::nif]
 pub fn lf_select(data: ExLazyFrame, columns: Vec<&str>) -> Result<ExLazyFrame, ExplorerError> {
-    let lf = &data.resource.0.clone().select(&[cols(columns)]);
-    Ok(ExLazyFrame::new(lf.clone()))
+    let lf = data.clone_inner().select(&[cols(columns)]);
+    Ok(ExLazyFrame::new(lf))
 }
 
 #[rustler::nif]
 pub fn lf_drop(data: ExLazyFrame, columns: Vec<&str>) -> Result<ExLazyFrame, ExplorerError> {
-    let lf = &data.resource.0.clone().select(&[col("*").exclude(columns)]);
-    Ok(ExLazyFrame::new(lf.clone()))
+    let lf = data.clone_inner().select(&[col("*").exclude(columns)]);
+    Ok(ExLazyFrame::new(lf))
 }
 
 #[rustler::nif]
 pub fn lf_slice(data: ExLazyFrame, offset: i64, length: u32) -> Result<ExLazyFrame, ExplorerError> {
-    let lf = data.resource.0.clone();
+    let lf = data.clone_inner();
     Ok(ExLazyFrame::new(lf.slice(offset, length)))
 }

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -228,7 +228,6 @@ rustler::init!(
         s_add,
         s_and,
         s_argsort,
-        s_as_str,
         s_cast,
         s_categories,
         s_categorise,


### PR DESCRIPTION
The idea is to simplify cloning the inner datatypes, since this is quite frequent in our codebase.

Internally Polars uses Arc to represent the Series (DF is a Vec<Series>), so cloning is normally a cheap operation.