### PR TITLE
Add binary dtype to Series.in/2

### DIFF
--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -368,6 +368,7 @@ pub fn s_in(data: ExSeries, rhs: ExSeries) -> Result<ExSeries, ExplorerError> {
         DataType::Int64 => s.i64()?.is_in(&rhs)?,
         DataType::Float64 => s.f64()?.is_in(&rhs)?,
         DataType::Utf8 => s.utf8()?.is_in(&rhs)?,
+        DataType::Binary => s.binary()?.is_in(&rhs)?,
         DataType::Date => s.date()?.is_in(&rhs)?,
         DataType::Datetime(_, _) => s.datetime()?.is_in(&rhs)?,
         dt => panic!("is_in/2 not implemented for {dt:?}"),

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -293,6 +293,122 @@ defmodule Explorer.SeriesTest do
     end
   end
 
+  describe "in/2" do
+    test "with integer series" do
+      s1 = Series.from_list([1, 2, 3])
+      s2 = Series.from_list([1, 0, 3])
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "with float series" do
+      s1 = Series.from_list([1.0, 2.0, 3.0])
+      s2 = Series.from_list([1.0, 0.0, 3.0])
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "with binary series" do
+      s1 = Series.from_list([<<239, 191, 19>>, <<2>>, <<3>>], dtype: :binary)
+      s2 = Series.from_list([<<239, 191, 19>>, <<0>>, <<3>>], dtype: :binary)
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "with string series" do
+      s1 = Series.from_list(["1", "2", "3"])
+      s2 = Series.from_list(["1", "0", "3"])
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "with date series" do
+      s1 = Series.from_list([~D[2023-01-17], ~D[2023-01-18], ~D[2023-01-09]])
+      s2 = Series.from_list([~D[2023-01-17], ~D[2023-01-04], ~D[2023-01-09]])
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "with datetime series" do
+      s1 =
+        Series.from_list([
+          ~N[2023-01-17 20:00:56.576456Z],
+          ~N[2023-01-18 20:30:56.576456Z],
+          ~N[2023-01-09 21:00:56.576456Z]
+        ])
+
+      s2 =
+        Series.from_list([
+          ~N[2023-01-17 20:00:56.576456Z],
+          ~N[2023-01-04 22:00:56.576456Z],
+          ~N[2023-01-09 21:00:56.576456Z]
+        ])
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "with a list on the right-hand side" do
+      s1 = Series.from_list([1, 2, 3])
+      l1 = [1, 0, 3]
+
+      assert s1 |> Series.in(l1) |> Series.to_list() == [true, false, true]
+    end
+
+    test "with a smaller series on the right-hand side" do
+      s1 = Series.from_list([1, 2, 3])
+      s2 = Series.from_list([1, 3])
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "with a bigger series on the right-hand side" do
+      s1 = Series.from_list([1, 2, 3])
+      s2 = Series.from_list([1, 3, 5, 10])
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "compare integer series with a float series" do
+      s1 = Series.from_list([1, 2, 3])
+      s2 = Series.from_list([1.0, 0.5, 3.0])
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "compare integer series with a string series" do
+      s1 = Series.from_list([1, 2, 3])
+      s2 = Series.from_list(["1", "0", "3"])
+
+      assert_raise ArgumentError, fn ->
+        Series.in(s1, s2)
+      end
+    end
+
+    test "compare string series with a binary series" do
+      s1 = Series.from_list(["1", "2", "3"])
+      s2 = Series.from_list([<<1>>, <<0>>, <<"3">>], dtype: :binary)
+
+      assert_raise ArgumentError, fn ->
+        Series.in(s1, s2)
+      end
+    end
+
+    test "compare date series with a datetime series" do
+      s1 = Series.from_list([~D[2023-01-17], ~D[2023-01-18], ~D[2023-01-09]])
+
+      s2 =
+        Series.from_list([
+          ~N[2023-01-17 20:00:56.576456Z],
+          ~N[2023-01-04 22:00:56.576456Z],
+          ~N[2023-01-09 21:00:56.576456Z]
+        ])
+
+      assert_raise ArgumentError, fn ->
+        Series.in(s1, s2)
+      end
+    end
+  end
+
   describe "iotype/1" do
     test "integer series" do
       s = Series.from_list([1, 2, 3])


### PR DESCRIPTION
This PR allows the Series.in/2 function to receive series with binary dtype.

Addition to: https://github.com/elixir-nx/explorer/pull/420 and https://github.com/elixir-nx/explorer/pull/475

Before this PR, if you try to compare two binary series using the Series.in/2 function, an error will be returned:
```elixir
iex(1)> s1 = Explorer.Series.from_list([<<239, 191, 19>>, <<2>>, <<3>>], dtype: :binary)
#Explorer.Series<
  Polars[3]
  binary [<<239, 191, 19>>, <<2>>, <<3>>]
>

iex(2)> s2 = Explorer.Series.from_list([<<239, 191, 19>>, <<0>>, <<3>>], dtype: :binary)
#Explorer.Series<
  Polars[3]
  binary [<<239, 191, 19>>, <<0>>, <<3>>]
>

iex(3)> Explorer.Series.in(s1, s2)
** (ErlangError) Erlang error: :nif_panicked
    (explorer 0.6.0-dev) Explorer.PolarsBackend.Native.s_in(%Inspect.Error{message: "got FunctionClauseError with message \"no function clause matching in Explorer.PolarsBackend.Shared.apply_series/3\" while inspecting %{__struct__: Explorer.PolarsBackend.Series, resource: #Reference<0.3313078941.1795293224.105471>}"}, %Inspect.Error{message: "got FunctionClauseError with message \"no function clause matching in Explorer.PolarsBackend.Shared.apply_series/3\" while inspecting %{__struct__: Explorer.PolarsBackend.Series, resource: #Reference<0.3313078941.1795293224.105473>}"})
    (explorer 0.6.0-dev) lib/explorer/polars_backend/shared.ex:23: Explorer.PolarsBackend.Shared.apply_series/3
```

After this PR the result is:

```elixir
iex(3)> Explorer.Series.in(s1, s2)                                                      
#Explorer.Series<
  Polars[3]
  boolean [true, false, true]
>
```
