### PR TITLE
Allows Series functions to receive nan, infinity, and neg_infinity values

### DIFF
--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -203,8 +203,11 @@ defmodule Explorer.PolarsBackend.Series do
   def subtract(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_subtract, [right.data])
 
-  def subtract(left, right) when is_number(right), do: apply_scalar_on_rhs(:subtract, left, right)
-  def subtract(left, right) when is_number(left), do: apply_scalar_on_lhs(:subtract, left, right)
+  def subtract(left, right) when is_number(right) or right in [:nan, :infinity, :neg_infinity],
+    do: apply_scalar_on_rhs(:subtract, left, right)
+
+  def subtract(left, right) when is_number(left) or left in [:nan, :infinity, :neg_infinity],
+    do: apply_scalar_on_lhs(:subtract, left, right)
 
   @impl true
   def multiply(%Series{} = left, %Series{} = right),

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -252,7 +252,7 @@ defmodule Explorer.PolarsBackend.Series do
   def pow(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_pow, [right.data])
 
-  def pow(left, exponent) when is_float(exponent),
+  def pow(left, exponent) when is_float(exponent) or exponent in [:nan, :infinity, :neg_infinity],
     do: Shared.apply_series(left, :s_pow_f_rhs, [exponent])
 
   def pow(left, exponent) when is_integer(exponent) and exponent >= 0 do
@@ -262,8 +262,9 @@ defmodule Explorer.PolarsBackend.Series do
     end
   end
 
-  def pow(exponent, right) when is_float(exponent),
-    do: Shared.apply_series(right, :s_pow_f_lhs, [exponent])
+  def pow(exponent, right)
+      when is_float(exponent) or exponent in [:nan, :infinity, :neg_infinity],
+      do: Shared.apply_series(right, :s_pow_f_lhs, [exponent])
 
   def pow(exponent, right) when is_integer(exponent) and exponent >= 0 do
     cond do

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -193,8 +193,11 @@ defmodule Explorer.PolarsBackend.Series do
   def add(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_add, [right.data])
 
-  def add(left, right) when is_number(right), do: apply_scalar_on_rhs(:add, left, right)
-  def add(left, right) when is_number(left), do: apply_scalar_on_lhs(:add, left, right)
+  def add(left, right) when is_number(right) or right in [:nan, :infinity, :neg_infinity],
+    do: apply_scalar_on_rhs(:add, left, right)
+
+  def add(left, right) when is_number(left) or left in [:nan, :infinity, :neg_infinity],
+    do: apply_scalar_on_lhs(:add, left, right)
 
   @impl true
   def subtract(%Series{} = left, %Series{} = right),

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -223,8 +223,11 @@ defmodule Explorer.PolarsBackend.Series do
   def divide(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_divide, [right.data])
 
-  def divide(left, right) when is_number(right), do: apply_scalar_on_rhs(:divide, left, right)
-  def divide(left, right) when is_number(left), do: apply_scalar_on_lhs(:divide, left, right)
+  def divide(left, right) when is_number(right) or right in [:nan, :infinity, :neg_infinity],
+    do: apply_scalar_on_rhs(:divide, left, right)
+
+  def divide(left, right) when is_number(left) or left in [:nan, :infinity, :neg_infinity],
+    do: apply_scalar_on_lhs(:divide, left, right)
 
   @impl true
   def quotient(%Series{} = left, %Series{} = right),

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -213,8 +213,11 @@ defmodule Explorer.PolarsBackend.Series do
   def multiply(%Series{} = left, %Series{} = right),
     do: Shared.apply_series(left, :s_multiply, [right.data])
 
-  def multiply(left, right) when is_number(right), do: apply_scalar_on_rhs(:multiply, left, right)
-  def multiply(left, right) when is_number(left), do: apply_scalar_on_lhs(:multiply, left, right)
+  def multiply(left, right) when is_number(right) or right in [:nan, :infinity, :neg_infinity],
+    do: apply_scalar_on_rhs(:multiply, left, right)
+
+  def multiply(left, right) when is_number(left) or left in [:nan, :infinity, :neg_infinity],
+    do: apply_scalar_on_lhs(:multiply, left, right)
 
   @impl true
   def divide(%Series{} = left, %Series{} = right),

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -79,11 +79,11 @@ defmodule Explorer.Series do
   @compile {:no_warn_undefined, Nx}
 
   defguardp is_numerical(n) when K.or(is_number(n), K.in(n, [:nan, :infinity, :neg_infinity]))
-  defguardp io_dtype?(dtype) when K.not(K.in(dtype, [:binary, :string]))
-  defguardp numeric_dtype?(dtype) when K.in(dtype, [:float, :integer])
-  defguardp numeric_or_bool_dtype?(dtype) when K.in(dtype, [:float, :integer, :boolean])
+  defguardp is_io_dtype(dtype) when K.not(K.in(dtype, [:binary, :string]))
+  defguardp is_numeric_dtype(dtype) when K.in(dtype, [:float, :integer])
+  defguardp is_numeric_or_bool_dtype(dtype) when K.in(dtype, [:float, :integer, :boolean])
 
-  defguardp numeric_or_date_dtype?(dtype)
+  defguardp is_numeric_or_date_dtype(dtype)
             when K.in(dtype, [:float, :integer, :date, :time, :datetime])
 
   @impl true
@@ -620,7 +620,7 @@ defmodule Explorer.Series do
   @doc type: :conversion
   @spec to_iovec(series :: Series.t()) :: [binary]
   def to_iovec(%Series{dtype: dtype} = series) do
-    if io_dtype?(dtype) do
+    if is_io_dtype(dtype) do
       Shared.apply_impl(series, :to_iovec)
     else
       raise ArgumentError, "cannot convert series of dtype #{inspect(dtype)} into iovec"
@@ -870,7 +870,7 @@ defmodule Explorer.Series do
   @doc type: :introspection
   @spec iotype(series :: Series.t()) :: {:s | :u | :f, non_neg_integer()} | :none
   def iotype(%Series{dtype: dtype} = series) do
-    if io_dtype?(dtype) do
+    if is_io_dtype(dtype) do
       Shared.apply_impl(series, :iotype)
     else
       :none
@@ -1068,7 +1068,7 @@ defmodule Explorer.Series do
     end
 
     cond do
-      K.and(numeric_dtype?(on_true_dtype), numeric_dtype?(on_false_dtype)) ->
+      K.and(is_numeric_dtype(on_true_dtype), is_numeric_dtype(on_false_dtype)) ->
         Shared.apply_impl(predicate, :select, [on_true, on_false])
 
       on_true_dtype == on_false_dtype ->
