### PR TITLE
Allow Series.fill_missing/2 to receive infinity and neg_infinity values

### DIFF
--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -149,6 +149,57 @@ defmodule Explorer.SeriesTest do
       assert Series.fill_missing(s1, true) |> Series.to_list() == [true, false, true]
       assert Series.fill_missing(s1, false) |> Series.to_list() == [true, false, false]
     end
+
+    test "with nan" do
+      s1 = Series.from_list([1.0, 2.0, nil, 4.5])
+      assert Series.fill_missing(s1, :nan) |> Series.to_list() == [1.0, 2.0, :nan, 4.5]
+    end
+
+    test "non-float series with nan" do
+      s1 = Series.from_list([1, 2, nil, 4])
+
+      assert_raise ArgumentError,
+                   "fill_missing with :nan values require a :float series, got :integer",
+                   fn ->
+                     Series.fill_missing(s1, :nan)
+                   end
+    end
+
+    test "with infinity" do
+      s1 = Series.from_list([1.0, 2.0, nil, 4.5])
+      assert Series.fill_missing(s1, :infinity) |> Series.to_list() == [1.0, 2.0, :infinity, 4.5]
+    end
+
+    test "non-float series with infinity" do
+      s1 = Series.from_list([1, 2, nil, 4])
+
+      assert_raise ArgumentError,
+                   "fill_missing with :infinity values require a :float series, got :integer",
+                   fn ->
+                     Series.fill_missing(s1, :infinity)
+                   end
+    end
+
+    test "with neg_infinity" do
+      s1 = Series.from_list([1.0, 2.0, nil, 4.5])
+
+      assert Series.fill_missing(s1, :neg_infinity) |> Series.to_list() == [
+               1.0,
+               2.0,
+               :neg_infinity,
+               4.5
+             ]
+    end
+
+    test "non-float series with neg_infinity" do
+      s1 = Series.from_list([1, 2, nil, 4])
+
+      assert_raise ArgumentError,
+                   "fill_missing with :neg_infinity values require a :float series, got :integer",
+                   fn ->
+                     Series.fill_missing(s1, :neg_infinity)
+                   end
+    end
   end
 
   describe "equal/2" do


### PR DESCRIPTION
This PR allows the Series.fill_missing/2 function to receive :infinity and :neg_infinity values.

This is part of https://github.com/elixir-nx/explorer/issues/467

Before this PR, if you try to send a :infinity or :neg_infinity value to the Series.fill_missing/2 function, an error will be returned:

```elixir
iex(1)> s1 = Explorer.Series.from_list([1.0, 2.0, nil, 4.5])            
#Explorer.Series<
  Polars[4]
  float [1.0, 2.0, nil, 4.5]
>

iex(2)> Explorer.Series.fill_missing(s1, :infinity)
** (ArgumentError) cannot invoke Explorer.Series.fill_missing/2 with mismatched dtypes: :float and :infinity
    (explorer 0.6.0-dev) lib/explorer/series.ex:3313: Explorer.Series.dtype_mismatch_error/3

iex(2)> Explorer.Series.fill_missing(s1, :neg_infinity)
** (ArgumentError) cannot invoke Explorer.Series.fill_missing/2 with mismatched dtypes: :float and :neg_infinity
    (explorer 0.6.0-dev) lib/explorer/series.ex:3313: Explorer.Series.dtype_mismatch_error/3
```

After this PR the result is:

```elixir
iex(2)> Explorer.Series.fill_missing(s1, :infinity)         
#Explorer.Series<
  Polars[4]
  float [1.0, 2.0, Inf, 4.5]
>

iex(3)> Explorer.Series.fill_missing(s1, :neg_infinity)     
#Explorer.Series<
  Polars[4]
  float [1.0, 2.0, -Inf, 4.5]
>
```