### PR TITLE
Allow Series.from_list/2 to receive nan, infinity and neg_infinity values

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -170,6 +170,26 @@ defmodule Explorer.Series do
         float [1.0, 2.0]
       >
 
+  Floats series can accept NaN, Inf, and -Inf values:
+
+      iex> Explorer.Series.from_list([1.0, 2.0, :nan, 4.0])
+      #Explorer.Series<
+        Polars[4]
+        float [1.0, 2.0, NaN, 4.0]
+      >
+
+      iex> Explorer.Series.from_list([1.0, 2.0, :infinity, 4.0])
+      #Explorer.Series<
+        Polars[4]
+        float [1.0, 2.0, Inf, 4.0]
+      >
+
+      iex> Explorer.Series.from_list([1.0, 2.0, :neg_infinity, 4.0])
+      #Explorer.Series<
+        Polars[4]
+        float [1.0, 2.0, -Inf, 4.0]
+      >
+
   Trying to create a "nil" series will, by default, result in a series of floats:
 
       iex> Explorer.Series.from_list([nil, nil])

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -135,8 +135,13 @@ defmodule Explorer.Shared do
   defp type(item, type) when is_float(item) and type == :integer, do: :numeric
   defp type(item, type) when is_number(item) and type == :numeric, do: :numeric
 
+  defp type(item, type)
+       when item in [:nan, :infinity, :neg_infinity] and type in [:integer, :float, :numeric],
+       do: :numeric
+
   defp type(item, _type) when is_integer(item), do: :integer
   defp type(item, _type) when is_float(item), do: :float
+  defp type(item, _type) when item in [:nan, :infinity, :neg_infinity], do: :float
   defp type(item, _type) when is_boolean(item), do: :boolean
 
   defp type(item, :binary) when is_binary(item), do: :binary
@@ -155,7 +160,7 @@ defmodule Explorer.Shared do
   def cast_numerics(list, type) when type == :numeric do
     data =
       Enum.map(list, fn
-        nil -> nil
+        item when is_atom(item) -> item
         item -> item / 1
       end)
 

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -160,7 +160,7 @@ defmodule Explorer.Shared do
   def cast_numerics(list, type) when type == :numeric do
     data =
       Enum.map(list, fn
-        item when is_atom(item) -> item
+        item when item in [nil, :infinity, :neg_infinity, :nan] -> item
         item -> item / 1
       end)
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -9,7 +9,7 @@ use polars::prelude::*;
 use rand::seq::IteratorRandom;
 use rand::{Rng, SeedableRng};
 use rand_pcg::Pcg64;
-use rustler::{Binary, Encoder, Env, Term};
+use rustler::{Binary, Encoder, Env, ListIterator, Term, TermType};
 use std::{result::Result, slice};
 
 use polars::export::arrow::temporal_conversions::date32_to_date;