@@ -1444,7 +1444,7 @@ defmodule Explorer.Series do
   """
   @doc type: :aggregation
   @spec sum(series :: Series.t()) :: number() | nil
-  def sum(%Series{dtype: dtype} = series) when numeric_or_bool_dtype?(dtype),
+  def sum(%Series{dtype: dtype} = series) when is_numeric_or_bool_dtype(dtype),
     do: Shared.apply_impl(series, :sum)
 
   def sum(%Series{dtype: dtype}), do: dtype_error("sum/1", dtype, [:integer, :float, :boolean])
@@ -1488,7 +1488,7 @@ defmodule Explorer.Series do
   """
   @doc type: :aggregation
   @spec min(series :: Series.t()) :: number() | Date.t() | Time.t() | NaiveDateTime.t() | nil
-  def min(%Series{dtype: dtype} = series) when numeric_or_date_dtype?(dtype),
+  def min(%Series{dtype: dtype} = series) when is_numeric_or_date_dtype(dtype),
     do: Shared.apply_impl(series, :min)
 
   def min(%Series{dtype: dtype}),
@@ -1533,7 +1533,7 @@ defmodule Explorer.Series do
   """
   @doc type: :aggregation
   @spec max(series :: Series.t()) :: number() | Date.t() | Time.t() | NaiveDateTime.t() | nil
-  def max(%Series{dtype: dtype} = series) when numeric_or_date_dtype?(dtype),
+  def max(%Series{dtype: dtype} = series) when is_numeric_or_date_dtype(dtype),
     do: Shared.apply_impl(series, :max)
 
   def max(%Series{dtype: dtype}),
@@ -1563,7 +1563,7 @@ defmodule Explorer.Series do
   """
   @doc type: :aggregation
   @spec mean(series :: Series.t()) :: float() | nil
-  def mean(%Series{dtype: dtype} = series) when numeric_dtype?(dtype),
+  def mean(%Series{dtype: dtype} = series) when is_numeric_dtype(dtype),
     do: Shared.apply_impl(series, :mean)
 
   def mean(%Series{dtype: dtype}), do: dtype_error("mean/1", dtype, [:integer, :float])
@@ -1592,7 +1592,7 @@ defmodule Explorer.Series do
   """
   @doc type: :aggregation
   @spec median(series :: Series.t()) :: float() | nil
-  def median(%Series{dtype: dtype} = series) when numeric_dtype?(dtype),
+  def median(%Series{dtype: dtype} = series) when is_numeric_dtype(dtype),
     do: Shared.apply_impl(series, :median)
 
   def median(%Series{dtype: dtype}), do: dtype_error("median/1", dtype, [:integer, :float])
@@ -1621,7 +1621,7 @@ defmodule Explorer.Series do
   """
   @doc type: :aggregation
   @spec variance(series :: Series.t()) :: float() | nil
-  def variance(%Series{dtype: dtype} = series) when numeric_dtype?(dtype),
+  def variance(%Series{dtype: dtype} = series) when is_numeric_dtype(dtype),
     do: Shared.apply_impl(series, :variance)
 
   def variance(%Series{dtype: dtype}), do: dtype_error("variance/1", dtype, [:integer, :float])
@@ -1650,7 +1650,7 @@ defmodule Explorer.Series do
   """
   @doc type: :aggregation
   @spec standard_deviation(series :: Series.t()) :: float() | nil
-  def standard_deviation(%Series{dtype: dtype} = series) when numeric_dtype?(dtype),
+  def standard_deviation(%Series{dtype: dtype} = series) when is_numeric_dtype(dtype),
     do: Shared.apply_impl(series, :standard_deviation)
 
   def standard_deviation(%Series{dtype: dtype}),
@@ -1696,7 +1696,7 @@ defmodule Explorer.Series do
   @doc type: :aggregation
   @spec quantile(series :: Series.t(), quantile :: float()) :: any()
   def quantile(%Series{dtype: dtype} = series, quantile)
-      when numeric_or_date_dtype?(dtype),
+      when is_numeric_or_date_dtype(dtype),
       do: Shared.apply_impl(series, :quantile, [quantile])
 
   def quantile(%Series{dtype: dtype}, _),
@@ -1747,7 +1747,7 @@ defmodule Explorer.Series do
   def cumulative_max(series, opts \\ [])
 
   def cumulative_max(%Series{dtype: dtype} = series, opts)
-      when numeric_or_date_dtype?(dtype) do
+      when is_numeric_or_date_dtype(dtype) do
     opts = Keyword.validate!(opts, reverse: false)
     Shared.apply_impl(series, :cumulative_max, [opts[:reverse]])
   end
@@ -1798,7 +1798,7 @@ defmodule Explorer.Series do
   def cumulative_min(series, opts \\ [])
 
   def cumulative_min(%Series{dtype: dtype} = series, opts)
-      when numeric_or_date_dtype?(dtype) do
+      when is_numeric_or_date_dtype(dtype) do
     opts = Keyword.validate!(opts, reverse: false)
     Shared.apply_impl(series, :cumulative_min, [opts[:reverse]])
   end
@@ -1840,7 +1840,7 @@ defmodule Explorer.Series do
   def cumulative_sum(series, opts \\ [])
 
   def cumulative_sum(%Series{dtype: dtype} = series, opts)
-      when numeric_dtype?(dtype) do
+      when is_numeric_dtype(dtype) do
     opts = Keyword.validate!(opts, reverse: false)
     Shared.apply_impl(series, :cumulative_sum, [opts[:reverse]])
   end
@@ -1882,7 +1882,7 @@ defmodule Explorer.Series do
   def peaks(series, max_or_min \\ :max)
 
   def peaks(%Series{dtype: dtype} = series, max_or_min)
-      when numeric_or_date_dtype?(dtype),
+      when is_numeric_or_date_dtype(dtype),
       do: Shared.apply_impl(series, :peaks, [max_or_min])
 
   def peaks(%Series{dtype: dtype}, _),
@@ -2045,13 +2045,13 @@ defmodule Explorer.Series do
   """
   @doc type: :element_wise
   @spec divide(left :: Series.t() | number(), right :: Series.t() | number()) :: Series.t()
-  def divide(%Series{dtype: dtype} = left, right) when numeric_dtype?(dtype) do
+  def divide(%Series{dtype: dtype} = left, right) when is_numeric_dtype(dtype) do
     left = cast(left, :float)
 
     basic_numeric_operation(:divide, left, right)
   end
 
