### PR TITLE
Add `filter_with/2` for Polars LazyFrame backend

### DIFF
--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -206,13 +206,11 @@ defmodule Explorer.PolarsBackend.LazyFrame do
 
   @impl true
   def filter_with(
-        %DF{} = df,
-        %DF{groups: [_ | _]} = out_df,
-        %LazySeries{aggregation: true} = lseries
+        %DF{},
+        %DF{groups: [_ | _]},
+        %LazySeries{aggregation: true}
       ) do
-    aggregation = Explorer.PolarsBackend.Expression.to_expr(lseries)
-
-    Shared.apply_dataframe(df, out_df, :lf_filter_with_aggregation, [aggregation, out_df.groups])
+    raise "filter_with/2 with groups and aggregations is not supported yet for lazy frames"
   end
 
   @impl true

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -169,7 +169,6 @@ defmodule Explorer.PolarsBackend.Native do
       do: err()
 
   def lf_filter_with(_df, _expression), do: err()
-  def lf_filter_with_aggregation(_df, _agg, _groups), do: err()
 
   # Series
   def s_add(_s, _other), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -168,6 +168,9 @@ defmodule Explorer.PolarsBackend.Native do
       ),
       do: err()
 
+  def lf_filter_with(_df, _expression), do: err()
+  def lf_filter_with_aggregation(_df, _agg, _groups), do: err()
+
   # Series
   def s_add(_s, _other), do: err()
   def s_and(_s, _s2), do: err()

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -4,6 +4,7 @@ use polars_ops::pivot::{pivot_stable, PivotAgg};
 use std::result::Result;
 
 use crate::{ExDataFrame, ExExpr, ExLazyFrame, ExSeries, ExplorerError};
+use crate::ex_expr_to_exprs;
 
 // Loads the IO functions for read/writing CSV, NDJSON, Parquet, etc.
 pub mod io;
@@ -26,13 +27,6 @@ pub fn normalize_numeric_dtypes(df: &mut DataFrame) -> Result<DataFrame, crate::
     }
 
     Ok(df.clone())
