### PR TITLE
Add LazyFrame implementation for `arrange_with/2`, `distinct/3`, `mutate_with/2` and `summarise_with/2`

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -138,7 +138,7 @@ defmodule Explorer.Backend.DataFrame do
   @callback filter_with(df, out_df :: df(), lazy_series()) :: df
   @callback mutate_with(df, out_df :: df(), mutations :: [{column_name(), lazy_series()}]) :: df
   @callback arrange_with(df, out_df :: df(), directions :: [{:asc | :desc, lazy_series()}]) :: df
-  @callback distinct(df, out_df :: df(), columns :: [column_name()], keep_all :: boolean()) :: df
+  @callback distinct(df, out_df :: df(), columns :: [column_name()]) :: df
   @callback rename(df, out_df :: df(), [{old :: column_name(), new :: column_name()}]) :: df
   @callback dummies(df, out_df :: df(), columns :: [column_name()]) :: df
   @callback sample(df, n_or_frac :: number(), replacement :: boolean(), seed :: integer()) :: df

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2705,7 +2705,7 @@ defmodule Explorer.DataFrame do
           %{df | names: keep, dtypes: Map.take(df.dtypes, keep)}
         end
 
-      Shared.apply_impl(df, :distinct, [out_df, columns, opts[:keep_all]])
+      Shared.apply_impl(df, :distinct, [out_df, columns])
     else
       df
     end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -416,11 +416,10 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def distinct(%DataFrame{} = df, %DataFrame{} = out_df, columns, keep_all) do
-    # This is an Option in the Nif side.
-    columns_to_keep = unless keep_all, do: out_df.names
+  def distinct(%DataFrame{} = df, %DataFrame{} = out_df, columns) do
+    maybe_columns_to_keep = if df.names != out_df.names, do: out_df.names
 
-    Shared.apply_dataframe(df, out_df, :df_distinct, [true, columns, columns_to_keep])
+    Shared.apply_dataframe(df, out_df, :df_distinct, [columns, maybe_columns_to_keep])
   end
 
   @impl true

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -262,6 +262,19 @@ defmodule Explorer.PolarsBackend.LazyFrame do
 
   # Groups
 
+  @impl true
+  def summarise_with(%DF{groups: groups} = df, %DF{} = out_df, column_pairs) do
+    exprs =
+      for {name, lazy_series} <- column_pairs do
+        original_expr = to_expr(lazy_series)
+        alias_expr(original_expr, name)
+      end
+
+    groups_exprs = for group <- groups, do: Native.expr_column(group)
+
+    Shared.apply_dataframe(df, out_df, :lf_summarise_with, [groups_exprs, exprs])
+  end
+
   # TODO: Make the functions of non-implemented functions
   # explicit once the lazy interface is ready.
   funs =

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -43,10 +43,10 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   # Single table verbs
 
   @impl true
-  def head(ldf, rows), do: Shared.apply_dataframe(ldf, :lf_head, [rows])
+  def head(ldf, rows), do: Shared.apply_dataframe(ldf, ldf, :lf_head, [rows])
 
   @impl true
-  def tail(ldf, rows), do: Shared.apply_dataframe(ldf, :lf_tail, [rows])
+  def tail(ldf, rows), do: Shared.apply_dataframe(ldf, ldf, :lf_tail, [rows])
 
   @impl true
   def select(ldf, out_ldf), do: Shared.apply_dataframe(ldf, out_ldf, :lf_select, [out_ldf.names])
@@ -236,6 +236,14 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   @impl true
   def arrange_with(_df, _out_df, _directions) do
     raise "arrange_with/2 with groups is not supported yet for lazy frames"
+  end
+
+  @impl true
+  def distinct(%DF{} = df, %DF{} = out_df, columns) do
+    maybe_columns_to_keep =
+      if df.names != out_df.names, do: Enum.map(out_df.names, &Native.expr_column/1)
+
+    Shared.apply_dataframe(df, out_df, :lf_distinct, [columns, maybe_columns_to_keep])
   end
 
   # Groups

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -220,6 +220,24 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     Shared.apply_dataframe(df, out_df, :lf_filter_with, [expression])
   end
 
+  @impl true
+  def arrange_with(%DF{groups: []} = df, out_df, column_pairs) do
+    {directions, expressions} =
+      column_pairs
+      |> Enum.map(fn {direction, lazy_series} ->
+        expr = Explorer.PolarsBackend.Expression.to_expr(lazy_series)
+        {direction == :desc, expr}
+      end)
+      |> Enum.unzip()
+
+    Shared.apply_dataframe(df, out_df, :lf_arrange_with, [expressions, directions])
+  end
+
+  @impl true
+  def arrange_with(_df, _out_df, _directions) do
+    raise "arrange_with/2 with groups is not supported yet for lazy frames"
+  end
+
   # Groups
 
   # TODO: Make the functions of non-implemented functions

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -169,6 +169,7 @@ defmodule Explorer.PolarsBackend.Native do
       do: err()
 
   def lf_filter_with(_df, _expression), do: err()