-  def divide(left, %Series{dtype: dtype} = right) when numeric_dtype?(dtype) do
+  def divide(left, %Series{dtype: dtype} = right) when is_numeric_dtype(dtype) do
     right = cast(right, :float)
 
     basic_numeric_operation(:divide, left, right)
@@ -2203,18 +2203,18 @@ defmodule Explorer.Series do
          %Series{dtype: left_dtype} = left,
          %Series{dtype: right_dtype} = right
        )
-       when K.and(numeric_dtype?(left_dtype), numeric_dtype?(right_dtype)),
+       when K.and(is_numeric_dtype(left_dtype), is_numeric_dtype(right_dtype)),
        do: Shared.apply_series_impl(operation, [left, right])
 
   defp basic_numeric_operation(operation, %Series{} = left, %Series{} = right),
     do: dtype_mismatch_error("#{operation}/2", left, right)
 
   defp basic_numeric_operation(operation, %Series{dtype: dtype} = left, right)
-       when K.and(numeric_dtype?(dtype), is_numerical(right)),
+       when K.and(is_numeric_dtype(dtype), is_numerical(right)),
        do: Shared.apply_series_impl(operation, [left, right])
 
   defp basic_numeric_operation(operation, left, %Series{dtype: dtype} = right)
-       when K.and(numeric_dtype?(dtype), is_numerical(left)),
+       when K.and(is_numeric_dtype(dtype), is_numerical(left)),
        do: Shared.apply_series_impl(operation, [left, right])
 
   defp basic_numeric_operation(operation, _, %Series{dtype: dtype}),
@@ -2550,11 +2550,11 @@ defmodule Explorer.Series do
     do: true
 
   defp valid_for_bool_mask_operation?(%Series{dtype: left_dtype}, %Series{dtype: right_dtype})
-       when K.and(numeric_dtype?(left_dtype), numeric_dtype?(right_dtype)),
+       when K.and(is_numeric_dtype(left_dtype), is_numeric_dtype(right_dtype)),
        do: true
 
   defp valid_for_bool_mask_operation?(%Series{dtype: dtype}, right)
-       when K.and(numeric_dtype?(dtype), is_numerical(right)),
+       when K.and(is_numeric_dtype(dtype), is_numerical(right)),
        do: true
 
   defp valid_for_bool_mask_operation?(%Series{dtype: :date}, %Date{}), do: true
@@ -2562,7 +2562,7 @@ defmodule Explorer.Series do
   defp valid_for_bool_mask_operation?(%Series{dtype: :datetime}, %NaiveDateTime{}), do: true
 
   defp valid_for_bool_mask_operation?(left, %Series{dtype: dtype})
-       when K.and(numeric_dtype?(dtype), is_numerical(left)),
+       when K.and(is_numeric_dtype(dtype), is_numerical(left)),
        do: true
 
   defp valid_for_bool_mask_operation?(%Date{}, %Series{dtype: :date}), do: true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2553,7 +2553,10 @@ defmodule Explorer.Series do
        do: true
 
   defp valid_for_bool_mask_operation?(%Series{dtype: dtype}, right)
-       when K.and(numeric_dtype?(dtype), is_number(right)),
+       when K.and(
+              numeric_dtype?(dtype),
+              K.or(is_number(right), K.in(right, [:nan, :infinity, :neg_infinity]))
+            ),
        do: true
 
   defp valid_for_bool_mask_operation?(%Series{dtype: :date}, %Date{}), do: true
@@ -2561,7 +2564,10 @@ defmodule Explorer.Series do
   defp valid_for_bool_mask_operation?(%Series{dtype: :datetime}, %NaiveDateTime{}), do: true
 
   defp valid_for_bool_mask_operation?(left, %Series{dtype: dtype})
-       when K.and(numeric_dtype?(dtype), is_number(left)),
+       when K.and(
+              numeric_dtype?(dtype),
+              K.or(is_number(left), K.in(left, [:nan, :infinity, :neg_infinity]))
+            ),
        do: true
 
   defp valid_for_bool_mask_operation?(%Date{}, %Series{dtype: :date}), do: true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -2209,11 +2209,17 @@ defmodule Explorer.Series do
     do: dtype_mismatch_error("#{operation}/2", left, right)
 
   defp basic_numeric_operation(operation, %Series{dtype: dtype} = left, right)
-       when K.and(numeric_dtype?(dtype), is_number(right)),
+       when K.and(
+              numeric_dtype?(dtype),
+              K.or(is_number(right), K.in(right, [:nan, :infinity, :neg_infinity]))
+            ),
        do: Shared.apply_series_impl(operation, [left, right])
 
   defp basic_numeric_operation(operation, left, %Series{dtype: dtype} = right)
-       when K.and(numeric_dtype?(dtype), is_number(left)),
+       when K.and(
+              numeric_dtype?(dtype),
+              K.or(is_number(left), K.in(left, [:nan, :infinity, :neg_infinity]))
+            ),
        do: Shared.apply_series_impl(operation, [left, right])
 
   defp basic_numeric_operation(operation, _, %Series{dtype: dtype}),

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -78,6 +78,7 @@ defmodule Explorer.Series do
   @behaviour Access
   @compile {:no_warn_undefined, Nx}
 
+  defguardp is_numerical(n) when K.or(is_number(n), K.in(n, [:nan, :infinity, :neg_infinity]))
   defguardp io_dtype?(dtype) when K.not(K.in(dtype, [:binary, :string]))
   defguardp numeric_dtype?(dtype) when K.in(dtype, [:float, :integer])
   defguardp numeric_or_bool_dtype?(dtype) when K.in(dtype, [:float, :integer, :boolean])
@@ -2209,17 +2210,11 @@ defmodule Explorer.Series do
     do: dtype_mismatch_error("#{operation}/2", left, right)
 
   defp basic_numeric_operation(operation, %Series{dtype: dtype} = left, right)
-       when K.and(
-              numeric_dtype?(dtype),
-              K.or(is_number(right), K.in(right, [:nan, :infinity, :neg_infinity]))
-            ),
+       when K.and(numeric_dtype?(dtype), is_numerical(right)),
        do: Shared.apply_series_impl(operation, [left, right])
 
   defp basic_numeric_operation(operation, left, %Series{dtype: dtype} = right)
-       when K.and(
-              numeric_dtype?(dtype),
-              K.or(is_number(left), K.in(left, [:nan, :infinity, :neg_infinity]))
-            ),
+       when K.and(numeric_dtype?(dtype), is_numerical(left)),
        do: Shared.apply_series_impl(operation, [left, right])
 
   defp basic_numeric_operation(operation, _, %Series{dtype: dtype}),
