### PR TITLE
add max_rows and columns options to from_parquet

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -59,7 +59,11 @@ defmodule Explorer.Backend.DataFrame do
             ) :: result(df)
 
   # IO: Parquet
-  @callback from_parquet(filename :: String.t()) :: result(df)
+  @callback from_parquet(
+              filename :: String.t(),
+              max_rows :: integer() | nil,
+              columns :: columns_for_io()
+            ) :: result(df)
   @callback to_parquet(
               df,
               filename :: String.t(),

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -536,13 +536,30 @@ defmodule Explorer.DataFrame do
 
   @doc """
   Reads a parquet file into a dataframe.
+
+  ## Options
+    * `:max_rows` - Maximum number of lines to read. (default: `nil`)
+    * `:columns` - A list of column names or indexes to keep. If present, only these columns are read into the dataframe. (default: `nil`)
   """
   @doc type: :io
   @spec from_parquet(filename :: String.t(), opts :: Keyword.t()) ::
           {:ok, DataFrame.t()} | {:error, term()}
   def from_parquet(filename, opts \\ []) do
-    backend = backend_from_options!(opts)
-    backend.from_parquet(filename)
+    {backend_opts, opts} = Keyword.split(opts, [:backend, :lazy])
+
+    opts =
+      Keyword.validate!(opts,
+        max_rows: nil,
+        columns: nil
+      )
+
+    backend = backend_from_options!(backend_opts)
+
+    backend.from_parquet(
+      filename,
+      opts[:max_rows],
+      to_columns_for_io(opts[:columns])
+    )
   end
 
   @doc """

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -538,8 +538,11 @@ defmodule Explorer.DataFrame do
   Reads a parquet file into a dataframe.
 
   ## Options
+
     * `:max_rows` - Maximum number of lines to read. (default: `nil`)
-    * `:columns` - A list of column names or indexes to keep. If present, only these columns are read into the dataframe. (default: `nil`)
+
+    * `:columns` - A list of column names or indexes to keep. If present,
+      only these columns are read into the dataframe. (default: `nil`)
   """
   @doc type: :io
   @spec from_parquet(filename :: String.t(), opts :: Keyword.t()) ::

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -176,8 +176,8 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def from_parquet(filename) do
-    case Native.df_from_parquet(filename) do
+  def from_parquet(filename, max_rows, columns) do
+    case Native.df_from_parquet(filename, max_rows, columns) do
       {:ok, df} -> {:ok, Shared.create_dataframe(df)}
       {:error, error} -> {:error, error}
     end

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -177,7 +177,17 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def from_parquet(filename, max_rows, columns) do
-    case Native.df_from_parquet(filename, max_rows, columns) do
+    {columns, with_projection} = column_names_or_projection(columns)
+
+    df =
+      Native.df_from_parquet(
+        filename,
+        max_rows,
+        columns,
+        with_projection
+      )
+
+    case df do
       {:ok, df} -> {:ok, Shared.create_dataframe(df)}
       {:error, error} -> {:error, error}
     end

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -113,8 +113,14 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     end
   end
 
+  # TODO
+
   @impl true
-  def from_parquet(filename) do
+  def from_parquet(
+        filename,
+        _max_rows,
+        _columns
+      ) do
     case Native.lf_from_parquet(filename) do
       {:ok, df} -> {:ok, Shared.create_dataframe(df)}
       {:error, error} -> {:error, error}
@@ -304,7 +310,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     Shared.apply_dataframe(df, out_df, :lf_summarise_with, [groups_exprs, exprs])
   end
 
-  # Two or more tables 
+  # Two or more tables
 
   @impl true
   def join(%DF{} = left, %DF{} = right, %DF{} = out_df, on, how)

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -113,14 +113,9 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     end
   end
 
-  # TODO
-
   @impl true
-  def from_parquet(
-        filename,
-        _max_rows,
-        _columns
-      ) do
+  def from_parquet(filename, _max_rows, _columns) do
+    # TODO pass max_rows, columns down to lf_from_parquet and handle logic
     case Native.lf_from_parquet(filename) do
       {:ok, df} -> {:ok, Shared.create_dataframe(df)}
       {:error, error} -> {:error, error}

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -114,9 +114,14 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def from_parquet(filename, _max_rows, _columns) do
-    # TODO pass max_rows, columns down to lf_from_parquet and handle logic
-    case Native.lf_from_parquet(filename) do
+  def from_parquet(filename, max_rows, columns) do
+    if columns do
+      raise ArgumentError,
+            "`columns` is not supported by Polars' lazy backend. " <>
+              "Consider using `select/2` after reading the parquet file"
+    end
+
+    case Native.lf_from_parquet(filename, max_rows) do
       {:ok, df} -> {:ok, Shared.create_dataframe(df)}
       {:error, error} -> {:error, error}
     end

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -163,7 +163,7 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_slice(_df, _offset, _length), do: err()
   def lf_from_ipc(_filename), do: err()
   def lf_from_ndjson(_filename, _infer_schema_length, _batch_size), do: err()
-  def lf_from_parquet(_filename), do: err()
+  def lf_from_parquet(_filename, _stop_after_n_rows), do: err()
 
   def lf_from_csv(
         _filename,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -64,7 +64,14 @@ defmodule Explorer.PolarsBackend.Native do
   def df_from_ipc(_filename, _columns, _projection), do: err()
   def df_from_ipc_stream(_filename, _columns, _projection), do: err()
   def df_from_ndjson(_filename, _infer_schema_length, _batch_size), do: err()
-  def df_from_parquet(_filename), do: err()
+
+  def df_from_parquet(
+        _filename,
+        _stop_after_n_rows,
+        _columns
+      ),
+      do: err()
+
   def df_from_series(_columns), do: err()
   def df_group_indices(_df, _column_names), do: err()
   def df_groups(_df, _column_names), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -68,7 +68,8 @@ defmodule Explorer.PolarsBackend.Native do
   def df_from_parquet(
         _filename,
         _stop_after_n_rows,
-        _columns
+        _columns,
+        _projection
       ),
       do: err()
 

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -189,10 +189,17 @@ pub fn df_load_csv(
 // ============ Parquet ============ //
 
 #[rustler::nif(schedule = "DirtyIo")]
-pub fn df_from_parquet(filename: &str) -> Result<ExDataFrame, ExplorerError> {
+pub fn df_from_parquet(
+    filename: &str,
+    stop_after_n_rows: Option<usize>,
+    column_names: Option<Vec<String>>,
+) -> Result<ExDataFrame, ExplorerError> {
     let file = File::open(filename)?;
     let buf_reader = BufReader::new(file);
-    let reader = ParquetReader::new(buf_reader);
+
+    let reader = ParquetReader::new(buf_reader)
+        .with_n_rows(stop_after_n_rows)
+        .with_columns(column_names);
 
     finish_reader(reader)
 }

--- a/native/explorer/src/dataframe/io.rs
+++ b/native/explorer/src/dataframe/io.rs
@@ -193,13 +193,15 @@ pub fn df_from_parquet(
     filename: &str,
     stop_after_n_rows: Option<usize>,
     column_names: Option<Vec<String>>,
+    projection: Option<Vec<usize>>,
 ) -> Result<ExDataFrame, ExplorerError> {
     let file = File::open(filename)?;
     let buf_reader = BufReader::new(file);
 
     let reader = ParquetReader::new(buf_reader)
         .with_n_rows(stop_after_n_rows)
-        .with_columns(column_names);
+        .with_columns(column_names)
+        .with_projection(projection);
 
     finish_reader(reader)
 }

--- a/native/explorer/src/lazyframe/io.rs
+++ b/native/explorer/src/lazyframe/io.rs
@@ -7,13 +7,16 @@ use crate::{ExLazyFrame, ExplorerError};
 
 #[rustler::nif]
 pub fn lf_from_parquet(
-  filename: &str,
-  stop_after_n_rows: Option<usize>,
+    filename: &str,
+    stop_after_n_rows: Option<usize>,
 ) -> Result<ExLazyFrame, ExplorerError> {
-  let options = ScanArgsParquet { n_rows: stop_after_n_rows, ..Default::default() };
-  let lf = LazyFrame::scan_parquet(filename, options)?;
+    let options = ScanArgsParquet {
+        n_rows: stop_after_n_rows,
+        ..Default::default()
+    };
+    let lf = LazyFrame::scan_parquet(filename, options)?;
 
-  Ok(ExLazyFrame::new(lf))
+    Ok(ExLazyFrame::new(lf))
 }
 
 #[rustler::nif(schedule = "DirtyIo")]

--- a/native/explorer/src/lazyframe/io.rs
+++ b/native/explorer/src/lazyframe/io.rs
@@ -6,9 +6,14 @@ use crate::datatypes::ExParquetCompression;
 use crate::{ExLazyFrame, ExplorerError};
 
 #[rustler::nif]
-pub fn lf_from_parquet(filename: &str) -> Result<ExLazyFrame, ExplorerError> {
-    let lf = LazyFrame::scan_parquet(filename, Default::default())?;
-    Ok(ExLazyFrame::new(lf))
+pub fn lf_from_parquet(
+  filename: &str,
+  stop_after_n_rows: Option<usize>,
+) -> Result<ExLazyFrame, ExplorerError> {
+  let options = ScanArgsParquet { n_rows: stop_after_n_rows, ..Default::default() };
+  let lf = LazyFrame::scan_parquet(filename, options)?;
+
+  Ok(ExLazyFrame::new(lf))
 }
 
 #[rustler::nif(schedule = "DirtyIo")]

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -126,7 +126,7 @@ defmodule Explorer.DataFrame.LazyTest do
 
     ldf = DF.from_csv!(path, lazy: true)
 
-    # no-op 
+    # no-op
     assert DF.to_lazy(ldf) == ldf
 
     df1 = DF.collect(ldf)
@@ -155,12 +155,38 @@ defmodule Explorer.DataFrame.LazyTest do
 
     ldf = DF.from_parquet!(path, lazy: true)
 
-    # no-op 
+    # no-op
     assert DF.to_lazy(ldf) == ldf
 
     df1 = DF.collect(ldf)
 
     assert DF.to_columns(df1) == DF.to_columns(df)
+  end
+
+  describe "from_parquet/2 - with options" do
+    @tag :tmp_dir
+    test "max_rows", %{df: df, tmp_dir: tmp_dir} do
+      path = Path.join([tmp_dir, "fossil_fuels.parquet"])
+      DF.to_parquet!(df, path)
+
+      ldf = DF.from_parquet!(path, lazy: true, max_rows: 1)
+
+      df1 = DF.collect(ldf)
+
+      assert DF.n_rows(df1) == 1
+    end
+
+    @tag :tmp_dir
+    test "columns", %{df: df, tmp_dir: tmp_dir} do
+      path = Path.join([tmp_dir, "fossil_fuels.parquet"])
+      DF.to_parquet!(df, path)
+
+      assert_raise ArgumentError,
+                   "`columns` is not supported by Polars' lazy backend. Consider using `select/2` after reading the parquet file",
+                   fn ->
+                     DF.from_parquet!(path, lazy: true, columns: ["country", "year", "total"])
+                   end
+    end
   end
 
   @tag :tmp_dir
@@ -184,7 +210,7 @@ defmodule Explorer.DataFrame.LazyTest do
 
     ldf = DF.from_ndjson!(path, lazy: true)
 
-    # no-op 
+    # no-op
     assert DF.to_lazy(ldf) == ldf
 
     df1 = DF.collect(ldf)
@@ -200,7 +226,7 @@ defmodule Explorer.DataFrame.LazyTest do
 
     ldf = DF.from_ipc!(path, lazy: true)
 
-    # no-op 
+    # no-op
     assert DF.to_lazy(ldf) == ldf
 
     df1 = DF.collect(ldf)
@@ -227,7 +253,7 @@ defmodule Explorer.DataFrame.LazyTest do
 
     ldf = DF.load_csv!(contents, lazy: true)
 
-    # no-op 
+    # no-op
     assert DF.to_lazy(ldf) == ldf
 
     df1 = DF.collect(ldf)
@@ -241,7 +267,7 @@ defmodule Explorer.DataFrame.LazyTest do
 
     ldf = DF.load_parquet!(contents, lazy: true)
 
-    # no-op 
+    # no-op
     assert DF.to_lazy(ldf) == ldf
 
     df1 = DF.collect(ldf)
@@ -255,7 +281,7 @@ defmodule Explorer.DataFrame.LazyTest do
 
     ldf = DF.load_ndjson!(contents, lazy: true)
 
-    # no-op 
+    # no-op
     assert DF.to_lazy(ldf) == ldf
 
     df1 = DF.collect(ldf)
@@ -269,7 +295,7 @@ defmodule Explorer.DataFrame.LazyTest do
 
     ldf = DF.load_ipc!(contents, lazy: true)
 
-    # no-op 
+    # no-op
     assert DF.to_lazy(ldf) == ldf
 
     df1 = DF.collect(ldf)
@@ -283,7 +309,7 @@ defmodule Explorer.DataFrame.LazyTest do
 
     ldf = DF.load_ipc_stream!(contents, lazy: true)
 
-    # no-op 
+    # no-op
     assert DF.to_lazy(ldf) == ldf
 
     df1 = DF.collect(ldf)

--- a/test/explorer/data_frame/parquet_test.exs
+++ b/test/explorer/data_frame/parquet_test.exs
@@ -36,6 +36,38 @@ defmodule Explorer.DataFrame.ParquetTest do
     assert File.read!(file_path) == File.read!(parquet)
   end
 
+  describe "from_parquet/2 options" do
+    test "max_rows" do
+      parquet = tmp_parquet_file!(Explorer.Datasets.iris())
+
+      {:ok, frame} = DF.from_parquet(parquet, max_rows: 1)
+
+      assert DF.n_rows(frame) == 1
+      assert DF.n_columns(frame) == 5
+    end
+
+    test "columns - str" do
+      parquet = tmp_parquet_file!(Explorer.Datasets.iris())
+      {:ok, frame} = DF.from_parquet(parquet, columns: ["sepal_length"])
+
+      assert DF.n_columns(frame) == 1
+    end
+
+    test "columns - atom" do
+      parquet = tmp_parquet_file!(Explorer.Datasets.iris())
+      {:ok, frame} = DF.from_parquet(parquet, columns: [:sepal_width, :petal_length])
+
+      assert DF.n_columns(frame) == 2
+    end
+
+    test "columns - integer" do
+      parquet = tmp_parquet_file!(Explorer.Datasets.iris())
+      {:ok, frame} = DF.from_parquet(parquet, columns: [3, 4])
+
+      assert DF.n_columns(frame) == 3
+    end
+  end
+
   test "load_parquet/2" do
     parquet = tmp_parquet_file!(Explorer.Datasets.iris())
     contents = File.read!(parquet)

--- a/test/explorer/data_frame/parquet_test.exs
+++ b/test/explorer/data_frame/parquet_test.exs
@@ -51,6 +51,7 @@ defmodule Explorer.DataFrame.ParquetTest do
       {:ok, frame} = DF.from_parquet(parquet, columns: ["sepal_length"])
 
       assert DF.n_columns(frame) == 1
+      assert DF.names(frame) == ["sepal_length"]
     end
 
     test "columns - atom" do
@@ -58,13 +59,15 @@ defmodule Explorer.DataFrame.ParquetTest do
       {:ok, frame} = DF.from_parquet(parquet, columns: [:sepal_width, :petal_length])
 
       assert DF.n_columns(frame) == 2
+      assert DF.names(frame) == ["sepal_width", "petal_length"]
     end
 
-    test "columns - integer" do
+    test "columns - integer 0 indexed" do
       parquet = tmp_parquet_file!(Explorer.Datasets.iris())
-      {:ok, frame} = DF.from_parquet(parquet, columns: [3, 4])
+      {:ok, frame} = DF.from_parquet(parquet, columns: [2, 3, 4])
 
       assert DF.n_columns(frame) == 3
+      assert DF.names(frame) == ["petal_length", "petal_width", "species"]
     end
   end
 


### PR DESCRIPTION
Add `max_rows` and `columns` options to `DataFrame.from_parquet/2` -- inspired by the options available in `DataFrame.from_csv/2` and in [polars.read_parquet](https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.read_parquet.html) and [ParquetReader](https://pola-rs.github.io/polars/polars/prelude/struct.ParquetReader.html#)

**TODO:** I could use guidance on if/how this should be applied to the lazy backend.