### PR TITLE
Allow Series.fill_missing/2 to receive date and datetime values

### DIFF
--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -198,6 +198,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_fill_missing_with_int(_s, _value), do: err()
   def s_fill_missing_with_atom(_s, _value), do: err()
   def s_fill_missing_with_date(_s, _value), do: err()
+  def s_fill_missing_with_datetime(_s, _value), do: err()
   def s_greater(_s, _rhs), do: err()
   def s_greater_equal(_s, _rhs), do: err()
   def s_head(_s, _length), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -197,6 +197,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_fill_missing_with_float(_s, _value), do: err()
   def s_fill_missing_with_int(_s, _value), do: err()
   def s_fill_missing_with_atom(_s, _value), do: err()
+  def s_fill_missing_with_date(_s, _value), do: err()
   def s_greater(_s, _rhs), do: err()
   def s_greater_equal(_s, _rhs), do: err()
   def s_head(_s, _length), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -411,6 +411,7 @@ defmodule Explorer.PolarsBackend.Series do
         is_binary(value) -> :s_fill_missing_with_bin
         is_boolean(value) -> :s_fill_missing_with_boolean
         is_struct(value, Date) -> :s_fill_missing_with_date
+        is_struct(value, NaiveDateTime) -> :s_fill_missing_with_datetime
       end
 
     Shared.apply_series(series, operation, [value])

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -410,6 +410,7 @@ defmodule Explorer.PolarsBackend.Series do
         is_integer(value) -> :s_fill_missing_with_int
         is_binary(value) -> :s_fill_missing_with_bin
         is_boolean(value) -> :s_fill_missing_with_boolean