@@ -2559,10 +2554,7 @@ defmodule Explorer.Series do
        do: true
 
   defp valid_for_bool_mask_operation?(%Series{dtype: dtype}, right)
-       when K.and(
-              numeric_dtype?(dtype),
-              K.or(is_number(right), K.in(right, [:nan, :infinity, :neg_infinity]))
-            ),
+       when K.and(numeric_dtype?(dtype), is_numerical(right)),
        do: true
 
   defp valid_for_bool_mask_operation?(%Series{dtype: :date}, %Date{}), do: true
@@ -2570,10 +2562,7 @@ defmodule Explorer.Series do
   defp valid_for_bool_mask_operation?(%Series{dtype: :datetime}, %NaiveDateTime{}), do: true
 
   defp valid_for_bool_mask_operation?(left, %Series{dtype: dtype})
-       when K.and(
-              numeric_dtype?(dtype),
-              K.or(is_number(left), K.in(left, [:nan, :infinity, :neg_infinity]))
-            ),
+       when K.and(numeric_dtype?(dtype), is_numerical(left)),
        do: true
 
   defp valid_for_bool_mask_operation?(%Date{}, %Series{dtype: :date}), do: true

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -768,21 +768,61 @@ pub fn s_pow(s: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_pow_f_rhs(s: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
+pub fn s_pow_f_rhs(s: ExSeries, exponent: Term) -> Result<ExSeries, ExplorerError> {
+    let nan = atoms::nan();
+    let infinity = atoms::infinity();
+    let neg_infinity = atoms::neg_infinity();
+
+    let float = match exponent.get_type() {
+        TermType::Number => exponent.decode::<f64>().unwrap(),
+        TermType::Atom => {
+            if nan.eq(&exponent) {
+                f64::NAN
+            } else if infinity.eq(&exponent) {
+                f64::INFINITY
+            } else if neg_infinity.eq(&exponent) {
+                f64::NEG_INFINITY
+            } else {
+                panic!("pow/2 invalid float")
+            }
+        }
+        term_type => panic!("pow/2 not implemented for {term_type:?}"),
+    };
+
     let s = s
         .cast(&DataType::Float64)?
         .f64()?
-        .apply(|v| v.powf(exponent))
+        .apply(|v| v.powf(float))
         .into_series();
     Ok(ExSeries::new(s))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_pow_f_lhs(s: ExSeries, exponent: f64) -> Result<ExSeries, ExplorerError> {
+pub fn s_pow_f_lhs(s: ExSeries, exponent: Term) -> Result<ExSeries, ExplorerError> {
+    let nan = atoms::nan();
+    let infinity = atoms::infinity();
+    let neg_infinity = atoms::neg_infinity();
+
+    let float = match exponent.get_type() {
+        TermType::Number => exponent.decode::<f64>().unwrap(),
+        TermType::Atom => {
+            if nan.eq(&exponent) {
+                f64::NAN
+            } else if infinity.eq(&exponent) {
+                f64::INFINITY
+            } else if neg_infinity.eq(&exponent) {
+                f64::NEG_INFINITY
+            } else {
+                panic!("pow/2 invalid float")
+            }
+        }
+        term_type => panic!("pow/2 not implemented for {term_type:?}"),
+    };
+
     let s = s
         .cast(&DataType::Float64)?
         .f64()?
-        .apply(|v| exponent.powf(v))
+        .apply(|v| float.powf(v))
         .into_series();
     Ok(ExSeries::new(s))
 }

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -721,6 +721,20 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.greater(s2) |> Series.to_list() == [false, false, true]
     end
 
+    test "compare float series" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity, :infinity])
+      s2 = Series.from_list([1.0, 2.0, :nan, :infinity, :neg_infinity, :neg_infinity])
+
+      assert s1 |> Series.greater(s2) |> Series.to_list() == [
+               false,
+               true,
+               false,
+               false,
+               false,
+               true
+             ]
+    end
+
     test "compare time series" do
       s1 = Series.from_list([~T[00:00:00.000000], ~T[12:00:00.000000], ~T[23:59:59.999999]])
       s2 = Series.from_list([~T[00:00:00.000000], ~T[12:30:00.000000], ~T[23:50:59.999999]])
@@ -734,10 +748,78 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.greater(2) |> Series.to_list() == [false, false, false, true]
     end
 
+    test "compare float series with a float value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+      assert s1 |> Series.greater(2.0) |> Series.to_list() == [false, true, false, true, false]
+    end
+
+    test "compare float series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+      assert s1 |> Series.greater(:nan) |> Series.to_list() == [false, false, false, false, false]
+    end
+
+    test "compare float series with an infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.greater(:infinity) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.greater(:neg_infinity) |> Series.to_list() == [
+               true,
+               true,
+               false,
+               true,
+               false
+             ]
+    end
+
     test "compare integer series with a scalar value on the left-hand side" do
       s1 = Series.from_list([1, 0, 2, 3])
 
       assert 2 |> Series.greater(s1) |> Series.to_list() == [true, true, false, false]
+    end
+
+    test "compare float series with a float value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+      assert 2.5 |> Series.greater(s1) |> Series.to_list() == [true, false, false, false, true]
+    end
+
+    test "compare float series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+      assert :nan |> Series.greater(s1) |> Series.to_list() == [false, false, false, false, false]
+    end
+
+    test "compare float series with an infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :infinity |> Series.greater(s1) |> Series.to_list() == [
+               true,
+               true,
+               false,
+               false,
+               true
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :neg_infinity |> Series.greater(s1) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -969,6 +969,20 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.less(s2) |> Series.to_list() == [false, false, true]
     end
 
+    test "compare float series" do
+      s1 = Series.from_list([1.0, 2.0, :nan, :infinity, :neg_infinity, :neg_infinity])
+      s2 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity, :infinity])
+
+      assert s1 |> Series.less(s2) |> Series.to_list() == [
+               false,
+               true,
+               false,
+               false,
+               false,
+               true
+             ]
+    end
+
     test "compare time series" do
       s1 = Series.from_list([~T[00:00:00.000000], ~T[12:00:00.000000], ~T[23:59:59.999999]])
       s2 = Series.from_list([~T[00:00:00.000000], ~T[12:30:00.000000], ~T[23:50:59.999999]])
@@ -982,10 +996,106 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.less(2) |> Series.to_list() == [true, true, false, false]
     end
 