+  def lf_arrange_with(_df, _expressions, _directions), do: err()
 
   # Series
   def s_add(_s, _other), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -172,6 +172,7 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_arrange_with(_df, _expressions, _directions), do: err()
   def lf_distinct(_df, _subset, _selection), do: err()
   def lf_mutate_with(_df, _exprs), do: err()
+  def lf_summarise_with(_df, _groups, _aggs), do: err()
 
   # Series
   def s_add(_s, _other), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -171,6 +171,7 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_filter_with(_df, _expression), do: err()
   def lf_arrange_with(_df, _expressions, _directions), do: err()
   def lf_distinct(_df, _subset, _selection), do: err()
+  def lf_mutate_with(_df, _exprs), do: err()
 
   # Series
   def s_add(_s, _other), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -29,7 +29,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_arrange_with(_df, _expressions, _directions, _groups), do: err()
   def df_concat_columns(_df, _others), do: err()
   def df_concat_rows(_df, _others), do: err()
-  def df_distinct(_df, _maintain_order, _subset, _selection), do: err()
+  def df_distinct(_df, _subset, _selection), do: err()
   def df_drop(_df, _name), do: err()
   def df_drop_nulls(_df, _subset), do: err()
   def df_dtypes(_df), do: err()
@@ -170,6 +170,7 @@ defmodule Explorer.PolarsBackend.Native do
 
   def lf_filter_with(_df, _expression), do: err()
   def lf_arrange_with(_df, _expressions, _directions), do: err()