+        is_struct(value, Date) -> :s_fill_missing_with_date
       end
 
     Shared.apply_series(series, operation, [value])

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -256,6 +256,7 @@ rustler::init!(
         s_fill_missing_with_int,
         s_fill_missing_with_atom,
         s_fill_missing_with_date,
+        s_fill_missing_with_datetime,
         s_greater,
         s_greater_equal,
         s_head,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -255,6 +255,7 @@ rustler::init!(
         s_fill_missing_with_float,
         s_fill_missing_with_int,
         s_fill_missing_with_atom,
+        s_fill_missing_with_date,
         s_greater,
         s_greater_equal,
         s_head,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -471,6 +471,20 @@ pub fn s_fill_missing_with_date(
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_fill_missing_with_datetime(
+    data: ExSeries,
+    strategy: ExDateTime,
+) -> Result<ExSeries, ExplorerError> {
+    let s = data.clone_inner();
+    let s = s
+        .datetime()?
+        .fill_null_with_values(strategy.into())?
+        .cast(&DataType::Datetime(TimeUnit::Microseconds, None))?
+        .into_series();
+    Ok(ExSeries::new(s))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_fill_missing_with_boolean(
     data: ExSeries,
     strategy: bool,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -476,7 +476,7 @@ pub fn s_fill_missing_with_datetime(
     let s = s
         .datetime()?
         .fill_null_with_values(datetime.into())?
-        .cast(&DataType::Datetime(TimeUnit::Microseconds, None))?
+        .cast(s.dtype())?
         .into_series();
     Ok(ExSeries::new(s))
 }

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -436,35 +436,32 @@ pub fn s_fill_missing_with_atom(data: ExSeries, atom: &str) -> Result<ExSeries, 
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_fill_missing_with_int(data: ExSeries, strategy: i64) -> Result<ExSeries, ExplorerError> {
+pub fn s_fill_missing_with_int(data: ExSeries, integer: i64) -> Result<ExSeries, ExplorerError> {
     let s = data.clone_inner();
-    let s = s.i64()?.fill_null_with_values(strategy)?.into_series();
+    let s = s.i64()?.fill_null_with_values(integer)?.into_series();
     Ok(ExSeries::new(s))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_fill_missing_with_float(data: ExSeries, strategy: f64) -> Result<ExSeries, ExplorerError> {
+pub fn s_fill_missing_with_float(data: ExSeries, float: f64) -> Result<ExSeries, ExplorerError> {
     let s = data.clone_inner();
-    let s = s.f64()?.fill_null_with_values(strategy)?.into_series();
+    let s = s.f64()?.fill_null_with_values(float)?.into_series();
     Ok(ExSeries::new(s))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_fill_missing_with_bin(data: ExSeries, strategy: &str) -> Result<ExSeries, ExplorerError> {
+pub fn s_fill_missing_with_bin(data: ExSeries, binary: &str) -> Result<ExSeries, ExplorerError> {
     let s = data.clone_inner();
-    let s = s.utf8()?.fill_null_with_values(strategy)?.into_series();
+    let s = s.utf8()?.fill_null_with_values(binary)?.into_series();
     Ok(ExSeries::new(s))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_fill_missing_with_date(
-    data: ExSeries,
-    strategy: ExDate,
-) -> Result<ExSeries, ExplorerError> {
+pub fn s_fill_missing_with_date(data: ExSeries, date: ExDate) -> Result<ExSeries, ExplorerError> {
     let s = data.clone_inner();
     let s = s
         .date()?
-        .fill_null_with_values(strategy.into())?
+        .fill_null_with_values(date.into())?
         .cast(&DataType::Date)?
         .into_series();
     Ok(ExSeries::new(s))
@@ -473,12 +470,12 @@ pub fn s_fill_missing_with_date(
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_fill_missing_with_datetime(
     data: ExSeries,
-    strategy: ExDateTime,
+    datetime: ExDateTime,
 ) -> Result<ExSeries, ExplorerError> {
     let s = data.clone_inner();
     let s = s
         .datetime()?
-        .fill_null_with_values(strategy.into())?
+        .fill_null_with_values(datetime.into())?
         .cast(&DataType::Datetime(TimeUnit::Microseconds, None))?
         .into_series();
     Ok(ExSeries::new(s))
@@ -487,10 +484,10 @@ pub fn s_fill_missing_with_datetime(
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_fill_missing_with_boolean(
     data: ExSeries,
-    strategy: bool,
+    boolean: bool,
 ) -> Result<ExSeries, ExplorerError> {
     let s = data.clone_inner();
-    let s = s.bool()?.fill_null_with_values(strategy)?.into_series();
+    let s = s.bool()?.fill_null_with_values(boolean)?.into_series();
     Ok(ExSeries::new(s))
 }
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -457,6 +457,20 @@ pub fn s_fill_missing_with_bin(data: ExSeries, strategy: &str) -> Result<ExSerie
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_fill_missing_with_date(
+    data: ExSeries,
+    strategy: ExDate,
+) -> Result<ExSeries, ExplorerError> {
+    let s = data.clone_inner();
+    let s = s
+        .date()?
+        .fill_null_with_values(strategy.into())?
+        .cast(&DataType::Date)?
+        .into_series();
+    Ok(ExSeries::new(s))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_fill_missing_with_boolean(
     data: ExSeries,
     strategy: bool,

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -322,12 +322,6 @@ defmodule Explorer.SeriesTest do
       assert_raise RuntimeError, fn ->
         Series.fill_missing(s1, :mean)
       end
-
-      assert_raise ArgumentError,
-                   "fill_missing with :nan values require a :float series, got :integer",
-                   fn ->
-                     Series.fill_missing(s1, :nan)
-                   end
     end
 
     test "with nan" do
@@ -338,9 +332,9 @@ defmodule Explorer.SeriesTest do
     test "non-float series with nan" do
       s1 = Series.from_list([1, 2, nil, 4])
 
-      assert_raise ArgumentError, fn ->
-        Series.fill_missing(s1, :nan)
-      end
+      assert_raise ArgumentError,
+                   "fill_missing with :nan values require a :float series, got :integer",
+                   fn -> Series.fill_missing(s1, :nan) end
     end
 
     test "with infinity" do
@@ -353,9 +347,7 @@ defmodule Explorer.SeriesTest do
 
       assert_raise ArgumentError,
                    "fill_missing with :infinity values require a :float series, got :integer",
-                   fn ->
-                     Series.fill_missing(s1, :infinity)
-                   end
+                   fn -> Series.fill_missing(s1, :infinity) end
     end
 
     test "with neg_infinity" do
@@ -374,9 +366,7 @@ defmodule Explorer.SeriesTest do
 
       assert_raise ArgumentError,
                    "fill_missing with :neg_infinity values require a :float series, got :integer",
-                   fn ->
-                     Series.fill_missing(s1, :neg_infinity)
-                   end
+                   fn -> Series.fill_missing(s1, :neg_infinity) end
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -149,6 +149,193 @@ defmodule Explorer.SeriesTest do
       assert Series.fill_missing(s1, true) |> Series.to_list() == [true, false, true]
       assert Series.fill_missing(s1, false) |> Series.to_list() == [true, false, false]
     end
+
+    test "with integer" do
+      s1 = Series.from_list([1, 2, nil, 4])
+      assert Series.fill_missing(s1, 3) |> Series.to_list() == [1, 2, 3, 4]
+    end
+
+    test "with float" do
+      s1 = Series.from_list([1.0, 2.0, nil, 4.0])
+      assert Series.fill_missing(s1, 3.5) |> Series.to_list() == [1.0, 2.0, 3.5, 4.0]
+    end
+
+    test "with string" do
+      s1 = Series.from_list(["1", "2", nil, "4"])
+      assert Series.fill_missing(s1, "3") |> Series.to_list() == ["1", "2", "3", "4"]
+    end
+
+    test "with date" do
+      s1 = Series.from_list([~D[2023-01-17], ~D[2023-01-18], nil, ~D[2023-01-09]])
+
+      assert Series.fill_missing(s1, ~D[2023-01-19]) |> Series.to_list() == [
+               ~D[2023-01-17],
+               ~D[2023-01-18],
+               ~D[2023-01-19],
+               ~D[2023-01-09]
+             ]
+    end
+
+    test "with datetime" do
+      s1 =
+        Series.from_list([
+          ~N[2023-01-17 20:00:56.576456],
+          ~N[2023-01-18 20:30:56.576456],
+          nil,
+          ~N[2023-01-09 21:00:56.576456]
+        ])
+
+      assert Series.fill_missing(s1, ~N[2023-01-19 20:00:56.576456]) |> Series.to_list() == [
+               ~N[2023-01-17 20:00:56.576456],
+               ~N[2023-01-18 20:30:56.576456],
+               ~N[2023-01-19 20:00:56.576456],
+               ~N[2023-01-09 21:00:56.576456]
+             ]
+    end
+
+    test "with nan" do
+      s1 = Series.from_list([1.0, 2.0, nil, 4.5])
+      assert Series.fill_missing(s1, :nan) |> Series.to_list() == [1.0, 2.0, :nan, 4.5]
+    end
+
+    test "non-float series with nan" do
+      s1 = Series.from_list([1, 2, nil, 4])
+
+      assert_raise ArgumentError, fn ->
+        Series.fill_missing(s1, :nan)
+      end
+    end
+
+    test "with forward strategy" do
+      s1 = Series.from_list([1, 2, nil, 4])
+      assert Series.fill_missing(s1, :forward) |> Series.to_list() == [1, 2, 2, 4]
+    end
+
+    test "with backward strategy" do
+      s1 = Series.from_list([1, 2, nil, 4])
+      assert Series.fill_missing(s1, :backward) |> Series.to_list() == [1, 2, 4, 4]
+    end
+
+    test "with max strategy" do
+      s1 = Series.from_list([1, 2, nil, 10, 5])
+      assert Series.fill_missing(s1, :max) |> Series.to_list() == [1, 2, 10, 10, 5]
+    end
+
+    test "boolean series with max strategy" do
+      s1 = Series.from_list([true, nil, false])
+      assert Series.fill_missing(s1, :max) |> Series.to_list() == [true, true, false]
+    end
+
+    test "date series with max strategy" do
+      s1 = Series.from_list([~D[2023-01-18], ~D[2023-01-17], nil, ~D[2023-01-09]])
+
+      assert Series.fill_missing(s1, :max) |> Series.to_list() == [
+               ~D[2023-01-18],
+               ~D[2023-01-17],
+               ~D[2023-01-18],
+               ~D[2023-01-09]
+             ]
+    end
+
+    test "datetime series with max strategy" do
+      s1 =
+        Series.from_list([
+          ~N[2023-01-17 20:00:56.576456],
+          ~N[2023-01-18 20:30:56.576456],
+          nil,
+          ~N[2023-01-09 21:00:56.576456],
+          ~N[2023-01-18 23:35:56.576456]
+        ])
+
+      assert Series.fill_missing(s1, :max) |> Series.to_list() == [
+               ~N[2023-01-17 20:00:56.576456],
+               ~N[2023-01-18 20:30:56.576456],
+               ~N[2023-01-18 23:35:56.576456],
+               ~N[2023-01-09 21:00:56.576456],
+               ~N[2023-01-18 23:35:56.576456]
+             ]
+    end
+
+    test "with min strategy" do
+      s1 = Series.from_list([1, 2, nil, 5])
+      assert Series.fill_missing(s1, :min) |> Series.to_list() == [1, 2, 1, 5]
+    end
+
+    test "boolean series with min strategy" do
+      s1 = Series.from_list([true, nil, false])
+      assert Series.fill_missing(s1, :min) |> Series.to_list() == [true, false, false]
+    end
+
+    test "date series with min strategy" do
+      s1 = Series.from_list([~D[2023-01-18], ~D[2023-01-17], nil, ~D[2023-01-09]])
+
+      assert Series.fill_missing(s1, :min) |> Series.to_list() == [
+               ~D[2023-01-18],
+               ~D[2023-01-17],
+               ~D[2023-01-09],
+               ~D[2023-01-09]
+             ]
+    end
+
+    test "datetime series with min strategy" do
+      s1 =
+        Series.from_list([
+          ~N[2023-01-17 20:00:56.576456],
+          ~N[2023-01-18 20:30:56.576456],
+          nil,
+          ~N[2023-01-09 21:00:56.576456],
+          ~N[2023-01-18 23:35:56.576456]
+        ])
+
+      assert Series.fill_missing(s1, :min) |> Series.to_list() == [
+               ~N[2023-01-17 20:00:56.576456],
+               ~N[2023-01-18 20:30:56.576456],
+               ~N[2023-01-09 21:00:56.576456],
+               ~N[2023-01-09 21:00:56.576456],
+               ~N[2023-01-18 23:35:56.576456]
+             ]
+    end
+
+    test "with mean strategy" do
+      s1 = Series.from_list([1, 3, nil, 5])
+      assert Series.fill_missing(s1, :mean) |> Series.to_list() == [1, 3, 3, 5]
+    end
+
+    test "date series with mean strategy" do
+      s1 = Series.from_list([~D[2023-01-18], ~D[2023-06-17], nil, ~D[2023-01-09]])
+
+      assert Series.fill_missing(s1, :mean) |> Series.to_list() == [
+               ~D[2023-01-18],
+               ~D[2023-06-17],
+               ~D[2023-03-06],
+               ~D[2023-01-09]
+             ]
+    end
+
+    test "datetime series with mean strategy" do
+      s1 =
+        Series.from_list([
+          ~N[2023-01-18 20:30:56.576456],
+          ~N[2023-06-17 20:00:56.576456],
+          nil,
+          ~N[2023-01-09 21:00:56.576456]
+        ])
+
+      assert Series.fill_missing(s1, :mean) |> Series.to_list() == [
+               ~N[2023-01-18 20:30:56.576456],
+               ~N[2023-06-17 20:00:56.576456],
+               ~N[2023-03-06 20:30:56.576456],
+               ~N[2023-01-09 21:00:56.576456]
+             ]
+    end
+
+    test "boolean series with mean strategy" do
+      s1 = Series.from_list([true, nil, false])
+
+      assert_raise RuntimeError, fn ->
+        Series.fill_missing(s1, :mean)
+      end
+    end
   end
 
   describe "equal/2" do


### PR DESCRIPTION
This PR allows the Series.fill_missing/2 function to receive date and datetime values.

Before this PR, if you try to send a date or datetime value to the Series.fill_missing/2 function, an error will be returned:

```elixir
iex(1)> s1 = Explorer.Series.from_list([~D[2023-01-17], ~D[2023-01-18], nil, ~D[2023-01-09]])
#Explorer.Series<
  Polars[4]
  date [2023-01-17, 2023-01-18, nil, 2023-01-09]
>

iex(2)> Explorer.Series.fill_missing(s1, ~D[2023-01-19])
** (CondClauseError) no cond clause evaluated to a truthy value
    (explorer 0.6.0-dev) lib/explorer/polars_backend/series.ex:412: Explorer.PolarsBackend.Series.fill_missing_with_value/2

iex(2)> s2 = Explorer.Series.from_list([~N[2023-01-17 20:00:56.576456], ~N[2023-01-18 20:30:56.576456], nil, ~N[2023-01-09 21:00:56.576456]])
#Explorer.Series<
  Polars[4]
  datetime [2023-01-17 20:00:56.576456, 2023-01-18 20:30:56.576456, nil,
   2023-01-09 21:00:56.576456]
>

iex(3)> Explorer.Series.fill_missing(s2, ~N[2023-01-19 20:00:56.576456])
** (CondClauseError) no cond clause evaluated to a truthy value
    (explorer 0.6.0-dev) lib/explorer/polars_backend/series.ex:412: Explorer.PolarsBackend.Series.fill_missing_with_value/2
```

After this PR the result is:

```elixir
iex(3)> Explorer.Series.fill_missing(s1, ~D[2023-01-19])
#Explorer.Series<
  Polars[4]
  date [2023-01-17, 2023-01-18, 2023-01-19, 2023-01-09]
>

iex(4)> Explorer.Series.fill_missing(s2, ~N[2023-01-19 20:00:56.576456])
#Explorer.Series<
  Polars[4]
  datetime [2023-01-17 20:00:56.576456, 2023-01-18 20:30:56.576456, 2023-01-19 20:00:56.576456,
   2023-01-09 21:00:56.576456]
>
```