+    test "compare float series with a float value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.less(2.0) |> Series.to_list() == [
+               true,
+               false,
+               false,
+               false,
+               true
+             ]
+    end
+
+    test "compare float series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.less(:nan) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
+    end
+
+    test "compare float series with an infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.less(:infinity) |> Series.to_list() == [
+               true,
+               true,
+               false,
+               false,
+               true
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.less(:neg_infinity) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
+    end
+
     test "compare integer series with a scalar value on the left-hand side" do
       s1 = Series.from_list([1, 0, 2, 3])
 
       assert 2 |> Series.less(s1) |> Series.to_list() == [false, false, false, true]
+    end
+
+    test "compare float series with a float value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert 2.5 |> Series.less(s1) |> Series.to_list() == [
+               false,
+               true,
+               false,
+               true,
+               false
+             ]
+    end
+
+    test "compare float series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :nan |> Series.less(s1) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
+    end
+
+    test "compare float series with an infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :infinity |> Series.less(s1) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :neg_infinity |> Series.less(s1) |> Series.to_list() == [
+               true,
+               true,
+               false,
+               true,
+               false
+             ]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1386,7 +1386,7 @@ defmodule Explorer.SeriesTest do
     end
 
     test "float series" do
-      s = Series.from_list([1.2, 2.3, 3.4])
+      s = Series.from_list([1.2, 2.3, 3.4, :nan, :infinity, :neg_infinity])
       assert Series.iotype(s) == {:f, 64}
     end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1945,6 +1945,24 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(result) == [2, 0, 3, 1]
     end
 
+    test "indices of sorting a float series in ascending order" do
+      s1 = Series.from_list([3.0, 1.0, :nan, nil, :infinity, :neg_infinity, 2.0])
+
+      result = Series.argsort(s1)
+
+      assert Series.to_list(result) == [5, 1, 6, 0, 4, 2, 3]
+    end
+
+    # There is a bug which is not considering "nils first" for descending argsort
+    @tag :skip
+    test "indices of sorting a float series in descending order" do
+      s1 = Series.from_list([3.0, 1.0, :nan, nil, :infinity, :neg_infinity, 2.0])
+
+      result = Series.argsort(s1, direction: :desc)
+
+      assert Series.to_list(result) == [3, 2, 4, 0, 6, 1, 5]
+    end
+
     test "sort a series in descending order, but with nils last" do
       s1 = Series.from_list([9, 4, nil, 5])
 
@@ -1959,6 +1977,22 @@ defmodule Explorer.SeriesTest do
       result = Series.argsort(s1, nils: :first)
 
       assert Series.to_list(result) == [2, 1, 3, 0]
+    end
+
+    test "sort a float series in descending order, but with nils last" do
+      s1 = Series.from_list([3.0, 1.0, :nan, nil, :infinity, :neg_infinity, 2.0])
+
+      result = Series.argsort(s1, direction: :desc, nils: :last)
+
+      assert Series.to_list(result) == [2, 4, 0, 6, 1, 5, 3]
+    end
+
+    test "sort a float series in ascending order, but nils first" do
+      s1 = Series.from_list([3.0, 1.0, :nan, nil, :infinity, :neg_infinity, 2.0])
+
+      result = Series.argsort(s1, nils: :first)
+
+      assert Series.to_list(result) == [3, 5, 1, 6, 0, 4, 2]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1877,6 +1877,22 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(result) == [nil, 3, 2, 1]
     end
 
+    test "sort a float series in ascending order" do
+      s1 = Series.from_list([3.0, 1.0, :nan, nil, :infinity, :neg_infinity, 2.0])
+
+      result = Series.sort(s1)
+
+      assert Series.to_list(result) == [:neg_infinity, 1.0, 2.0, 3.0, :infinity, :nan, nil]
+    end
+
+    test "sort a float series in descending order" do
+      s1 = Series.from_list([3.0, 1.0, :nan, nil, :infinity, :neg_infinity, 2.0])
+
+      result = Series.sort(s1, direction: :desc)
+
+      assert Series.to_list(result) == [nil, :nan, :infinity, 3.0, 2.0, 1.0, :neg_infinity]
+    end
+
     test "sort a series in descending order, but with nils last" do
       s1 = Series.from_list([3, 1, nil, 2])
 
@@ -1891,6 +1907,22 @@ defmodule Explorer.SeriesTest do
       result = Series.sort(s1, nils: :first)
 
       assert Series.to_list(result) == [nil, 1, 2, 3]
+    end
+
+    test "sort a float series in descending order, but with nils last" do
+      s1 = Series.from_list([3.0, 1.0, :nan, nil, :infinity, :neg_infinity, 2.0])
+
+      result = Series.sort(s1, direction: :desc, nils: :last)
+
+      assert Series.to_list(result) == [:nan, :infinity, 3.0, 2.0, 1.0, :neg_infinity, nil]
+    end
+
+    test "sort a float series in ascending order, but nils first" do
+      s1 = Series.from_list([3.0, 1.0, :nan, nil, :infinity, :neg_infinity, 2.0])
+
+      result = Series.sort(s1, nils: :first)
+
+      assert Series.to_list(result) == [nil, :neg_infinity, 1.0, 2.0, 3.0, :infinity, :nan]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -618,6 +618,13 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.not_equal(s2) |> Series.to_list() == [false, false, true]
     end
 
