### PR TITLE
Simplify release workflow with a new action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,5 @@
 name: Build precompiled NIFs
 
-env:
-  NIF_DIRECTORY: "native/explorer"
-
 on:
   push:
     branches:
@@ -16,15 +13,9 @@ on:
       # Tags will always run.
       - "*"
 
-defaults:
-  run:
-    # Sets the working dir for "run" scripts.
-    # Note that this won't change the directory for actions (tasks with "uses").
-    working-directory: "./native/explorer"
-
 jobs:
   build_release:
-    name: NIF ${{ matrix.job.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
     strategy:
       fail-fast: false
@@ -47,8 +38,6 @@ jobs:
           - { target: x86_64-pc-windows-gnu, os: windows-2019 }
           - { target: x86_64-pc-windows-msvc, os: windows-2019 }
 
-    env:
-      RUSTLER_NIF_VERSION: ${{ matrix.nif }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v3
@@ -56,9 +45,8 @@ jobs:
       - name: Extract crate information
         shell: bash
         run: |
-          echo "PROJECT_NAME=$(sed -n 's/^name = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
           # Get the project version from mix.exs
-          echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' ../../mix.exs | head -n1)" >> $GITHUB_ENV
+          echo "PROJECT_VERSION=$(sed -n 's/^  @version "\(.*\)"/\1/p' mix.exs | head -n1)" >> $GITHUB_ENV
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -68,17 +56,6 @@ jobs:
           override: true
           profile: minimal
 
-      - name: Show version information (Rust, cargo, GCC)
-        shell: bash
-        run: |
-          gcc --version || true
-          rustup -V
-          rustup toolchain list
-          rustup default
-          cargo -V
-          rustc -V
-          rustc --print=cfg
-
       - name: Disable JSON feature from Polars that won't compile on certain targets
         if: ${{ matrix.job.disable-polars-json-feature }}
         shell: bash
@@ -86,84 +63,26 @@ jobs:
           cargo install cargo-feature
           cargo feature polars ^json
 
-      - name: Download cross from GitHub releases
-        uses: giantswarm/install-binary-action@v1.0.0
-        if: ${{ matrix.job.use-cross }}
+      - name: Build the project
+        id: build-crate
+        uses: philss/rustler-precompiled-action@v1.0.0
         with:
-          binary: "cross"
-          version: "v0.2.4"
-          download_url: "https://github.com/cross-rs/cross/releases/download/${version}/cross-x86_64-unknown-linux-gnu.tar.gz"
-          tarball_binary_path: "${binary}"
-          smoke_test: "${binary} --version"
+          project-name: explorer
+          project-version: ${{ env.PROJECT_VERSION }}
+          target: ${{ matrix.job.target }}
+          nif-version: ${{ matrix.nif }}
+          use-cross: ${{ matrix.job.use-cross }}
+          project-dir: "native/explorer"
 
-      - name: Build
-        shell: bash
-        run: |
-          if [ "${{ matrix.job.use-cross }}" == "true" ]; then
-            cross build --release --target=${{ matrix.job.target }}
-          else
-            cargo build --release --target=${{ matrix.job.target }}
-          fi
-
-      - name: Rename lib to the final name
-        id: rename
-        shell: bash
-        run: |
-          LIB_PREFIX="lib"
-          case ${{ matrix.job.target }} in
-            *-pc-windows-*) LIB_PREFIX="" ;;
-          esac;
-
-          # Figure out suffix of lib
-          # See: https://doc.rust-lang.org/reference/linkage.html
-          LIB_SUFFIX=".so"
-          case ${{ matrix.job.target }} in
-            *-apple-darwin) LIB_SUFFIX=".dylib" ;;
-            *-pc-windows-*) LIB_SUFFIX=".dll" ;;
-          esac;
-
-          CICD_INTERMEDIATES_DIR=$(mktemp -d) 
-
-          # Setup paths
-          LIB_DIR="${CICD_INTERMEDIATES_DIR}/released-lib"
-          mkdir -p "${LIB_DIR}"
-          LIB_NAME="${LIB_PREFIX}${{ env.PROJECT_NAME }}${LIB_SUFFIX}"
-          LIB_PATH="${LIB_DIR}/${LIB_NAME}"
-
-          # Copy the release build lib to the result location
-          cp "target/${{ matrix.job.target }}/release/${LIB_NAME}" "${LIB_DIR}"
-
-          # Final paths
-          # In the end we use ".so" for MacOS in the final build
-          # See: https://www.erlang.org/doc/man/erlang.html#load_nif-2
-          LIB_FINAL_SUFFIX="${LIB_SUFFIX}"
-          case ${{ matrix.job.target }} in
-            *-apple-darwin) LIB_FINAL_SUFFIX=".so" ;;
-          esac;
-
-          LIB_FINAL_NAME="${LIB_PREFIX}${PROJECT_NAME}-v${PROJECT_VERSION}-nif-${RUSTLER_NIF_VERSION}-${{ matrix.job.target }}${LIB_FINAL_SUFFIX}"
-
-          # Copy lib to final name on this directory
-          cp "${LIB_PATH}" "${LIB_FINAL_NAME}"
-
-          tar -cvzf "${LIB_FINAL_NAME}.tar.gz" "${LIB_FINAL_NAME}"
-
-          # Passes the path relative to the root of the project.
-          LIB_FINAL_PATH="${NIF_DIRECTORY}/${LIB_FINAL_NAME}.tar.gz"
-
-          # Let subsequent steps know where to find the lib
-          echo "LIB_FINAL_PATH=${LIB_FINAL_PATH}" >> $GITHUB_OUTPUT
-          echo "LIB_FINAL_NAME=${LIB_FINAL_NAME}.tar.gz" >> $GITHUB_OUTPUT
-
-      - name: "Artifact upload"
-        uses: actions/upload-artifact@v2
+      - name: Artifact upload
+        uses: actions/upload-artifact@v3
         with:
-          name: ${{ steps.rename.outputs.LIB_FINAL_NAME }}
-          path: ${{ steps.rename.outputs.LIB_FINAL_PATH }}
+          name: ${{ steps.build-crate.outputs.file-name }}
+          path: ${{ steps.build-crate.outputs.file-path }}
 
       - name: Publish archives and packages
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            ${{ steps.rename.outputs.LIB_FINAL_PATH }}
+            ${{ steps.build-crate.outputs.file-path }}
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Since we now have https://github.com/philss/rustler-precompiled-action, it's possible to remove a lot of code from the current workflow.

This also have a small fix for the title of each job.