+  def lf_distinct(_df, _subset, _selection), do: err()
 
   # Series
   def s_add(_s, _other), do: err()

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -389,15 +389,11 @@ pub fn df_pivot_longer(
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_distinct(
     data: ExDataFrame,
-    maintain_order: bool,
     subset: Vec<String>,
     columns_to_keep: Option<Vec<&str>>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let df = data.clone_inner();
-    let new_df = match maintain_order {
-        false => df.unique(Some(&subset), UniqueKeepStrategy::First)?,
-        true => df.unique_stable(Some(&subset), UniqueKeepStrategy::First)?,
-    };
+    let new_df = df.unique_stable(Some(&subset), UniqueKeepStrategy::First)?;
 
     match columns_to_keep {
         Some(columns) => Ok(ExDataFrame::new(new_df.select(columns)?)),

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -107,3 +107,14 @@ pub fn lf_distinct(
         None => Ok(ExLazyFrame::new(new_df)),
     }
 }
+
+#[rustler::nif]
+pub fn lf_mutate_with(
+    data: ExLazyFrame,
+    columns: Vec<ExExpr>,
+) -> Result<ExLazyFrame, ExplorerError> {
+    let ldf = data.clone_inner();
+    let mutations = ex_expr_to_exprs(columns);
+
+    Ok(ExLazyFrame::new(ldf.with_columns(mutations)))
+}

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -92,3 +92,18 @@ pub fn lf_arrange_with(
 
     Ok(ExLazyFrame::new(ldf))
 }
+
+#[rustler::nif]
+pub fn lf_distinct(
+    data: ExLazyFrame,
+    subset: Vec<String>,
+    columns_to_keep: Option<Vec<ExExpr>>,
+) -> Result<ExLazyFrame, ExplorerError> {
+    let df = data.clone_inner();
+    let new_df = df.unique_stable(Some(subset), UniqueKeepStrategy::First);
+
+    match columns_to_keep {
+        Some(columns) => Ok(ExLazyFrame::new(new_df.select(ex_expr_to_exprs(columns)))),
+        None => Ok(ExLazyFrame::new(new_df)),
+    }
+}

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -1,4 +1,4 @@
-use crate::{ExDataFrame, ExExpr, ExLazyFrame, ExplorerError};
+use crate::{expressions::ex_expr_to_exprs, ExDataFrame, ExExpr, ExLazyFrame, ExplorerError};
 use polars::prelude::*;
 use std::result::Result;
 
@@ -79,4 +79,16 @@ pub fn lf_filter_with(data: ExLazyFrame, ex_expr: ExExpr) -> Result<ExLazyFrame,
     let expr = ex_expr.clone_inner();
 
     Ok(ExLazyFrame::new(ldf.filter(expr)))
+}
+
+#[rustler::nif]
+pub fn lf_arrange_with(
+    data: ExLazyFrame,
+    expressions: Vec<ExExpr>,
+    directions: Vec<bool>,
+) -> Result<ExLazyFrame, ExplorerError> {
+    let exprs = ex_expr_to_exprs(expressions);
+    let ldf = data.clone_inner().sort_by_exprs(exprs, directions, false);
+
+    Ok(ExLazyFrame::new(ldf))
 }

--- a/native/explorer/src/lazyframe.rs
+++ b/native/explorer/src/lazyframe.rs
@@ -118,3 +118,17 @@ pub fn lf_mutate_with(
 
     Ok(ExLazyFrame::new(ldf.with_columns(mutations)))
 }
+
+#[rustler::nif]
+pub fn lf_summarise_with(
+    data: ExLazyFrame,
+    groups: Vec<ExExpr>,
+    aggs: Vec<ExExpr>,
+) -> Result<ExLazyFrame, ExplorerError> {
+    let ldf = data.clone_inner();
+    let groups = ex_expr_to_exprs(groups);
+    let aggs = ex_expr_to_exprs(aggs);
+
+    let new_df = ldf.groupby_stable(groups).agg(aggs);
+    Ok(ExLazyFrame::new(new_df))
+}

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -227,6 +227,7 @@ rustler::init!(
         lf_filter_with,
         lf_arrange_with,
         lf_distinct,
+        lf_mutate_with,
         // series
         s_add,
         s_and,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -225,6 +225,7 @@ rustler::init!(
         lf_from_parquet,
         lf_from_ndjson,
         lf_filter_with,
+        lf_arrange_with,
         // series
         s_add,
         s_and,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -226,6 +226,7 @@ rustler::init!(
         lf_from_ndjson,
         lf_filter_with,
         lf_arrange_with,
+        lf_distinct,
         // series
         s_add,
         s_and,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -228,6 +228,7 @@ rustler::init!(
         lf_arrange_with,
         lf_distinct,
         lf_mutate_with,
+        lf_summarise_with,
         // series
         s_add,
         s_and,

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -422,4 +422,59 @@ defmodule Explorer.DataFrame.LazyTest do
                    end
     end
   end
+
+  describe "head/2" do
+    test "selects the first 5 rows by default", %{ldf: ldf} do
+      ldf1 = DF.head(ldf)
+      df = DF.collect(ldf1)
+
+      assert DF.shape(df) == {5, 10}
+    end
+
+    test "selects the first 2 rows", %{ldf: ldf} do
+      ldf1 = DF.head(ldf, 2)
+      df = DF.collect(ldf1)
+
+      assert DF.shape(df) == {2, 10}
+    end
+  end
+
+  describe "distinct/2" do
+    test "with lists of strings", %{ldf: ldf} do
+      ldf1 = DF.distinct(ldf, [:year, :country])
+      assert DF.names(ldf1) == ["year", "country"]
+
+      assert DF.n_columns(ldf1) == 2
+
+      ldf2 = DF.head(ldf1, 1)
+      df = DF.collect(ldf2)
+
+      assert DF.to_columns(df, atom_keys: true) == %{country: ["AFGHANISTAN"], year: [2010]}
+    end
+
+    test "keeping all columns", %{ldf: ldf} do
+      ldf2 = DF.distinct(ldf, [:year, :country], keep_all: true)
+      assert DF.names(ldf2) == DF.names(ldf)
+    end
+
+    test "with lists of indices", %{ldf: ldf} do
+      ldf1 = DF.distinct(ldf, [0, 2, 4])
+      assert DF.names(ldf1) == ["year", "total", "liquid_fuel"]
+
+      assert DF.n_columns(ldf1) == 3
+    end
+
+    test "with ranges", %{df: df} do
+      df1 = DF.distinct(df, 0..1)
+      assert DF.names(df1) == ["year", "country"]
+
+      df2 = DF.distinct(df)
+      assert DF.names(df2) == DF.names(df)
+
+      df3 = DF.distinct(df, 0..-1)
+      assert DF.names(df3) == DF.names(df)
+
+      assert df == DF.distinct(df, 100..200)
+    end
+  end
 end

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -536,4 +536,50 @@ defmodule Explorer.DataFrame.LazyTest do
                    end
     end
   end
+
+  describe "summarise_with/2" do
+    test "with one group and one column with aggregations", %{ldf: ldf} do
+      ldf1 =
+        ldf
+        |> DF.group_by("year")
+        |> DF.summarise_with(fn ldf ->
+          total = ldf["total"]
+
+          [total_min: Series.min(total), total_max: Series.max(total)]
+        end)
+
+      df = DF.collect(ldf1)
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               year: [2010, 2011, 2012, 2013, 2014],
+               total_min: [1, 2, 2, 2, 3],
+               total_max: [2_393_248, 2_654_360, 2_734_817, 2_797_384, 2_806_634]
+             }
+    end
+
+    test "with one group and two columns with aggregations", %{ldf: ldf} do
+      ldf1 =
+        ldf
+        |> DF.group_by("year")
+        |> DF.summarise_with(fn ldf ->
+          total = ldf["total"]
+          liquid_fuel = ldf["liquid_fuel"]
+
+          [
+            total_min: Series.min(total),
+            total_max: Series.max(total),
+            median_liquid_fuel: Series.median(liquid_fuel)
+          ]
+        end)
+
+      df = DF.collect(ldf1)
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               year: [2010, 2011, 2012, 2013, 2014],
+               total_min: [1, 2, 2, 2, 3],
+               total_max: [2_393_248, 2_654_360, 2_734_817, 2_797_384, 2_806_634],
+               median_liquid_fuel: [1193.0, 1236.0, 1199.0, 1260.0, 1255.0]
+             }
+    end
+  end
 end


### PR DESCRIPTION
These implementations don't take into account grouped dataframes yet.
EDIT: only `summarise_with/2` deals with groups. `distinct/3` does not take care of groups.

This is part of #227 