+    test "compare float series" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+      s2 = Series.from_list([1.0, 3.0, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.not_equal(s2) |> Series.to_list() == [false, true, true, false, false]
+    end
+
     test "compare time series" do
       s1 = Series.from_list([~T[00:00:00.000000], ~T[12:00:00.000000], ~T[23:59:59.999999]])
       s2 = Series.from_list([~T[00:00:00.000000], ~T[12:30:00.000000], ~T[23:59:59.999999]])
@@ -631,10 +638,78 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.not_equal(2) |> Series.to_list() == [true, true, false]
     end
 
+    test "compare float series with a float value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+      assert s1 |> Series.not_equal(2.5) |> Series.to_list() == [true, false, true, true, true]
+    end
+
+    test "compare float series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+      assert s1 |> Series.not_equal(:nan) |> Series.to_list() == [true, true, true, true, true]
+    end
+
+    test "compare float series with an infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.not_equal(:infinity) |> Series.to_list() == [
+               true,
+               true,
+               true,
+               false,
+               true
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.not_equal(:neg_infinity) |> Series.to_list() == [
+               true,
+               true,
+               true,
+               true,
+               false
+             ]
+    end
+
     test "compare integer series with a scalar value on the left-hand side" do
       s1 = Series.from_list([1, 0, 2])
 
       assert 2 |> Series.not_equal(s1) |> Series.to_list() == [true, true, false]
+    end
+
+    test "compare float series with a float value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+      assert 2.5 |> Series.not_equal(s1) |> Series.to_list() == [true, false, true, true, true]
+    end
+
+    test "compare float series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+      assert :nan |> Series.not_equal(s1) |> Series.to_list() == [true, true, true, true, true]
+    end
+
+    test "compare float series with an infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      assert :infinity |> Series.not_equal(s1) |> Series.to_list() == [
+               true,
+               true,
+               true,
+               false,
+               true
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      assert :neg_infinity |> Series.not_equal(s1) |> Series.to_list() == [
+               true,
+               true,
+               true,
+               true,
+               false
+             ]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1422,6 +1422,16 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(s3) == [5, 7, 9]
     end
 
+    test "adding two float series together" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity, :infinity])
+      s2 = Series.from_list([4.0, 4.5, :nan, :infinity, :neg_infinity, :neg_infinity])
+
+      s3 = Series.add(s1, s2)
+
+      assert s3.dtype == :float
+      assert Series.to_list(s3) == [5.0, 7.0, :nan, :infinity, :neg_infinity, :nan]
+    end
+
     test "adding a series with an integer scalar value on the right-hand side" do
       s1 = Series.from_list([1, 2, 3])
 
@@ -1448,6 +1458,33 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(s2) == [2.1, 3.1, 4.1]
     end
 
+    test "adding a series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.add(s1, :nan)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:nan, :nan, :nan, :nan, :nan]
+    end
+
+    test "adding a series with a infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.add(s1, :infinity)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:infinity, :infinity, :nan, :infinity, :nan]
+    end
+
+    test "adding a series with a negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.add(s1, :neg_infinity)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:neg_infinity, :neg_infinity, :nan, :nan, :neg_infinity]
+    end
+
     test "adding a series with a float scalar value on the left-hand side" do
       s1 = Series.from_list([1, 2, 3])
 
@@ -1455,6 +1492,33 @@ defmodule Explorer.SeriesTest do
       assert s2.dtype == :float
 
       assert Series.to_list(s2) == [2.1, 3.1, 4.1]
+    end
+
+    test "adding a series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.add(:nan, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:nan, :nan, :nan, :nan, :nan]
+    end
+
+    test "adding a series with a infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.add(:infinity, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:infinity, :infinity, :nan, :infinity, :nan]
+    end
+
+    test "adding a series with a negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.add(:neg_infinity, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:neg_infinity, :neg_infinity, :nan, :nan, :neg_infinity]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1988,6 +1988,33 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(result) == [1.0, 4.0, 9.0]
     end
 
+    test "pow of a series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1, 2, 3])
+
+      s2 = Series.pow(s1, :nan)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [1, :nan, :nan]
+    end
+
+    test "pow of a series with a infinity value on the right-hand side" do
+      s1 = Series.from_list([1, 2, 3])
+
+      s2 = Series.pow(s1, :infinity)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [1.0, :infinity, :infinity]
+    end
+
+    test "pow of a series with a negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1, 2, 3])
+
+      s2 = Series.pow(s1, :neg_infinity)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [1.0, 0.0, 0.0]
+    end
+
     test "pow of a series with an integer scalar value on the left-hand side" do
       s1 = Series.from_list([1, 2, 3])
 
@@ -2004,6 +2031,33 @@ defmodule Explorer.SeriesTest do
 
       assert result.dtype == :float
       assert Series.to_list(result) == [2.0, 4.0, 8.0]
+    end
+
+    test "pow of a series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1, 2, 3])
+
+      s2 = Series.pow(:nan, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:nan, :nan, :nan]
+    end
+
+    test "pow of a series with a infinity value on the left-hand side" do
+      s1 = Series.from_list([1, 2, 3])
+
+      s2 = Series.pow(:infinity, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:infinity, :infinity, :infinity]
+    end
+
+    test "pow of a series with a negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1, 2, 3])
+
+      s2 = Series.pow(:neg_infinity, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:neg_infinity, :infinity, :neg_infinity]
     end
 
     test "pow of a scalar value on the left-hand side to a series with a negative integer" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -504,6 +504,13 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.equal(s2) |> Series.to_list() == [true, true, false]
     end
 
+    test "compare float series" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+      s2 = Series.from_list([1.0, 3.0, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.equal(s2) |> Series.to_list() == [true, false, false, true, true]
+    end
+
     test "compare time series" do
       s1 = Series.from_list([~T[00:00:00.000000], ~T[12:00:00.000000], ~T[23:59:59.999999]])
       s2 = Series.from_list([~T[00:00:00.000000], ~T[12:30:00.000000], ~T[23:59:59.999999]])
@@ -519,12 +526,80 @@ defmodule Explorer.SeriesTest do
       assert s2 |> Series.equal("baz") |> Series.to_list() == [false, false, true]
     end
 
+    test "compare float series with a float value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+      assert s1 |> Series.equal(2.5) |> Series.to_list() == [false, true, false, false, false]
+    end
+
+    test "compare float series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+      assert s1 |> Series.equal(:nan) |> Series.to_list() == [false, false, false, false, false]
+    end
+
+    test "compare float series with an infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.equal(:infinity) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               true,
+               false
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.equal(:neg_infinity) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               true
+             ]
+    end
+
     test "compare integer series with a scalar value on the left-hand side" do
       s1 = Series.from_list([1, 0, 2])
       assert 2 |> Series.equal(s1) |> Series.to_list() == [false, false, true]
 
       s2 = Series.from_list(["foo", "bar", "baz"])
       assert "baz" |> Series.equal(s2) |> Series.to_list() == [false, false, true]
+    end
+
+    test "compare float series with a float value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+      assert 2.5 |> Series.equal(s1) |> Series.to_list() == [false, true, false, false, false]
+    end
+
+    test "compare float series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+      assert :nan |> Series.equal(s1) |> Series.to_list() == [false, false, false, false, false]
+    end
+
+    test "compare float series with an infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      assert :infinity |> Series.equal(s1) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               true,
+               false
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      assert :neg_infinity |> Series.equal(s1) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               true
+             ]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1756,6 +1756,16 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(s3) == [4.0, 2.5, 2.0]
     end
 
+    test "dividing two float series together" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity, :infinity])
+      s2 = Series.from_list([4.0, 4.5, :nan, :infinity, :neg_infinity, :neg_infinity])
+
+      s3 = Series.divide(s1, s2)
+
+      assert s3.dtype == :float
+      assert Series.to_list(s3) == [0.25, 0.5555555555555556, :nan, :nan, :nan, :nan]
+    end
+
     test "dividing a series with an integer scalar value on the right-hand side" do
       s1 = Series.from_list([1, 2, 3])
 
