### PR TITLE
Add Series.in/2 tests for boolean series

### DIFF
--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -294,6 +294,13 @@ defmodule Explorer.SeriesTest do
   end
 
   describe "in/2" do
+    test "with boolean series" do
+      s1 = Series.from_list([true, false, true])
+      s2 = Series.from_list([false, false, false, false])
+
+      assert s1 |> Series.in(s2) |> Series.to_list() == [false, true, false]
+    end
+
     test "with integer series" do
       s1 = Series.from_list([1, 2, 3])
       s2 = Series.from_list([1, 0, 3])
@@ -366,6 +373,15 @@ defmodule Explorer.SeriesTest do
       s2 = Series.from_list([1, 3, 5, 10])
 
       assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+    end
+
+    test "compare boolean series with an integer series" do
+      s1 = Series.from_list([true, false, true])
+      s2 = Series.from_list([0, 1])
+
+      assert_raise ArgumentError, fn ->
+        Series.in(s1, s2)
+      end
     end
 
     test "compare integer series with a float series" do


### PR DESCRIPTION
This adds boolean series tests for `Series.in/2` and rounds out https://github.com/elixir-nx/explorer/pull/475.

Addition to the tests (https://github.com/elixir-nx/explorer/pull/477/commits/7936681622cfb7d792f696749d84c3167d0f4b4d) written in https://github.com/elixir-nx/explorer/pull/477.

Original PR: https://github.com/elixir-nx/explorer/pull/420

Thanks y'all! :purple_heart: 