### PR TITLE
Add LazyFrame version of `to_parquet/3`

### DIFF
--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -208,6 +208,19 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
+  def to_parquet(%DF{groups: []} = df, filename, {compression, level}) do
+    case Native.lf_to_parquet(df.data, filename, Shared.parquet_compression(compression, level)) do
+      {:ok, _} -> :ok
+      {:error, _} = err -> err
+    end
+  end
+
+  @impl true
+  def to_parquet(_df, _filename, _compression) do
+    raise "to_parquet/3 with groups is not supported yet for lazy frames"
+  end
+
+  @impl true
   def filter_with(
         %DF{},
         %DF{groups: [_ | _]},

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -183,6 +183,7 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_join(_df, _other, _left_on, _right_on, _how, _suffix), do: err()
   def lf_concat_rows(_dfs), do: err()
   def lf_concat_columns(_df, _others), do: err()
+  def lf_to_parquet(_df, _filename, _compression), do: err()
 
   # Series
   def s_add(_s, _other), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -39,7 +39,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_dtypes(_df), do: err()
   def df_dump_csv(_df, _has_headers, _delimiter), do: err()
   def df_dump_ndjson(_df), do: err()
-  def df_dump_parquet(_df, _compression, _compression_level), do: err()
+  def df_dump_parquet(_df, _compression), do: err()
   def df_dump_ipc(_df, _compression), do: err()
   def df_dump_ipc_stream(_df, _compression), do: err()
   def df_filter_with(_df, _operation, _groups), do: err()
@@ -118,7 +118,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_to_ipc_stream(_df, _filename, _compression), do: err()
   def df_to_lazy(_df), do: err()
   def df_to_ndjson(_df, _filename), do: err()
-  def df_to_parquet(_df, _filename, _compression, _compression_level), do: err()
+  def df_to_parquet(_df, _filename, _compression), do: err()
   def df_width(_df), do: err()
   def df_describe(_df, _percentiles), do: err()
 

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -151,4 +151,11 @@ defmodule Explorer.PolarsBackend.Shared do
 
   defp error_message({_err_type, error}) when is_binary(error), do: error
   defp error_message(error), do: inspect(error)
+
+  def parquet_compression(nil, _), do: :uncompressed
+
+  def parquet_compression(algorithm, level) when algorithm in ~w(gzip brotli zstd)a,
+    do: {algorithm, level}
+
+  def parquet_compression(algorithm, _) when algorithm in ~w(snappy lz4raw)a, do: algorithm
 end

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -55,6 +55,7 @@ features = [
   "temporal",
   "to_dummies",
   "is_in",
+  "streaming",
   "strings",
   "round_series"
 ]

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -236,6 +236,7 @@ rustler::init!(
         lf_join,
         lf_concat_rows,
         lf_concat_columns,
+        lf_to_parquet,
         // series
         s_add,
         s_and,

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -164,6 +164,19 @@ defmodule Explorer.DataFrame.LazyTest do
   end
 
   @tag :tmp_dir
+  test "to_parquet/2 - with defaults", %{ldf: ldf, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.parquet"])
+
+    ldf = DF.head(ldf, 15)
+    DF.to_parquet!(ldf, path)
+
+    df = DF.collect(ldf)
+    df1 = DF.from_parquet!(path)
+
+    assert DF.to_columns(df1) == DF.to_columns(df)
+  end
+
+  @tag :tmp_dir
   test "from_ndjson/2 - with defaults", %{df: df, tmp_dir: tmp_dir} do
     path = Path.join([tmp_dir, "fossil_fuels.ndjson"])
     df = DF.slice(df, 0, 10)


### PR DESCRIPTION
This is going to save a lazy frame to a parquet file using a stream.
This should keep the memory usage low for bigger files.