### PR TITLE
Allow Series.fill_missing/2 to receive binary values

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2322,8 +2322,10 @@ defmodule Explorer.Series do
   end
 
   defp sides_comparable?(%Series{dtype: :string}, right) when is_binary(right), do: true
+  defp sides_comparable?(%Series{dtype: :binary}, right) when is_binary(right), do: true
   defp sides_comparable?(%Series{dtype: :boolean}, right) when is_boolean(right), do: true
   defp sides_comparable?(left, %Series{dtype: :string}) when is_binary(left), do: true
+  defp sides_comparable?(left, %Series{dtype: :binary}) when is_binary(left), do: true
   defp sides_comparable?(left, %Series{dtype: :boolean}) when is_boolean(left), do: true
   defp sides_comparable?(_, _), do: false
 


### PR DESCRIPTION
This PR allows the Series.fill_missing/2 function to receive binary values.

Before this PR:

```elixir
iex(1)> s1 = Explorer.Series.from_list([<<1>>, <<2>>, nil, <<4>>], dtype: :binary)
#Explorer.Series<
  Polars[4]
  binary [<<1>>, <<2>>, nil, <<4>>]
>

iex(2)> Explorer.Series.fill_missing(s1, <<3>>)           
** (RuntimeError) Data types dont match: Series of dtype: Binary != Utf8
    (explorer 0.6.0-dev) lib/explorer/polars_backend/shared.ex:26: Explorer.PolarsBackend.Shared.apply_series/3

iex(2)> Explorer.Series.fill_missing(s1, <<239, 191, 19>>)
** (ArgumentError) argument error
    (explorer 0.6.0-dev) Explorer.PolarsBackend.Native.s_fill_missing_with_bin(%Inspect.Error{message: "got FunctionClauseError with message \"no function clause matching in Explorer.PolarsBackend.Shared.apply_series/3\" while inspecting %{__struct__: Explorer.PolarsBackend.Series, resource: #Reference<0.2258451173.2643591206.140034>}"}, <<239, 191, 19>>)
    (explorer 0.6.0-dev) lib/explorer/polars_backend/shared.ex:23: Explorer.PolarsBackend.Shared.apply_series/3

# Mixing string series with binary:
iex(2)> s2 = Explorer.Series.from_list(["1", "2", nil, "4"])
#Explorer.Series<
  Polars[4]
  string ["1", "2", nil, "4"]
>

iex(3)> Explorer.Series.fill_missing(s2, <<3>>)
#Explorer.Series<
  Polars[4]
  string ["1", "2", <<3>>, "4"]
>

iex(4)> Explorer.Series.fill_missing(s2, <<239, 191, 19>>)
** (ArgumentError) argument error
    (explorer 0.6.0-dev) Explorer.PolarsBackend.Native.s_fill_missing_with_bin(%Inspect.Error{message: "got FunctionClauseError with message \"no function clause matching in Explorer.PolarsBackend.Shared.apply_series/3\" while inspecting %{__struct__: Explorer.PolarsBackend.Series, resource: #Reference<0.2258451173.2643591206.140036>}"}, <<239, 191, 19>>)
    (explorer 0.6.0-dev) lib/explorer/polars_backend/shared.ex:23: Explorer.PolarsBackend.Shared.apply_series/3
```

After this PR:

```elixir
iex(1)> s1 = Explorer.Series.from_list([<<1>>, <<2>>, nil, <<4>>], dtype: :binary)
#Explorer.Series<
  Polars[4]
  binary [<<1>>, <<2>>, nil, <<4>>]
>

iex(2)> Explorer.Series.fill_missing(s1, <<3>>)
#Explorer.Series<
  Polars[4]
  binary [<<1>>, <<2>>, <<3>>, <<4>>]
>

iex(3)> Explorer.Series.fill_missing(s1, <<239, 191, 19>>)
#Explorer.Series<
  Polars[4]
  binary [<<1>>, <<2>>, <<239, 191, 19>>, <<4>>]
>

# Mixing string series with binary:
iex(4)> s2 = Explorer.Series.from_list(["1", "2", nil, "4"])
#Explorer.Series<
  Polars[4]
  string ["1", "2", nil, "4"]
>

iex(5)> Explorer.Series.fill_missing(s2, <<3>>)
#Explorer.Series<
  Polars[4]
  string ["1", "2", <<3>>, "4"]
>

iex(6)> Explorer.Series.fill_missing(s2, <<239, 191, 19>>)
** (RuntimeError) cannot cast to string
    (explorer 0.6.0-dev) lib/explorer/polars_backend/shared.ex:26: Explorer.PolarsBackend.Shared.apply_series/3
```