@@ -1783,6 +1793,33 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(s2) == [-0.4, -0.8, -1.2]
     end
 
+    test "dividing a series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.divide(s1, :nan)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:nan, :nan, :nan, :nan, :nan]
+    end
+
+    test "dividing a series with a infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.divide(s1, :infinity)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [0.0, 0.0, :nan, :nan, :nan]
+    end
+
+    test "dividing a series with a negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.divide(s1, :neg_infinity)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [-0.0, -0.0, :nan, :nan, :nan]
+    end
+
     test "dividing a series with a float scalar value on the left-hand side" do
       s1 = Series.from_list([1, 2, 3])
 
@@ -1790,6 +1827,33 @@ defmodule Explorer.SeriesTest do
 
       assert s2.dtype == :float
       assert Series.to_list(s2) == [-3.12, -1.56, -1.04]
+    end
+
+    test "dividing a series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.divide(:nan, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:nan, :nan, :nan, :nan, :nan]
+    end
+
+    test "dividing a series with a infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.divide(:infinity, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:infinity, :infinity, :nan, :nan, :nan]
+    end
+
+    test "dividing a series with a negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.divide(:neg_infinity, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:neg_infinity, :neg_infinity, :nan, :nan, :nan]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -831,6 +831,20 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.greater_equal(s2) |> Series.to_list() == [true, true, false]
     end
 
+    test "compare float series" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity, :infinity])
+      s2 = Series.from_list([1.0, 2.0, :nan, :infinity, :neg_infinity, :neg_infinity])
+
+      assert s1 |> Series.greater_equal(s2) |> Series.to_list() == [
+               true,
+               true,
+               false,
+               true,
+               true,
+               true
+             ]
+    end
+
     test "compare time series" do
       s1 = Series.from_list([~T[00:00:00.000000], ~T[12:00:00.000000], ~T[23:59:59.999999]])
       s2 = Series.from_list([~T[00:00:00.000000], ~T[12:30:00.000000], ~T[23:50:59.999999]])
@@ -844,10 +858,106 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.greater_equal(2) |> Series.to_list() == [false, false, true, true]
     end
 
+    test "compare float series with a float value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.greater_equal(2.0) |> Series.to_list() == [
+               false,
+               true,
+               false,
+               true,
+               false
+             ]
+    end
+
+    test "compare float series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.greater_equal(:nan) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
+    end
+
+    test "compare float series with an infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.greater_equal(:infinity) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               true,
+               false
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.greater_equal(:neg_infinity) |> Series.to_list() == [
+               true,
+               true,
+               false,
+               true,
+               true
+             ]
+    end
+
     test "compare integer series with a scalar value on the left-hand side" do
       s1 = Series.from_list([1, 0, 2, 3])
 
       assert 2 |> Series.greater_equal(s1) |> Series.to_list() == [true, true, true, false]
+    end
+
+    test "compare float series with a float value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert 2.5 |> Series.greater_equal(s1) |> Series.to_list() == [
+               true,
+               false,
+               false,
+               false,
+               true
+             ]
+    end
+
+    test "compare float series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :nan |> Series.greater_equal(s1) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
+    end
+
+    test "compare float series with an infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :infinity |> Series.greater_equal(s1) |> Series.to_list() == [
+               true,
+               true,
+               false,
+               true,
+               true
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :neg_infinity |> Series.greater_equal(s1) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               true
+             ]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1533,6 +1533,16 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(s3) == [-3, -3, -3]
     end
 
+    test "subtracting two float series together" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity, :infinity, :neg_infinity])
+      s2 = Series.from_list([4.0, 4.5, :nan, :infinity, :neg_infinity, :neg_infinity, :infinity])
+
+      s3 = Series.subtract(s1, s2)
+
+      assert s3.dtype == :float
+      assert Series.to_list(s3) == [-3.0, -2.0, :nan, :nan, :nan, :infinity, :neg_infinity]
+    end
+
     test "subtracting a series with an integer scalar value on the right-hand side" do
       s1 = Series.from_list([1, 2, 3])
 
@@ -1559,6 +1569,33 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(s2) == [-0.5, 0.5, 1.5]
     end
 
+    test "subtracting a series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.subtract(s1, :nan)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:nan, :nan, :nan, :nan, :nan]
+    end
+
+    test "subtracting a series with a infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.subtract(s1, :infinity)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:neg_infinity, :neg_infinity, :nan, :nan, :neg_infinity]
+    end
+
+    test "subtracting a series with a negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.subtract(s1, :neg_infinity)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:infinity, :infinity, :nan, :infinity, :nan]
+    end
+
     test "subtracting a series with a float scalar value on the left-hand side" do
       s1 = Series.from_list([1, 2, 3])
 
@@ -1566,6 +1603,33 @@ defmodule Explorer.SeriesTest do
       assert s2.dtype == :float
 
       assert Series.to_list(s2) == [0.5, -0.5, -1.5]
+    end
+
+    test "subtracting a series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.subtract(:nan, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:nan, :nan, :nan, :nan, :nan]
+    end
+
+    test "subtracting a series with a infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.subtract(:infinity, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:infinity, :infinity, :nan, :nan, :infinity]
+    end
+
+    test "subtracting a series with a negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.subtract(:neg_infinity, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:neg_infinity, :neg_infinity, :nan, :neg_infinity, :nan]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1107,6 +1107,20 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.less_equal(s2) |> Series.to_list() == [true, true, true]
     end
 
+    test "compare float series" do
+      s1 = Series.from_list([1.0, 2.0, :nan, :infinity, :neg_infinity, :neg_infinity])
+      s2 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity, :infinity])
+
+      assert s1 |> Series.less_equal(s2) |> Series.to_list() == [
+               true,
+               true,
+               false,
+               true,
+               true,
+               true
+             ]
+    end
+
     test "compare time series" do
       s1 = Series.from_list([~T[00:00:00.000000], ~T[12:00:00.000000], ~T[23:59:59.999999]])
       s2 = Series.from_list([~T[00:00:00.000000], ~T[12:30:00.000000], ~T[23:50:59.999999]])
@@ -1120,10 +1134,106 @@ defmodule Explorer.SeriesTest do
       assert s1 |> Series.less_equal(2) |> Series.to_list() == [true, true, true, false]
     end
 