@@ -26,8 +26,29 @@ macro_rules! from_list {
 from_list!(s_from_list_i64, i64);
 from_list!(s_from_list_u32, u32);
 from_list!(s_from_list_bool, bool);
-from_list!(s_from_list_f64, f64);
 from_list!(s_from_list_str, String);
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_from_list_f64(name: &str, val: Term) -> ExSeries {
+    ExSeries::new(Series::new(
+        name,
+        val.decode::<ListIterator>()
+            .unwrap()
+            .map(|item| match item.get_type() {
+                TermType::Number => Some(item.decode::<f64>().unwrap()),
+                TermType::Atom => {
+                    let atom = item.atom_to_string().unwrap();
+                    if atom.contains("nil") {
+                        None
+                    } else {
+                        Some(cast_str_to_f64(atom.as_str()))
+                    }
+                }
+                term_type => panic!("from_list/2 not implemented for {term_type:?}"),
+            })
+            .collect::<Vec<Option<f64>>>(),
+    ))
+}
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_from_list_date(name: &str, val: Vec<Option<ExDate>>) -> ExSeries {

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -40,6 +40,24 @@ defmodule Explorer.SeriesTest do
       assert Series.dtype(s) == :float
     end
 
+    test "with nan" do
+      s = Series.from_list([:nan, :nan, :nan])
+      assert Series.to_list(s) === [:nan, :nan, :nan]
+      assert Series.dtype(s) == :float
+    end
+
+    test "with infinity" do
+      s = Series.from_list([:infinity, :infinity, :infinity])
+      assert Series.to_list(s) === [:infinity, :infinity, :infinity]
+      assert Series.dtype(s) == :float
+    end
+
+    test "with negative infinity" do
+      s = Series.from_list([:neg_infinity, :neg_infinity, :neg_infinity])
+      assert Series.to_list(s) === [:neg_infinity, :neg_infinity, :neg_infinity]
+      assert Series.dtype(s) == :float
+    end
+
     test "with binaries" do
       s = Series.from_list([<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>], dtype: :binary)
       assert Series.to_list(s) === [<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>]
@@ -69,6 +87,66 @@ defmodule Explorer.SeriesTest do
       s = Series.from_list([<<228, 146, 51>>, "hello", <<42, 209, 236>>], dtype: :binary)
       assert Series.to_list(s) === [<<228, 146, 51>>, <<"hello">>, <<42, 209, 236>>]
       assert Series.dtype(s) == :binary
+    end
+
+    test "mixing floats and integers" do
+      s = Series.from_list([1, 2.4, 3])
+      assert Series.to_list(s) === [1.0, 2.4, 3.0]
+      assert Series.dtype(s) == :float
+    end
+
+    test "mixing integers and nan" do
+      s = Series.from_list([1, :nan, 3])
+      assert Series.to_list(s) === [1.0, :nan, 3.0]
+      assert Series.dtype(s) == :float
+    end
+
+    test "mixing integers and infinity" do
+      s = Series.from_list([1, :infinity, 3])
+      assert Series.to_list(s) === [1.0, :infinity, 3.0]
+      assert Series.dtype(s) == :float
+    end
+
+    test "mixing integers and negative infinity" do
+      s = Series.from_list([1, :neg_infinity, 3])
+      assert Series.to_list(s) === [1.0, :neg_infinity, 3.0]
+      assert Series.dtype(s) == :float
+    end
+
+    test "mixing floats and nan" do
+      s = Series.from_list([3.0, :nan, 0.5])
+      assert Series.to_list(s) === [3.0, :nan, 0.5]
+      assert Series.dtype(s) == :float
+    end
+
+    test "mixing floats and infinity" do
+      s = Series.from_list([1.0, :infinity, 3.0])
+      assert Series.to_list(s) === [1.0, :infinity, 3.0]
+      assert Series.dtype(s) == :float
+    end
+
+    test "mixing floats and negative infinity" do
+      s = Series.from_list([1.0, :neg_infinity, 3.0])
+      assert Series.to_list(s) === [1.0, :neg_infinity, 3.0]
+      assert Series.dtype(s) == :float
+    end
+
+    test "mixing floats, integers, nan, infinity and negative infinity" do
+      s = Series.from_list([1, :nan, 2.0, :infinity, :neg_infinity])
+      assert Series.to_list(s) === [1.0, :nan, 2.0, :infinity, :neg_infinity]
+      assert Series.dtype(s) == :float
+    end
+
+    test "mixing integers with an invalid atom" do
+      assert_raise ArgumentError, "unsupported datatype: :error", fn ->
+        Series.from_list([1, 2, :error, 4])
+      end
+    end
+
+    test "mixing floats with an invalid atom" do
+      assert_raise ArgumentError, "unsupported datatype: :error", fn ->
+        Series.from_list([1.0, 2.0, :error, 4.0])
+      end
     end
 
     test "mixing types" do


### PR DESCRIPTION
This PR allows the Series.from_list/2 function to receive nan, infinity, and neg_infinity values. Thanks for the help @philss!

This is part of https://github.com/elixir-nx/explorer/issues/467

Before this PR:

```elixir
iex(1)> Explorer.Series.from_list([:nan, :nan, :nan])  
** (ArgumentError) unsupported datatype: :nan
    (explorer 0.6.0-dev) lib/explorer/shared.ex:150: Explorer.Shared.type/2
    (explorer 0.6.0-dev) lib/explorer/shared.ex:116: anonymous fn/2 in Explorer.Shared.check_types!/2
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (explorer 0.6.0-dev) lib/explorer/shared.ex:115: Explorer.Shared.check_types!/2
    (explorer 0.6.0-dev) lib/explorer/series.ex:247: Explorer.Series.from_list/2

iex(1)> Explorer.Series.from_list([:infinity, :infinity, :infinity])            
** (ArgumentError) unsupported datatype: :infinity
    (explorer 0.6.0-dev) lib/explorer/shared.ex:150: Explorer.Shared.type/2
    (explorer 0.6.0-dev) lib/explorer/shared.ex:116: anonymous fn/2 in Explorer.Shared.check_types!/2
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (explorer 0.6.0-dev) lib/explorer/shared.ex:115: Explorer.Shared.check_types!/2
    (explorer 0.6.0-dev) lib/explorer/series.ex:247: Explorer.Series.from_list/2

iex(1)> Explorer.Series.from_list([:neg_infinity, :neg_infinity, :neg_infinity])
** (ArgumentError) unsupported datatype: :neg_infinity
    (explorer 0.6.0-dev) lib/explorer/shared.ex:150: Explorer.Shared.type/2
    (explorer 0.6.0-dev) lib/explorer/shared.ex:116: anonymous fn/2 in Explorer.Shared.check_types!/2
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (explorer 0.6.0-dev) lib/explorer/shared.ex:115: Explorer.Shared.check_types!/2
    (explorer 0.6.0-dev) lib/explorer/series.ex:247: Explorer.Series.from_list/2

iex(1)> Explorer.Series.from_list([1, :nan, 2.0, :infinity, :neg_infinity])     
** (ArgumentError) unsupported datatype: :nan
    (explorer 0.6.0-dev) lib/explorer/shared.ex:150: Explorer.Shared.type/2
    (explorer 0.6.0-dev) lib/explorer/shared.ex:116: anonymous fn/2 in Explorer.Shared.check_types!/2
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (explorer 0.6.0-dev) lib/explorer/shared.ex:115: Explorer.Shared.check_types!/2
    (explorer 0.6.0-dev) lib/explorer/series.ex:247: Explorer.Series.from_list/2

iex(1)> Explorer.Series.from_list([1, :error, 2])
** (ArgumentError) unsupported datatype: :error
    (explorer 0.6.0-dev) lib/explorer/shared.ex:150: Explorer.Shared.type/2
    (explorer 0.6.0-dev) lib/explorer/shared.ex:116: anonymous fn/2 in Explorer.Shared.check_types!/2
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (explorer 0.6.0-dev) lib/explorer/shared.ex:115: Explorer.Shared.check_types!/2
    (explorer 0.6.0-dev) lib/explorer/series.ex:247: Explorer.Series.from_list/2
```

After this PR:

```elixir
iex(1)> Explorer.Series.from_list([:nan, :nan, :nan])
#Explorer.Series<
  Polars[3]
  float [NaN, NaN, NaN]
>

iex(2)> Explorer.Series.from_list([:infinity, :infinity, :infinity])
#Explorer.Series<
  Polars[3]
  float [Inf, Inf, Inf]
>

iex(3)> Explorer.Series.from_list([:neg_infinity, :neg_infinity, :neg_infinity])
#Explorer.Series<
  Polars[3]
  float [-Inf, -Inf, -Inf]
>

iex(4)> Explorer.Series.from_list([1, :nan, 2.0, :infinity, :neg_infinity])
#Explorer.Series<
  Polars[5]
  float [1.0, NaN, 2.0, Inf, -Inf]
>

iex(5)> Explorer.Series.from_list([1, :error, 2])                                  
** (ArgumentError) unsupported datatype: :error
    (explorer 0.6.0-dev) lib/explorer/shared.ex:155: Explorer.Shared.type/2
    (explorer 0.6.0-dev) lib/explorer/shared.ex:116: anonymous fn/2 in Explorer.Shared.check_types!/2
    (elixir 1.13.4) lib/enum.ex:2396: Enum."-reduce/3-lists^foldl/2-0-"/3
    (explorer 0.6.0-dev) lib/explorer/shared.ex:115: Explorer.Shared.check_types!/2
    (explorer 0.6.0-dev) lib/explorer/series.ex:267: Explorer.Series.from_list/2
```