### PR TITLE
Simplify `df_describe` with `as_deref()`

### DIFF
--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -430,11 +430,7 @@ pub fn df_describe(
     percentiles: Option<Vec<f64>>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let df = data.clone_inner();
-
-    let new_df = match percentiles {
-        Some(percentiles) => df.describe(Some(percentiles.as_slice())),
-        None => df.describe(None),
-    };
+    let new_df = df.describe(percentiles.as_deref());
 
     Ok(ExDataFrame::new(new_df))
 }


### PR DESCRIPTION
This makes the conversion of `Option<Vec<f64>>` to `Option<&[f64]>` in a cleaner manner.
