### PR TITLE
Implement the Deref trait for our Ex* structs in order to abstract usage

### DIFF
--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -269,16 +269,16 @@ pub fn df_arrange(
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_arrange_with(
-    df: ExDataFrame,
+    data: ExDataFrame,
     expressions: Vec<ExExpr>,
     directions: Vec<bool>,
     groups: Vec<String>,
 ) -> Result<ExDataFrame, ExplorerError> {
+    let df = data.clone_inner();
     let exprs = ex_expr_to_exprs(expressions);
 
     let new_df = if groups.is_empty() {
-        df.clone()
-            .lazy()
+        df.lazy()
             .sort_by_exprs(exprs, directions, false)
             .collect()?
     } else {
@@ -405,7 +405,7 @@ pub fn df_mutate_with_exprs(
 ) -> Result<ExDataFrame, ExplorerError> {
     let mutations = ex_expr_to_exprs(columns);
     let new_df = if groups.is_empty() {
-        df.clone().lazy().with_columns(mutations).collect()?
+        df.clone_inner().lazy().with_columns(mutations).collect()?
     } else {
         df.groupby_stable(groups)?
             .apply(|df| df.lazy().with_columns(&mutations).collect())?
@@ -469,7 +469,7 @@ pub fn df_summarise_with_exprs(
     let aggs = ex_expr_to_exprs(aggs);
 
     let new_df = df
-        .clone()
+        .clone_inner()
         .lazy()
         .groupby_stable(groups)
         .agg(aggs)
@@ -497,6 +497,6 @@ pub fn df_pivot_wider(
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_to_lazy(df: ExDataFrame) -> Result<ExLazyFrame, ExplorerError> {
-    let new_lf = df.clone().lazy();
+    let new_lf = df.clone_inner().lazy();
     Ok(ExLazyFrame::new(new_lf))
 }

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -167,9 +167,7 @@ pub fn df_select(df: ExDataFrame, selection: Vec<&str>) -> Result<ExDataFrame, E
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_mask(df: ExDataFrame, mask: ExSeries) -> Result<ExDataFrame, ExplorerError> {
-    let filter_series = mask.clone_inner();
-
-    if let Ok(ca) = filter_series.bool() {
+    if let Ok(ca) = mask.bool() {
         let new_df = df.filter(ca)?;
         Ok(ExDataFrame::new(new_df))
     } else {
@@ -212,7 +210,7 @@ pub fn df_slice_by_indices(
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_slice_by_series(df: ExDataFrame, series: ExSeries) -> Result<ExDataFrame, ExplorerError> {
-    let cast = series.clone_inner().cast(&DataType::UInt32)?;
+    let cast = series.cast(&DataType::UInt32)?;
     Ok(ExDataFrame::new(df.take(cast.u32()?)?))
 }
 

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -115,7 +115,7 @@ pub fn df_to_csv(
     CsvWriter::new(&mut buf_writer)
         .has_header(has_headers)
         .with_delimiter(delimiter)
-        .finish(&mut data.clone_inner())?;
+        .finish(&mut data.clone())?;
     Ok(())
 }
 
@@ -131,7 +131,7 @@ pub fn df_dump_csv(
     CsvWriter::new(&mut buf)
         .has_header(has_headers)
         .with_delimiter(delimiter)
-        .finish(&mut data.clone_inner())?;
+        .finish(&mut data.clone())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
     values_binary.copy_from_slice(&buf);
@@ -210,7 +210,7 @@ pub fn df_to_parquet(
 
     ParquetWriter::new(&mut buf_writer)
         .with_compression(compression)
-        .finish(&mut data.clone_inner())?;
+        .finish(&mut data.clone())?;
     Ok(())
 }
 
@@ -226,7 +226,7 @@ pub fn df_dump_parquet(
 
     ParquetWriter::new(&mut buf)
         .with_compression(compression)
-        .finish(&mut data.clone_inner())?;
+        .finish(&mut data.clone())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
     values_binary.copy_from_slice(&buf);
@@ -276,7 +276,7 @@ pub fn df_to_ipc(
     let mut buf_writer = BufWriter::new(file);
     IpcWriter::new(&mut buf_writer)
         .with_compression(compression)
-        .finish(&mut data.clone_inner())?;
+        .finish(&mut data.clone())?;
     Ok(())
 }
 
@@ -297,7 +297,7 @@ pub fn df_dump_ipc<'a>(
 
     IpcWriter::new(&mut buf)
         .with_compression(compression)
-        .finish(&mut data.clone_inner())?;
+        .finish(&mut data.clone())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
     values_binary.copy_from_slice(&buf);
@@ -352,7 +352,7 @@ pub fn df_to_ipc_stream(
     let mut file = File::create(filename).expect("could not create file");
     IpcStreamWriter::new(&mut file)
         .with_compression(compression)
-        .finish(&mut data.clone_inner())?;
+        .finish(&mut data.clone())?;
     Ok(())
 }
 
@@ -373,7 +373,7 @@ pub fn df_dump_ipc_stream<'a>(
 
     IpcStreamWriter::new(&mut buf)
         .with_compression(compression)
-        .finish(&mut data.clone_inner())?;
+        .finish(&mut data.clone())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
     values_binary.copy_from_slice(&buf);
@@ -422,7 +422,7 @@ pub fn df_to_ndjson(data: ExDataFrame, filename: &str) -> Result<(), ExplorerErr
 
     JsonWriter::new(&mut buf_writer)
         .with_json_format(JsonFormat::JsonLines)
-        .finish(&mut data.clone_inner())?;
+        .finish(&mut data.clone())?;
     Ok(())
 }
 
@@ -433,7 +433,7 @@ pub fn df_dump_ndjson(env: Env, data: ExDataFrame) -> Result<Binary, ExplorerErr
 
     JsonWriter::new(&mut buf)
         .with_json_format(JsonFormat::JsonLines)
-        .finish(&mut data.clone_inner())?;
+        .finish(&mut data.clone())?;
 
     let mut values_binary = NewBinary::new(env, buf.len());
     values_binary.copy_from_slice(&buf);

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -4,12 +4,19 @@ use chrono::prelude::*;
 use polars::prelude::*;
 use rustler::{Atom, NifStruct, NifTaggedEnum, ResourceArc};
 use std::convert::TryInto;
+use std::ops::Deref;
 
 pub struct ExDataFrameRef(pub DataFrame);
 pub struct ExExprRef(pub Expr);
 pub struct ExLazyFrameRef(pub LazyFrame);
 pub struct ExSeriesRef(pub Series);
 
+// The structs that start with "Ex" are related to the modules in Elixir.
+// Some of them are just wrappers around Polars data structs.
+// For example, a "ExDataFrame" is a wrapper around Polars' "DataFrame".
+//
+// In order to facilitate the usage of these structs, we implement the
+// "Deref" trait that points to the Polars' equivalent.
 #[derive(NifStruct)]
 #[module = "Explorer.PolarsBackend.DataFrame"]
 pub struct ExDataFrame {
@@ -68,6 +75,15 @@ impl ExDataFrame {
     // Returns a clone of the DataFrame inside the ResourceArc container.
     pub fn clone_inner(&self) -> DataFrame {
         self.resource.0.clone()
+    }
+}
+
+// Implement Deref so we can call `DataFrame` functions directly from a `ExDataFrame` struct.
+impl Deref for ExDataFrame {
+    type Target = DataFrame;
+
+    fn deref(&self) -> &Self::Target {
+        &self.resource.0
     }
 }
 

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -17,6 +17,9 @@ pub struct ExSeriesRef(pub Series);
 //
 // In order to facilitate the usage of these structs, we implement the
 // "Deref" trait that points to the Polars' equivalent.
+//
+// See a detailed explanation in this chapter of the Rust Book:
+// https://doc.rust-lang.org/nightly/book/ch15-02-deref.html
 #[derive(NifStruct)]
 #[module = "Explorer.PolarsBackend.DataFrame"]
 pub struct ExDataFrame {
@@ -100,6 +103,15 @@ impl ExExpr {
     }
 }
 
+// Implement Deref so we can call `Expr` functions directly from a `ExExpr` struct.
+impl Deref for ExExpr {
+    type Target = Expr;
+
+    fn deref(&self) -> &Self::Target {
+        &self.resource.0
+    }
+}
+
 impl ExLazyFrame {
     pub fn new(df: LazyFrame) -> Self {
         Self {
@@ -110,6 +122,15 @@ impl ExLazyFrame {
     // Returns a clone of the LazyFrame inside the ResourceArc container.
     pub fn clone_inner(&self) -> LazyFrame {
         self.resource.0.clone()
+    }
+}
+
+// Implement Deref so we can call `LazyFrame` functions directly from a `ExLazyFrame` struct.
+impl Deref for ExLazyFrame {
+    type Target = LazyFrame;
+
+    fn deref(&self) -> &Self::Target {
+        &self.resource.0
     }
 }
 
@@ -124,13 +145,14 @@ impl ExSeries {
     pub fn clone_inner(&self) -> Series {
         self.resource.0.clone()
     }
+}
 
-    pub fn name(&self) -> &str {
-        self.resource.0.name()
-    }
+// Implement Deref so we can call `Series` functions directly from a `ExSeries` struct.
+impl Deref for ExSeries {
+    type Target = Series;
 
-    pub fn dtype(&self) -> &DataType {
-        self.resource.0.dtype()
+    fn deref(&self) -> &Self::Target {
+        &self.resource.0
     }
 }
 

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -490,9 +490,7 @@ pub fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Result<Term<'b>, Explor
     }
 }
 
-pub fn list_from_series(data: ExSeries, env: Env) -> Result<Term, ExplorerError> {
-    let s = data.clone_inner();
-
+pub fn list_from_series(s: ExSeries, env: Env) -> Result<Term, ExplorerError> {
     match s.dtype() {
         DataType::Boolean => series_to_list!(s, env, bool),
         DataType::Int64 => series_to_list!(s, env, i64),
@@ -501,10 +499,10 @@ pub fn list_from_series(data: ExSeries, env: Env) -> Result<Term, ExplorerError>
         DataType::Time => time_series_to_list(&s, env),
         DataType::Datetime(time_unit, None) => datetime_series_to_list(&s, *time_unit, env),
         DataType::Utf8 => {
-            generic_binary_series_to_list(&data.resource, s.utf8()?.downcast_iter(), env)
+            generic_binary_series_to_list(&s.resource, s.utf8()?.downcast_iter(), env)
         }
         DataType::Binary => {
-            generic_binary_series_to_list(&data.resource, s.binary()?.downcast_iter(), env)
+            generic_binary_series_to_list(&s.resource, s.binary()?.downcast_iter(), env)
         }
         DataType::Categorical(Some(mapping)) => categorical_series_to_list(&s, env, mapping),
         dt => panic!("to_list/1 not implemented for {dt:?}"),
@@ -512,9 +510,8 @@ pub fn list_from_series(data: ExSeries, env: Env) -> Result<Term, ExplorerError>
 }
 
 #[allow(clippy::size_of_in_element_count)]
-pub fn iovec_from_series(data: ExSeries, env: Env) -> Result<Term, ExplorerError> {
-    let s = data.clone_inner();
-    let resource = &data.resource;
+pub fn iovec_from_series(s: ExSeries, env: Env) -> Result<Term, ExplorerError> {
+    let resource = &s.resource;
 
     match s.dtype() {
         DataType::Boolean => {

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -5,7 +5,7 @@
 // wrapped in an Elixir struct.
 
 use chrono::{NaiveDate, NaiveDateTime};
-use polars::prelude::{col, when, DataFrame, IntoLazy, LiteralValue, SortOptions};
+use polars::prelude::{col, when, IntoLazy, LiteralValue, SortOptions};
 use polars::prelude::{DataType, Expr, Literal};
 
 use crate::datatypes::{ExDate, ExDateTime};
@@ -573,7 +573,7 @@ pub fn expr_unary_not(expr: ExExpr) -> ExExpr {
 
 #[rustler::nif]
 pub fn expr_describe_filter_plan(data: ExDataFrame, expr: ExExpr) -> String {
-    let df: DataFrame = data.clone_inner();
+    let df = data.clone();
     let expressions = expr.clone_inner();
     df.lazy().filter(expressions).describe_plan()
 }

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -312,7 +312,9 @@ pub fn s_series_equal(
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_equal(lhs: ExSeries, rhs: ExSeries) -> Result<ExSeries, ExplorerError> {
-    Ok(ExSeries::new(lhs.clone_inner().equal(&rhs.clone_inner())?.into_series()))
+    Ok(ExSeries::new(
+        lhs.clone_inner().equal(&rhs.clone_inner())?.into_series(),
+    ))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
@@ -426,7 +428,10 @@ pub fn s_fill_missing_with_float(series: ExSeries, float: f64) -> Result<ExSerie
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_fill_missing_with_bin(series: ExSeries, binary: Binary) -> Result<ExSeries, ExplorerError> {
+pub fn s_fill_missing_with_bin(
+    series: ExSeries,
+    binary: Binary,
+) -> Result<ExSeries, ExplorerError> {
     let s = match series.dtype() {
         DataType::Utf8 => {
             if let Ok(string) = std::str::from_utf8(&binary) {
@@ -435,7 +440,10 @@ pub fn s_fill_missing_with_bin(series: ExSeries, binary: Binary) -> Result<ExSer
                 return Err(ExplorerError::Other("cannot cast to string".into()));
             }
         }
-        DataType::Binary => series.binary()?.fill_null_with_values(&binary)?.into_series(),
+        DataType::Binary => series
+            .binary()?
+            .fill_null_with_values(&binary)?
+            .into_series(),
         dt => panic!("fill_missing/2 not implemented for {dt:?}"),
     };
     Ok(ExSeries::new(s))
@@ -453,81 +461,75 @@ pub fn s_fill_missing_with_date(series: ExSeries, date: ExDate) -> Result<ExSeri
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_fill_missing_with_datetime(
-    data: ExSeries,
+    series: ExSeries,
     datetime: ExDateTime,
 ) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
-    let s = s
+    let s = series
         .datetime()?
         .fill_null_with_values(datetime.into())?
-        .cast(s.dtype())?
+        .cast(series.dtype())?
         .into_series();
     Ok(ExSeries::new(s))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_fill_missing_with_boolean(
-    data: ExSeries,
+    series: ExSeries,
     boolean: bool,
 ) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
-    let s = s.bool()?.fill_null_with_values(boolean)?.into_series();
+    let s = series.bool()?.fill_null_with_values(boolean)?.into_series();
     Ok(ExSeries::new(s))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_window_sum(
-    data: ExSeries,
+    series: ExSeries,
     window_size: usize,
     weights: Option<Vec<f64>>,
     min_periods: Option<usize>,
     center: bool,
 ) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
     let opts = rolling_opts(window_size, weights, min_periods, center);
-    let s1 = s.rolling_sum(opts.into())?;
+    let s1 = series.rolling_sum(opts.into())?;
     Ok(ExSeries::new(s1))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_window_mean(
-    data: ExSeries,
+    series: ExSeries,
     window_size: usize,
     weights: Option<Vec<f64>>,
     min_periods: Option<usize>,
     center: bool,
 ) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
     let opts = rolling_opts(window_size, weights, min_periods, center);
-    let s1 = s.rolling_mean(opts.into())?;
+    let s1 = series.rolling_mean(opts.into())?;
     Ok(ExSeries::new(s1))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_window_max(
-    data: ExSeries,
+    series: ExSeries,
     window_size: usize,
     weights: Option<Vec<f64>>,
     min_periods: Option<usize>,
     center: bool,
 ) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
     let opts = rolling_opts(window_size, weights, min_periods, center);
-    let s1 = s.rolling_max(opts.into())?;
+    let s1 = series.rolling_max(opts.into())?;
     Ok(ExSeries::new(s1))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_window_min(
-    data: ExSeries,
+    series: ExSeries,
     window_size: usize,
     weights: Option<Vec<f64>>,
     min_periods: Option<usize>,
     center: bool,
 ) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
     let opts = rolling_opts(window_size, weights, min_periods, center);
-    let s1 = s.rolling_min(opts.into())?;
+    let s1 = series.rolling_min(opts.into())?;
     Ok(ExSeries::new(s1))
 }
 
@@ -560,19 +562,18 @@ pub fn s_to_list(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_to_iovec(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
-    if data.resource.0.null_count() != 0 {
+pub fn s_to_iovec(env: Env, series: ExSeries) -> Result<Term, ExplorerError> {
+    if series.null_count() != 0 {
         Err(ExplorerError::Other(String::from(
             "cannot invoke to_iovec on series with nils",
         )))
     } else {
-        encoding::iovec_from_series(data, env)
+        encoding::iovec_from_series(series, env)
     }
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_sum(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_sum(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
     match s.dtype() {
         DataType::Boolean => Ok(s.sum::<i64>().encode(env)),
         DataType::Int64 => Ok(s.sum::<i64>().encode(env)),
@@ -582,8 +583,7 @@ pub fn s_sum(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_min(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_min(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
     match s.dtype() {
         DataType::Int64 => Ok(s.min::<i64>().encode(env)),
         DataType::Float64 => Ok(s.min::<f64>().encode(env)),
@@ -597,8 +597,7 @@ pub fn s_min(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_max(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_max(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
     match s.dtype() {
         DataType::Int64 => Ok(s.max::<i64>().encode(env)),
         DataType::Float64 => Ok(s.max::<f64>().encode(env)),
@@ -612,8 +611,7 @@ pub fn s_max(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_mean(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_mean(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
     match s.dtype() {
         DataType::Boolean => Ok(s.mean().encode(env)),
         DataType::Int64 | DataType::Float64 => Ok(s.mean().encode(env)),
@@ -622,8 +620,7 @@ pub fn s_mean(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_median(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_median(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
     match s.dtype() {
         DataType::Int64 | DataType::Float64 => Ok(s.median().encode(env)),
         dt => panic!("median/1 not implemented for {dt:?}"),
@@ -631,8 +628,7 @@ pub fn s_median(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_variance(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_variance(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
     match s.dtype() {
         DataType::Int64 => Ok(s.i64()?.var(1).encode(env)),
         DataType::Float64 => Ok(s.f64()?.var(1).encode(env)),
@@ -641,8 +637,7 @@ pub fn s_variance(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_standard_deviation(env: Env, data: ExSeries) -> Result<Term, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_standard_deviation(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
     match s.dtype() {
         DataType::Int64 => Ok(s.i64()?.std(1).encode(env)),
         DataType::Float64 => Ok(s.f64()?.std(1).encode(env)),
@@ -651,37 +646,32 @@ pub fn s_standard_deviation(env: Env, data: ExSeries) -> Result<Term, ExplorerEr
 }
 
 #[rustler::nif]
-pub fn s_at(env: Env, data: ExSeries, idx: usize) -> Result<Term, ExplorerError> {
-    let s = data.clone_inner();
-    encoding::resource_term_from_value(&data.resource, s.get(idx)?, env)
+pub fn s_at(env: Env, series: ExSeries, idx: usize) -> Result<Term, ExplorerError> {
+    encoding::resource_term_from_value(&series.resource, series.get(idx)?, env)
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_cumulative_sum(data: ExSeries, reverse: bool) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
-    Ok(ExSeries::new(s.cumsum(reverse)))
+pub fn s_cumulative_sum(series: ExSeries, reverse: bool) -> Result<ExSeries, ExplorerError> {
+    Ok(ExSeries::new(series.cumsum(reverse)))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_cumulative_max(data: ExSeries, reverse: bool) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
-    Ok(ExSeries::new(s.cummax(reverse)))
+pub fn s_cumulative_max(series: ExSeries, reverse: bool) -> Result<ExSeries, ExplorerError> {
+    Ok(ExSeries::new(series.cummax(reverse)))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_cumulative_min(data: ExSeries, reverse: bool) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
-    Ok(ExSeries::new(s.cummin(reverse)))
+pub fn s_cumulative_min(series: ExSeries, reverse: bool) -> Result<ExSeries, ExplorerError> {
+    Ok(ExSeries::new(series.cummin(reverse)))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_quantile<'a>(
     env: Env<'a>,
-    data: ExSeries,
+    s: ExSeries,
     quantile: f64,
     strategy: &str,
 ) -> Result<Term<'a>, ExplorerError> {
-    let s = data.clone_inner();
     let dtype = s.dtype();
     let strategy = parse_quantile_interpol_options(strategy);
     match dtype {
@@ -709,38 +699,31 @@ pub fn s_quantile<'a>(
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_peak_max(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_peak_max(s: ExSeries) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s.peak_max().into_series()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_peak_min(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_peak_min(s: ExSeries) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s.peak_min().into_series()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_reverse(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_reverse(s: ExSeries) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s.reverse()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_n_distinct(data: ExSeries) -> Result<usize, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_n_distinct(s: ExSeries) -> Result<usize, ExplorerError> {
     Ok(s.n_unique()?)
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_pow(data: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s = &data.resource.0;
-    let s1 = &other.resource.0;
-
+pub fn s_pow(s: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
     let iter1 = s.i64()?.into_iter();
-    match s1.strict_cast(&DataType::UInt32) {
-        Ok(s1) => {
-            let iter2 = s1.u32()?.into_iter();
+    match other.strict_cast(&DataType::UInt32) {
+        Ok(casted) => {
+            let iter2 = casted.u32()?.into_iter();
 
             let s = iter1
                 .zip(iter2)
@@ -756,8 +739,7 @@ pub fn s_pow(data: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError>
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_pow_f_rhs(data: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_pow_f_rhs(s: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
     let s = s
         .cast(&DataType::Float64)?
         .f64()?
@@ -767,8 +749,7 @@ pub fn s_pow_f_rhs(data: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerEr
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_pow_f_lhs(data: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_pow_f_lhs(s: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
     let s = s
         .cast(&DataType::Float64)?
         .f64()?
@@ -778,16 +759,13 @@ pub fn s_pow_f_lhs(data: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerEr
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_pow_i_rhs(data: ExSeries, exponent: u32) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_pow_i_rhs(s: ExSeries, exponent: u32) -> Result<ExSeries, ExplorerError> {
     let s = s.i64()?.apply(|v| v.pow(exponent)).into_series();
     Ok(ExSeries::new(s))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_pow_i_lhs(data: ExSeries, base: u32) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
-
+pub fn s_pow_i_lhs(s: ExSeries, base: u32) -> Result<ExSeries, ExplorerError> {
     let s = s
         .i64()?
         .try_apply(|v| match u32::try_from(v) {
@@ -802,8 +780,7 @@ pub fn s_pow_i_lhs(data: ExSeries, base: u32) -> Result<ExSeries, ExplorerError>
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_cast(data: ExSeries, to_type: &str) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_cast(s: ExSeries, to_type: &str) -> Result<ExSeries, ExplorerError> {
     let dtype = cast_str_to_dtype(to_type)?;
     Ok(ExSeries::new(s.cast(&dtype)?))
 }
@@ -832,8 +809,7 @@ pub fn cast_str_to_f64(atom: &str) -> f64 {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_categories(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_categories(s: ExSeries) -> Result<ExSeries, ExplorerError> {
     match s.dtype() {
         DataType::Categorical(Some(mapping)) => {
             let size = mapping.len() as u32;
@@ -846,9 +822,7 @@ pub fn s_categories(data: ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_categorise(indices: ExSeries, categories: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s = indices.clone_inner();
-    let cat = categories.clone_inner();
+pub fn s_categorise(s: ExSeries, cat: ExSeries) -> Result<ExSeries, ExplorerError> {
     let chunks = s.cast(&DataType::UInt32)?.u32()?.clone();
 
     match cat.dtype() {
@@ -920,9 +894,7 @@ pub fn parse_quantile_interpol_options(strategy: &str) -> QuantileInterpolOption
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_coalesce(data: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s1 = data.clone_inner();
-    let s2 = other.clone_inner();
+pub fn s_coalesce(s1: ExSeries, s2: ExSeries) -> Result<ExSeries, ExplorerError> {
     let coalesced = s1.zip_with(&s1.is_not_null(), &s2)?;
     Ok(ExSeries::new(coalesced))
 }
@@ -933,13 +905,8 @@ pub fn s_select(
     on_true: ExSeries,
     on_false: ExSeries,
 ) -> Result<ExSeries, ExplorerError> {
-    let s1 = pred.clone_inner();
-
-    if let Ok(ca) = s1.bool() {
-        let s2 = on_true.clone_inner();
-        let s3 = on_false.clone_inner();
-
-        let selected = s2.zip_with(ca, &s3)?;
+    if let Ok(ca) = pred.bool() {
+        let selected = on_true.zip_with(ca, &on_false)?;
         Ok(ExSeries::new(selected))
     } else {
         Err(ExplorerError::Other("Expected a boolean mask".into()))
@@ -947,8 +914,7 @@ pub fn s_select(
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_not(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s1 = data.clone_inner();
+pub fn s_not(s1: ExSeries) -> Result<ExSeries, ExplorerError> {
     let s2 = s1
         .bool()
         .unwrap()
@@ -960,26 +926,22 @@ pub fn s_not(data: ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_contains(data: ExSeries, pattern: &str) -> Result<ExSeries, ExplorerError> {
-    let s1 = data.clone_inner();
+pub fn s_contains(s1: ExSeries, pattern: &str) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s1.utf8()?.contains(pattern)?.into()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_upcase(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s1 = data.clone_inner();
+pub fn s_upcase(s1: ExSeries) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s1.utf8()?.to_uppercase().into()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_downcase(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s1 = data.clone_inner();
+pub fn s_downcase(s1: ExSeries) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s1.utf8()?.to_lowercase().into()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_trim(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s1 = data.clone_inner();
+pub fn s_trim(s1: ExSeries) -> Result<ExSeries, ExplorerError> {
     // There are no eager strip functions.
     Ok(ExSeries::new(
         s1.utf8()?.replace(r#"^[ \s]+|[ \s]+$"#, "")?.into(),
@@ -987,41 +949,34 @@ pub fn s_trim(data: ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_trim_leading(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s1 = data.clone_inner();
+pub fn s_trim_leading(s1: ExSeries) -> Result<ExSeries, ExplorerError> {
     // There are no eager strip functions.
     Ok(ExSeries::new(s1.utf8()?.replace(r#"^[ \s]+"#, "")?.into()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_trim_trailing(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s1 = data.clone_inner();
+pub fn s_trim_trailing(s1: ExSeries) -> Result<ExSeries, ExplorerError> {
     // There are no eager strip functions.
     Ok(ExSeries::new(s1.utf8()?.replace(r#"[ \s]+$"#, "")?.into()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_round(data: ExSeries, decimals: u32) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_round(s: ExSeries, decimals: u32) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s.round(decimals)?.into_series()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_floor(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_floor(s: ExSeries) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s.floor()?.into_series()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_ceil(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
+pub fn s_ceil(s: ExSeries) -> Result<ExSeries, ExplorerError> {
     Ok(ExSeries::new(s.ceil()?.into_series()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_day_of_week(data: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let s = data.clone_inner();
-
+pub fn s_day_of_week(s: ExSeries) -> Result<ExSeries, ExplorerError> {
     let s2 = match s.dtype() {
         DataType::Date => s
             .date()?


### PR DESCRIPTION
This change makes our structs behave like they were Polars structs: you can call `DataFrame` functions in our `ExDataFrame` struct.
This is possible because of the deref trait of Rust, that makes easier to work with the data that is "inside a box".

This is better than the previous version because it avoids unnecessary clones, since Polars is clonning the data on each operations most of the time. It also makes easier to implement new features.

The only drawback is that operations that consume the data (don't borrow) still need a cloned data. So most of the LazyFrame and Expr operations need to keep being cloned.

---
Inspirations:

* https://rauljordan.com/rust-concepts-i-wish-i-learned-earlier/#implement-deref-to-make-your-code-cleaner
* https://doc.rust-lang.org/nightly/book/ch15-02-deref.html
* my friend @lsunsi :heart: 
