### PR TITLE
Add `:name` field to `Series` struct

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3062,7 +3062,7 @@ defmodule Explorer.DataFrame do
   Extracts a single column as a series.
 
   This is equivalent to `df[field]` for retrieving a single field.
-  The resultant series is going to have the column name in the `:name` field.
+  The returned series will have its `:name` field set to the column name.
 
   ## Examples
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -368,7 +368,7 @@ defmodule Explorer.DataFrame do
 
     new_df = put(df, column, new_value)
 
-    {current_value, new_df}
+    {%{current_value | name: column}, new_df}
   end
 
   # IO
@@ -3082,7 +3082,8 @@ defmodule Explorer.DataFrame do
   def pull(df, column) when is_column(column) do
     [column] = to_existing_columns(df, [column])
 
-    Shared.apply_impl(df, :pull, [column])
+    series = Shared.apply_impl(df, :pull, [column])
+    %{series | name: column}
   end
 
   @doc """

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -359,6 +359,8 @@ defmodule Explorer.DataFrame do
     {select(df, columns), discard(df, columns)}
   end
 
+  # Notice that the resultant series is going to have the `:name` field
+  # equals to the column name.
   @impl true
   def get_and_update(df, column, fun) when is_column(column) do
     [column] = to_existing_columns(df, [column])
@@ -3060,6 +3062,7 @@ defmodule Explorer.DataFrame do
   Extracts a single column as a series.
 
   This is equivalent to `df[field]` for retrieving a single field.
+  The resultant series is going to have the column name in the `:name` field.
 
   ## Examples
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -73,7 +73,7 @@ defmodule Explorer.Series do
   @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
 
   @enforce_keys [:data, :dtype]
-  defstruct [:data, :dtype]
+  defstruct [:data, :dtype, :name]
 
   @behaviour Access
   @compile {:no_warn_undefined, Nx}

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -72,6 +72,8 @@ defmodule Explorer.Series do
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}
   @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
 
+  # The fields `:dtype` and `:name` are public. But `:name` is always `nil` unless
+  # the series is accessed through the dataframe.
   @enforce_keys [:data, :dtype]
   defstruct [:data, :dtype, :name]
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -72,8 +72,12 @@ defmodule Explorer.Series do
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}
   @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
 
-  # The fields `:dtype` and `:name` are public. But `:name` is always `nil` unless
-  # the series is accessed through the dataframe.
+  @doc """
+  The Series struct.
+
+  The fields `:dtype` and `:name` are public. `:name` is always `nil` unless
+  the series is retrieved from a dataframe.
+  """
   @enforce_keys [:data, :dtype]
   defstruct [:data, :dtype, :name]
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1603,8 +1603,21 @@ defmodule Explorer.DataFrameTest do
         {current_value, Series.from_list([0, 0, 0])}
       end)
 
+    assert s.name == "a"
+
     assert Series.to_list(s) == [1, 2, 3]
     assert DF.to_columns(df2, atom_keys: true) == %{a: [0, 0, 0], b: ["a", "b", "c"]}
+  end
+
+  test "pull/2" do
+    df1 = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
+
+    s = DF.pull(df1, "b")
+
+    assert %Series{} = s
+    assert s.name == "b"
+
+    assert Series.to_list(s) == ~w(a b c)
   end
 
   test "concat_rows/2" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -10,7 +10,7 @@ defmodule Explorer.SeriesTest do
       Code.fetch_docs(Explorer.Series)
 
     for {{:function, name, arity}, _ann, _signature, docs, metadata} <- entries,
-        is_map(docs) and map_size(docs) > 0,
+        is_map(docs) and map_size(docs) > 0 and name != :__struct__,
         metadata[:type] not in [
           :shape,
           :introspection,


### PR DESCRIPTION
And fill it when "pull" the series from the dataframe, and when using `get_and_update`.

This is related to https://github.com/elixir-nx/explorer/issues/507