-}
-
-fn ex_expr_to_exprs(ex_exprs: Vec<ExExpr>) -> Vec<Expr> {
-    ex_exprs
-        .iter()
-        .map(|ex_expr| ex_expr.clone_inner())
-        .collect()
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -3,8 +3,8 @@ use polars_ops::pivot::{pivot_stable, PivotAgg};
 
 use std::result::Result;
 
-use crate::{ExDataFrame, ExExpr, ExLazyFrame, ExSeries, ExplorerError};
 use crate::ex_expr_to_exprs;
+use crate::{ExDataFrame, ExExpr, ExLazyFrame, ExSeries, ExplorerError};
 
 // Loads the IO functions for read/writing CSV, NDJSON, Parquet, etc.
 pub mod io;

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -12,6 +12,14 @@ use crate::datatypes::{ExDate, ExDateTime};
 use crate::series::{cast_str_to_dtype, cast_str_to_f64, rolling_opts};
 use crate::{ExDataFrame, ExExpr, ExSeries};
 
+// Useful to get an ExExpr vec into a vec of expressions.
+pub fn ex_expr_to_exprs(ex_exprs: Vec<ExExpr>) -> Vec<Expr> {
+    ex_exprs
+        .iter()
+        .map(|ex_expr| ex_expr.clone_inner())
+        .collect()
+}
+
 #[rustler::nif]
 pub fn expr_integer(number: i64) -> ExExpr {
     let expr = number.lit();

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -73,7 +73,7 @@ pub fn lf_slice(data: ExLazyFrame, offset: i64, length: u32) -> Result<ExLazyFra
     Ok(ExLazyFrame::new(lf.slice(offset, length)))
 }
 
-#[rustler::nif(schedule = "DirtyCpu")]
+#[rustler::nif]
 pub fn lf_filter_with(data: ExLazyFrame, ex_expr: ExExpr) -> Result<ExLazyFrame, ExplorerError> {
     let ldf = data.clone_inner();
     let expr = ex_expr.clone_inner();
@@ -81,7 +81,7 @@ pub fn lf_filter_with(data: ExLazyFrame, ex_expr: ExExpr) -> Result<ExLazyFrame,
     Ok(ExLazyFrame::new(ldf.filter(expr)))
 }
 
-#[rustler::nif(schedule = "DirtyCpu")]
+#[rustler::nif]
 pub fn lf_filter_with_aggregation(
     data: ExLazyFrame,
     ex_expr: ExExpr,

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -80,27 +80,3 @@ pub fn lf_filter_with(data: ExLazyFrame, ex_expr: ExExpr) -> Result<ExLazyFrame,
 
     Ok(ExLazyFrame::new(ldf.filter(expr)))
 }
-
-#[rustler::nif]
-pub fn lf_filter_with_aggregation(
-    data: ExLazyFrame,
-    ex_expr: ExExpr,
-    groups: Vec<&str>,
-) -> Result<ExLazyFrame, ExplorerError> {
-    let ldf = data.clone_inner();
-    let aggs: Vec<Expr> = ldf
-        .schema()?
-        .iter_names()
-        .filter(|name| !groups.contains(&name.as_str()))
-        .map(|name| col(name).filter(ex_expr.clone_inner()).list().keep_name())
-        .collect();
-
-    let expr_groups: Vec<Expr> = groups.iter().map(|group| col(group)).collect();
-
-    let new_ldf = ldf
-        .groupby_stable(&expr_groups)
-        .agg(aggs)
-        .explode([col("*").exclude(&groups)]);
-
-    Ok(ExLazyFrame::new(new_ldf))
-}

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -1,4 +1,4 @@
-use crate::{ExDataFrame, ExLazyFrame, ExplorerError};
+use crate::{ExDataFrame, ExExpr, ExLazyFrame, ExplorerError};
 use polars::prelude::*;
 use std::result::Result;
 
@@ -71,4 +71,36 @@ pub fn lf_drop(data: ExLazyFrame, columns: Vec<&str>) -> Result<ExLazyFrame, Exp
 pub fn lf_slice(data: ExLazyFrame, offset: i64, length: u32) -> Result<ExLazyFrame, ExplorerError> {
     let lf = data.clone_inner();
     Ok(ExLazyFrame::new(lf.slice(offset, length)))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn lf_filter_with(data: ExLazyFrame, ex_expr: ExExpr) -> Result<ExLazyFrame, ExplorerError> {
+    let ldf = data.clone_inner();
+    let expr = ex_expr.clone_inner();
+
+    Ok(ExLazyFrame::new(ldf.filter(expr)))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn lf_filter_with_aggregation(
+    data: ExLazyFrame,
+    ex_expr: ExExpr,
+    groups: Vec<&str>,
+) -> Result<ExLazyFrame, ExplorerError> {
+    let ldf = data.clone_inner();
+    let aggs: Vec<Expr> = ldf
+        .schema()?
+        .iter_names()
+        .filter(|name| !groups.contains(&name.as_str()))
+        .map(|name| col(name).filter(ex_expr.clone_inner()).list().keep_name())
+        .collect();
+
+    let expr_groups: Vec<Expr> = groups.iter().map(|group| col(group)).collect();
+
+    let new_ldf = ldf
+        .groupby_stable(&expr_groups)
+        .agg(aggs)
+        .explode([col("*").exclude(&groups)]);
+
+    Ok(ExLazyFrame::new(new_ldf))
 }

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -225,7 +225,6 @@ rustler::init!(
         lf_from_parquet,
         lf_from_ndjson,
         lf_filter_with,
-        lf_filter_with_aggregation,
         // series
         s_add,
         s_and,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -224,6 +224,8 @@ rustler::init!(
         lf_from_ipc,
         lf_from_parquet,
         lf_from_ndjson,
+        lf_filter_with,
+        lf_filter_with_aggregation,
         // series
         s_add,
         s_and,

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -277,4 +277,71 @@ defmodule Explorer.DataFrame.LazyTest do
 
     assert DF.to_columns(df1) == DF.to_columns(df)
   end
+
+  describe "filter_with/2" do
+    test "filters by a simple selector" do
+      ldf = DF.new([a: [1, 2, 3, 4], b: [150, 50, 250, 0]], lazy: true)
+
+      ldf1 = DF.filter_with(ldf, fn ldf -> Series.greater(ldf["a"], 2) end)
+      df1 = DF.collect(ldf1)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [3, 4],
+               b: [250, 0]
+             }
+    end
+
+    test "filters with a group and without aggregation" do
+      ldf =
+        DF.new([col1: ["a", "b", "a", "b"], col2: [1, 2, 3, 4], col3: ["z", "y", "w", "k"]],
+          lazy: true
+        )
+
+      ldf_grouped = DF.group_by(ldf, "col1")
+
+      ldf1 =
+        DF.filter_with(ldf_grouped, fn ldf ->
+          Series.greater(ldf["col2"], 2)
+        end)
+
+      df1 = DF.collect(ldf1)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               col1: ["a", "b"],
+               col2: [3, 4],
+               col3: ["w", "k"]
+             }
+
+      assert DF.groups(df1) == ["col1"]
+    end
+
+    test "filters with a group and with aggregation" do
+      ldf =
+        DF.new(
+          [
+            col1: ["a", "b", "a", "b", "a", "b"],
+            col2: [1, 2, 3, 4, 5, 6],
+            col3: ["z", "y", "w", "k", "d", "j"]
+          ],
+          lazy: true
+        )
+
+      ldf_grouped = DF.group_by(ldf, "col1")
+
+      ldf1 =
+        DF.filter_with(ldf_grouped, fn ldf ->
+          Series.greater(ldf["col2"], Series.mean(ldf["col2"]))
+        end)
+
+      df1 = DF.collect(ldf1)
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               col1: ["a", "b"],
+               col2: [5, 6],
+               col3: ["d", "j"]
+             }
+
+      assert DF.groups(df1) == ["col1"]
+    end
+  end
 end

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -328,20 +328,13 @@ defmodule Explorer.DataFrame.LazyTest do
 
       ldf_grouped = DF.group_by(ldf, "col1")
 
-      ldf1 =
-        DF.filter_with(ldf_grouped, fn ldf ->
-          Series.greater(ldf["col2"], Series.mean(ldf["col2"]))
-        end)
-
-      df1 = DF.collect(ldf1)
-
-      assert DF.to_columns(df1, atom_keys: true) == %{
-               col1: ["a", "b"],
-               col2: [5, 6],
-               col3: ["d", "j"]
-             }
-
-      assert DF.groups(df1) == ["col1"]
+      assert_raise RuntimeError,
+                   "filter_with/2 with groups and aggregations is not supported yet for lazy frames",
+                   fn ->
+                     DF.filter_with(ldf_grouped, fn ldf ->
+                       Series.greater(ldf["col2"], Series.mean(ldf["col2"]))
+                     end)
+                   end
     end
   end
 end


### PR DESCRIPTION
This function has two versions:

* one that works for ungrouped lazy frames and grouped, but without aggregations.
* another one that aims grouped lazy frames with aggregations in the filter expression.

The second one is more complex, so I opt to add it to a separated function.