+    test "compare float series with a float value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.less_equal(2.0) |> Series.to_list() == [
+               true,
+               false,
+               false,
+               false,
+               true
+             ]
+    end
+
+    test "compare float series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.less_equal(:nan) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
+    end
+
+    test "compare float series with an infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.less_equal(:infinity) |> Series.to_list() == [
+               true,
+               true,
+               false,
+               true,
+               true
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert s1 |> Series.less_equal(:neg_infinity) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               true
+             ]
+    end
+
     test "compare integer series with a scalar value on the left-hand side" do
       s1 = Series.from_list([1, 0, 2, 3])
 
       assert 2 |> Series.less_equal(s1) |> Series.to_list() == [false, false, true, true]
+    end
+
+    test "compare float series with a float value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert 2.5 |> Series.less_equal(s1) |> Series.to_list() == [
+               false,
+               true,
+               false,
+               true,
+               false
+             ]
+    end
+
+    test "compare float series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :nan |> Series.less_equal(s1) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               false,
+               false
+             ]
+    end
+
+    test "compare float series with an infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :infinity |> Series.less_equal(s1) |> Series.to_list() == [
+               false,
+               false,
+               false,
+               true,
+               false
+             ]
+    end
+
+    test "compare float series with an negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
+
+      assert :neg_infinity |> Series.less_equal(s1) |> Series.to_list() == [
+               true,
+               true,
+               false,
+               true,
+               true
+             ]
     end
   end
 

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1253,10 +1253,10 @@ defmodule Explorer.SeriesTest do
     end
 
     test "with float series" do
-      s1 = Series.from_list([1.0, 2.0, 3.0])
-      s2 = Series.from_list([1.0, 0.0, 3.0])
+      s1 = Series.from_list([1.0, 2.0, :nan, :infinity, :neg_infinity])
+      s2 = Series.from_list([1.0, 3.5, :nan, :infinity, :neg_infinity])
 
-      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true]
+      assert s1 |> Series.in(s2) |> Series.to_list() == [true, false, true, true, true]
     end
 
     test "with binary series" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -1644,6 +1644,16 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(s3) == [4, 10, 18]
     end
 
+    test "multiplying two float series together" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity, :infinity])
+      s2 = Series.from_list([4.0, 4.5, :nan, :infinity, :neg_infinity, :neg_infinity])
+
+      s3 = Series.multiply(s1, s2)
+
+      assert s3.dtype == :float
+      assert Series.to_list(s3) == [4.0, 11.25, :nan, :infinity, :infinity, :neg_infinity]
+    end
+
     test "multiplying a series with an integer scalar value on the right-hand side" do
       s1 = Series.from_list([1, 2, 3])
 
@@ -1671,6 +1681,33 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(s2) == [-2.5, -5.0, -7.5]
     end
 
+    test "multiplying a series with a nan value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.multiply(s1, :nan)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:nan, :nan, :nan, :nan, :nan]
+    end
+
+    test "multiplying a series with a infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.multiply(s1, :infinity)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:infinity, :infinity, :nan, :infinity, :neg_infinity]
+    end
+
+    test "multiplying a series with a negative infinity value on the right-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.multiply(s1, :neg_infinity)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:neg_infinity, :neg_infinity, :nan, :neg_infinity, :infinity]
+    end
+
     test "multiplying a series with a float scalar value on the left-hand side" do
       s1 = Series.from_list([1, 2, 3])
 
@@ -1678,6 +1715,33 @@ defmodule Explorer.SeriesTest do
 
       assert s2.dtype == :float
       assert Series.to_list(s2) == [-2.5, -5.0, -7.5]
+    end
+
+    test "multiplying a series with a nan value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.multiply(:nan, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:nan, :nan, :nan, :nan, :nan]
+    end
+
+    test "multiplying a series with a infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.multiply(:infinity, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:infinity, :infinity, :nan, :infinity, :neg_infinity]
+    end
+
+    test "multiplying a series with a negative infinity value on the left-hand side" do
+      s1 = Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
+
+      s2 = Series.multiply(:neg_infinity, s1)
+
+      assert s2.dtype == :float
+      assert Series.to_list(s2) == [:neg_infinity, :neg_infinity, :nan, :neg_infinity, :infinity]
     end
   end
 


### PR DESCRIPTION
This PR allows Series functions to receive nan, infinity, and neg_infinity values.

This is part of #467

Functions that have been tested and are working:

- [X] Series.equal/2
- [X] Series.not_equal/2
- [X] Series.greater/2
- [X] Series.greater_equal/2
- [X] Series.less/2
- [X] Series.less_equal/2
- [X] Series.in/2
- [X] Series.iotype/2
- [X] Series.sort/2
- [X] Series.argsort/2
- [X] Series.add/2
- [X] Series.subtract/2
- [X] Series.multiply/2
- [X] Series.divide/2
- [X] Series.pow(series, :nan | :infinity | :neg_infinity)
- [X] Series.pow(:nan | :infinity | :neg_infinity, series)
- [ ] Series.pow(float_series_1, float_series_2)

NOTES:

- The Series.pow/2 function only accepts integer series. Is it to allow float series as well?
- In Rust, f64::NAN is not equal to f64::NAN
  - So when Series.equal/2 is called:

    ```elixir
    iex(1)> s1 = Explorer.Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
    #Explorer.Series<
    Polars[5]
    float [1.0, 2.5, NaN, Inf, -Inf]
    >

    iex(2)> s2 = Explorer.Series.from_list([1.0, 3.0, :nan, :infinity, :neg_infinity])
    #Explorer.Series<
    Polars[5]
    float [1.0, 3.0, NaN, Inf, -Inf]
    >

    iex(3)> Explorer.Series.equal(s1, s2)
    #Explorer.Series<
    Polars[5]
    boolean [true, false, false, true, true]
    >
    ```

  - But with the Series.in/2 function the behavior is different:

    ```elixir
    iex(1)> s1 = Explorer.Series.from_list([1.0, 2.5, :nan, :infinity, :neg_infinity])
    #Explorer.Series<
    Polars[5]
    float [1.0, 2.5, NaN, Inf, -Inf]
    >

    iex(2)> s2 = Explorer.Series.from_list([1.0, 3.0, :nan, :infinity, :neg_infinity])
    #Explorer.Series<
    Polars[5]
    float [1.0, 3.0, NaN, Inf, -Inf]
    >

    iex(3)> Explorer.Series.in(s1, s2)   
    #Explorer.Series<
    Polars[5]
    boolean [true, false, true, true, true]
    >
    ```