### PR TITLE
Add boolean type to `Series.in/2`

### DIFF
--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -364,6 +364,7 @@ pub fn s_in(data: ExSeries, rhs: ExSeries) -> Result<ExSeries, ExplorerError> {
     let rhs = rhs.clone_inner();
 
     let s = match s.dtype() {
+        DataType::Boolean => s.bool()?.is_in(&rhs)?,
         DataType::Int64 => s.i64()?.is_in(&rhs)?,
         DataType::Float64 => s.f64()?.is_in(&rhs)?,
         DataType::Utf8 => s.utf8()?.is_in(&rhs)?,


### PR DESCRIPTION
This PR fixes the inability to compare two series with boolean type for `Series.in/2`.

Addition to: https://github.com/elixir-nx/explorer/pull/420

Comparing two series of boolean types like so:
```elixir
left = Explorer.Series.from_list([true, false])
right = Explorer.Series.from_list([false, false, false, true])
Explorer.Series.in(left, right)
```

Resulted in:
```elixir
** (ErlangError) Erlang error: :nif_panicked
    (explorer 0.5.0) Explorer.PolarsBackend.Native.s_in(#Inspect.Error<
  got FunctionClauseError with message:

      """
      no function clause matching in Explorer.PolarsBackend.Shared.apply_series/3
      """

  while inspecting:

      %{
        __struct__: Explorer.PolarsBackend.Series,
        resource: #Reference<0.82471402.537788432.41151>
      }

```

Whereas now it correctly results in:
```elixir
#Explorer.Series<
  Polars[2]
  boolean [true, true]
>
```

Please let me know if I should add some extra tests (I'm not sure if it'll be unnecessary noise and to where exactly).

Thanks!