### PR TITLE
Remove Elixir 1.13 from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - otp_version: 24.2
-            elixir_version: 1.13
-          - otp_version: 25.0
+          - otp_version: 25.2
             elixir_version: 1.14
     runs-on: ubuntu-latest
     name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 25.0
+          otp-version: 25.2
           elixir-version: 1.14
       - run: mix format --check-formatted

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  ELIXIR_VERSION: 1.13
-  OTP_VERSION: 24.2
+  ELIXIR_VERSION: 1.14
+  OTP_VERSION: 25.2
   EXPLORER_BUILD: true
   RUST_TOOLCHAIN_VERSION: nightly-2023-02-14
 


### PR DESCRIPTION
We are planning to remove support in 0.6, since our dependency, Nx, does not support it.