### PR TITLE
Add Series.format/1 function

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -39,6 +39,7 @@ defmodule Explorer.Backend.LazySeries do
     pow: 2,
     fill_missing_with_value: 2,
     fill_missing_with_strategy: 2,
+    format: 2,
     concat: 2,
     coalesce: 2,
     cast: 2,

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -39,7 +39,7 @@ defmodule Explorer.Backend.LazySeries do
     pow: 2,
     fill_missing_with_value: 2,
     fill_missing_with_strategy: 2,
-    format: 2,
+    format: 1,
     concat: 1,
     coalesce: 2,
     cast: 2,
@@ -408,6 +408,14 @@ defmodule Explorer.Backend.LazySeries do
       end
 
     Backend.Series.new(data, dtype)
+  end
+
+  @impl true
+  def format(list) do
+    series_list = Enum.map(list, &series_or_lazy_series!/1)
+    data = new(:format, [series_list], aggregations?(series_list))
+
+    Backend.Series.new(data, :string)
   end
 
   @impl true

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -47,6 +47,7 @@ defmodule Explorer.Backend.Series do
   @callback mask(s, mask :: s) :: s
   @callback slice(s, indices :: list()) :: s
   @callback slice(s, offset :: integer(), length :: integer()) :: s
+  @callback format(s, s) :: s
   @callback concat(s, s) :: s
   @callback coalesce(s, s) :: s
   @callback first(s) :: valid_types() | lazy_s()

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -47,8 +47,8 @@ defmodule Explorer.Backend.Series do
   @callback mask(s, mask :: s) :: s
   @callback slice(s, indices :: list()) :: s
   @callback slice(s, offset :: integer(), length :: integer()) :: s
-  @callback format(s, s) :: s
-  @callback concat([s]) :: s
+  @callback format(list(s)) :: s
+  @callback concat(list(s)) :: s
   @callback coalesce(s, s) :: s
   @callback first(s) :: valid_types() | lazy_s()
   @callback last(s) :: valid_types() | lazy_s()

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -26,7 +26,7 @@ defmodule Explorer.PolarsBackend.Expression do
     equal: 2,
     fill_missing_with_value: 2,
     first: 1,
-    format: 2,
+    format: 1,
     greater: 2,
     greater_equal: 2,
     is_nil: 1,
@@ -147,6 +147,12 @@ defmodule Explorer.PolarsBackend.Expression do
     expr_list = Enum.map(series_list, &to_expr/1)
 
     Native.expr_concat(expr_list)
+  end
+
+  def to_expr(%LazySeries{op: :format, args: [series_list]}) when is_list(series_list) do
+    expr_list = Enum.map(series_list, &to_expr/1)
+
+    Native.expr_format(expr_list)
   end
 
   for {op, _arity} <- @first_only_expressions do

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -27,6 +27,7 @@ defmodule Explorer.PolarsBackend.Expression do
     equal: 2,
     fill_missing_with_value: 2,
     first: 1,
+    format: 2,
     greater: 2,
     greater_equal: 2,
     is_nil: 1,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -211,6 +211,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_fill_missing_with_atom(_s, _value), do: err()
   def s_fill_missing_with_date(_s, _value), do: err()
   def s_fill_missing_with_datetime(_s, _value), do: err()
+  def s_format(_s, _other), do: err()
   def s_greater(_s, _rhs), do: err()
   def s_greater_equal(_s, _rhs), do: err()
   def s_head(_s, _length), do: err()

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -219,7 +219,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_fill_missing_with_atom(_s, _value), do: err()
   def s_fill_missing_with_date(_s, _value), do: err()
   def s_fill_missing_with_datetime(_s, _value), do: err()
-  def s_format(_s, _other), do: err()
+  def s_format(_series_list), do: err()
   def s_greater(_s, _rhs), do: err()
   def s_greater_equal(_s, _rhs), do: err()
   def s_head(_s, _length), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -118,6 +118,9 @@ defmodule Explorer.PolarsBackend.Series do
   def at(series, idx), do: Shared.apply_series(series, :s_at, [idx])
 
   @impl true
+  def format(s1, s2), do: Shared.apply_series(matching_size!(s1, s2), :s_format, [s2.data])
+
+  @impl true
   def concat(s1, s2), do: Shared.apply_series(s1, :s_concat, [s2.data])
 
   @impl true

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -123,7 +123,7 @@ defmodule Explorer.PolarsBackend.Series do
 
     case Explorer.PolarsBackend.Native.s_format(polars_series) do
       {:ok, %__MODULE__{} = new_series} -> Shared.create_series(new_series)
-      {:error, error} -> raise "Cannot concat series with Polars. Reason: #{inspect(error)}"
+      {:error, error} -> raise "cannot format series with Polars, reason: #{inspect(error)}"
     end
   end
 
@@ -133,7 +133,7 @@ defmodule Explorer.PolarsBackend.Series do
 
     case Explorer.PolarsBackend.Native.s_concat(polars_series) do
       {:ok, %__MODULE__{} = new_series} -> Shared.create_series(new_series)
-      {:error, error} -> raise "Cannot concat series with Polars. Reason: #{inspect(error)}"
+      {:error, error} -> raise "cannot concat series with Polars, reason: #{inspect(error)}"
     end
   end
 

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -118,7 +118,14 @@ defmodule Explorer.PolarsBackend.Series do
   def at(series, idx), do: Shared.apply_series(series, :s_at, [idx])
 
   @impl true
-  def format(s1, s2), do: Shared.apply_series(matching_size!(s1, s2), :s_format, [s2.data])
+  def format(list) do
+    polars_series = for s <- list, do: s.data
+
+    case Explorer.PolarsBackend.Native.s_format(polars_series) do
+      {:ok, %__MODULE__{} = new_series} -> Shared.create_series(new_series)
+      {:error, error} -> raise "Cannot concat series with Polars. Reason: #{inspect(error)}"
+    end
+  end
 
   @impl true
   def concat([%Series{} | _] = series) do

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1401,22 +1401,15 @@ defmodule Explorer.Series do
   @spec format([
           Series.t() | number() | Date.t() | Time.t() | NaiveDateTime.t() | boolean() | String.t()
         ]) :: Series.t()
-  def format([%Series{} = h | t] = _list), do: Enum.reduce(t, h, &format_reducer/2)
+  def format([_ | _] = list), do: Shared.apply_series_impl(:format, [cast_to_string(list)])
 
-  def format([h | t] = _list),
-    do: Enum.reduce(t, from_list([h], dtype: :string), &format_reducer/2)
-
-  defp format_reducer(%Series{} = s, %Series{dtype: :string} = acc),
-    do: Shared.apply_series_impl(:format, [acc, cast(s, :string)])
-
-  defp format_reducer(s, %Series{dtype: :string} = acc),
-    do: Shared.apply_series_impl(:format, [acc, from_list([s], dtype: :string)])
-
-  defp format_reducer(%Series{} = s, %Series{} = acc),
-    do: Shared.apply_series_impl(:format, [cast(acc, :string), cast(s, :string)])
-
-  defp format_reducer(s, %Series{} = acc),
-    do: Shared.apply_series_impl(:format, [cast(acc, :string), from_list([s], dtype: :string)])
+  defp cast_to_string(list) do
+    Enum.map(list, fn
+      %Series{dtype: :string} = s -> s
+      %Series{} = s -> cast(s, :string)
+      value -> from_list([value], dtype: :string)
+    end)
+  end
 
   @doc """
   Concatenate one or more series.

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1398,16 +1398,23 @@ defmodule Explorer.Series do
       ** (RuntimeError) External error: invalid utf-8 sequence
   """
   @doc type: :shape
-  @spec format([
-          Series.t() | number() | Date.t() | Time.t() | NaiveDateTime.t() | boolean() | String.t()
-        ]) :: Series.t()
+  @spec format([Series.t() | String.t()]) :: Series.t()
   def format([_ | _] = list), do: Shared.apply_series_impl(:format, [cast_to_string(list)])
 
   defp cast_to_string(list) do
     Enum.map(list, fn
-      %Series{dtype: :string} = s -> s
-      %Series{} = s -> cast(s, :string)
-      value -> from_list([value], dtype: :string)
+      %Series{dtype: :string} = s ->
+        s
+
+      %Series{} = s ->
+        cast(s, :string)
+
+      value when is_binary(value) ->
+        from_list([value], dtype: :string)
+
+      other ->
+        raise ArgumentError,
+              "format/1 expects a list of series or strings, got: #{inspect(other)}"
     end)
   end
 

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -29,6 +29,7 @@ version = "0.26.1"
 default-features = false
 features = [
   "checked_arithmetic",
+  "concat_str",
   "cross_join",
   "cum_agg",
   "csv-file",

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -5,7 +5,7 @@
 // wrapped in an Elixir struct.
 
 use chrono::{NaiveDate, NaiveDateTime};
-use polars::prelude::{col, when, IntoLazy, LiteralValue, SortOptions};
+use polars::prelude::{col, concat_str, when, IntoLazy, LiteralValue, SortOptions};
 use polars::prelude::{DataType, Expr, Literal};
 
 use crate::datatypes::{ExDate, ExDateTime};
@@ -454,6 +454,11 @@ pub fn expr_last(expr: ExExpr) -> ExExpr {
     let expr = expr.clone_inner();
 
     ExExpr::new(expr.last())
+}
+
+#[rustler::nif]
+pub fn expr_format(exprs: Vec<ExExpr>) -> ExExpr {
+    ExExpr::new(concat_str(ex_expr_to_exprs(exprs), ""))
 }
 
 #[rustler::nif]

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -266,6 +266,7 @@ rustler::init!(
         s_fill_missing_with_atom,
         s_fill_missing_with_date,
         s_fill_missing_with_datetime,
+        s_format,
         s_greater,
         s_greater_equal,
         s_head,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -172,6 +172,7 @@ rustler::init!(
         expr_subtract,
         // slice and dice expressions
         expr_coalesce,
+        expr_format,
         expr_concat,
         expr_select,
         // agg expressions

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -162,6 +162,11 @@ pub fn s_slice(series: ExSeries, offset: i64, length: usize) -> Result<ExSeries,
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_format(s: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
+    Ok(ExSeries::new(s.utf8()?.concat(other.utf8()?).into_series()))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_concat(data: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
     let mut s = data.clone_inner();
     let s1 = other.clone_inner();

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -162,13 +162,15 @@ pub fn s_slice(series: ExSeries, offset: i64, length: usize) -> Result<ExSeries,
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_format(list: Vec<ExSeries>) -> Result<ExSeries, ExplorerError> {
-    Ok(list
-        .into_iter()
-        .reduce(|acc, s2| {
-            ExSeries::new(acc.utf8().unwrap().concat(s2.utf8().unwrap()).into_series())
-        })
-        .unwrap())
+pub fn s_format(series_vec: Vec<ExSeries>) -> Result<ExSeries, ExplorerError> {
+    let mut iter = series_vec.iter();
+    let mut series = iter.next().unwrap().clone_inner().utf8()?.clone();
+
+    for s in iter {
+        series = series.concat(s.utf8()?);
+    }
+
+    Ok(ExSeries::new(series.into_series()))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -162,8 +162,13 @@ pub fn s_slice(series: ExSeries, offset: i64, length: usize) -> Result<ExSeries,
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_format(s: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
-    Ok(ExSeries::new(s.utf8()?.concat(other.utf8()?).into_series()))
+pub fn s_format(list: Vec<ExSeries>) -> Result<ExSeries, ExplorerError> {
+    Ok(list
+        .into_iter()
+        .reduce(|acc, s2| {
+            ExSeries::new(acc.utf8().unwrap().concat(s2.utf8().unwrap()).into_series())
+        })
+        .unwrap())
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2245,22 +2245,6 @@ defmodule Explorer.SeriesTest do
       assert Series.format([s1, s2]) |> Series.to_list() == ["13", "24"]
     end
 
-    test "with two integers" do
-      assert Series.format([1, 2]) |> Series.to_list() == ["12"]
-    end
-
-    test "with an integer series and an integer value" do
-      s1 = Series.from_list([1, 2])
-
-      assert Series.format([s1, 3]) |> Series.to_list() == ["13", "23"]
-    end
-
-    test "with an integer value and an integer series" do
-      s1 = Series.from_list([1, 2])
-
-      assert Series.format([3, s1]) |> Series.to_list() == ["31", "32"]
-    end
-
     test "with many integer series with separator" do
       s1 = Series.from_list([1, 2])
       s2 = Series.from_list([3, 4])
@@ -2278,22 +2262,6 @@ defmodule Explorer.SeriesTest do
       assert Series.format([s1, s2]) |> Series.to_list() == ["1.23.1", "2.64.9"]
     end
 
-    test "with two floats" do
-      assert Series.format([1.5, :nan]) |> Series.to_list() == ["1.5NaN"]
-    end
-
-    test "with a float series and a float value" do
-      s1 = Series.from_list([1.5, :nan])
-
-      assert Series.format([s1, :infinity]) |> Series.to_list() == ["1.5inf", "NaNinf"]
-    end
-
-    test "with a float value and a float series" do
-      s1 = Series.from_list([1.5, :nan])
-
-      assert Series.format([:neg_infinity, s1]) |> Series.to_list() == ["-inf1.5", "-infNaN"]
-    end
-
     test "with many float series with separator" do
       s1 = Series.from_list([1.5, 2.7])
       s2 = Series.from_list([:nan, :infinity])
@@ -2309,22 +2277,6 @@ defmodule Explorer.SeriesTest do
       s2 = Series.from_list([true, false])
 
       assert Series.format([s1, s2]) |> Series.to_list() == ["truetrue", "falsefalse"]
-    end
-
-    test "with two booleans" do
-      assert Series.format([true, false]) |> Series.to_list() == ["truefalse"]
-    end
-
-    test "with a boolean series and a boolean value" do
-      s1 = Series.from_list([true, false])
-
-      assert Series.format([s1, true]) |> Series.to_list() == ["truetrue", "falsetrue"]
-    end
-
-    test "with a boolean value and a boolean series" do
-      s1 = Series.from_list([true, false])
-
-      assert Series.format([true, s1]) |> Series.to_list() == ["truetrue", "truefalse"]
     end
 
     test "with many boolean series with separator" do
@@ -2345,31 +2297,24 @@ defmodule Explorer.SeriesTest do
                ["2023-01-012023-01-03", "2023-01-022023-01-04"]
     end
 
+    test "with many date series with separator" do
+      s1 = Series.from_list([~D[2023-01-01], ~D[2023-01-02]])
+      s2 = Series.from_list([~D[2023-01-03], ~D[2023-01-04]])
+      s3 = Series.from_list([~D[2023-01-05], ~D[2023-01-06]])
+      s4 = Series.from_list([~D[2023-01-07], ~D[2023-01-08]])
+
+      assert Series.format([s1, " / ", s2, " - ", s3, " / ", s4]) |> Series.to_list() == [
+               "2023-01-01 / 2023-01-03 - 2023-01-05 / 2023-01-07",
+               "2023-01-02 / 2023-01-04 - 2023-01-06 / 2023-01-08"
+             ]
+    end
+
     test "with two time series" do
       s1 = Series.from_list([~T[01:00:00.000000], ~T[02:00:00.000000]])
       s2 = Series.from_list([~T[03:00:00.000000], ~T[04:00:00.000000]])
 
       assert Series.format([s1, s2]) |> Series.to_list() ==
                ["360000000010800000000", "720000000014400000000"]
-    end
-
-    test "with two times" do
-      assert Series.format([~T[01:00:00.000000], ~T[02:00:00.000000]]) |> Series.to_list() ==
-               ["36000000007200000000"]
-    end
-
-    test "with a time series and a time value" do
-      s1 = Series.from_list([~T[01:00:00.000000], ~T[02:00:00.000000]])
-
-      assert Series.format([s1, ~T[03:00:00.000000]]) |> Series.to_list() ==
-               ["360000000010800000000", "720000000010800000000"]
-    end
-
-    test "with a time value and a time series" do
-      s1 = Series.from_list([~T[01:00:00.000000], ~T[02:00:00.000000]])
-
-      assert Series.format([~T[03:00:00.000000], s1]) |> Series.to_list() ==
-               ["108000000003600000000", "108000000007200000000"]
     end
 
     test "with many time series with separator" do
@@ -2384,37 +2329,6 @@ defmodule Explorer.SeriesTest do
              ]
     end
 
-    test "with two dates" do
-      assert Series.format([~D[2023-01-01], ~D[2023-01-02]]) |> Series.to_list() ==
-               ["2023-01-012023-01-02"]
-    end
-
-    test "with a date series and a date value" do
-      s1 = Series.from_list([~D[2023-01-01], ~D[2023-01-02]])
-
-      assert Series.format([s1, ~D[2023-01-03]]) |> Series.to_list() ==
-               ["2023-01-012023-01-03", "2023-01-022023-01-03"]
-    end
-
-    test "with a date value and a date series" do
-      s1 = Series.from_list([~D[2023-01-01], ~D[2023-01-02]])
-
-      assert Series.format([~D[2023-01-03], s1]) |> Series.to_list() ==
-               ["2023-01-032023-01-01", "2023-01-032023-01-02"]
-    end
-
-    test "with many date series with separator" do
-      s1 = Series.from_list([~D[2023-01-01], ~D[2023-01-02]])
-      s2 = Series.from_list([~D[2023-01-03], ~D[2023-01-04]])
-      s3 = Series.from_list([~D[2023-01-05], ~D[2023-01-06]])
-      s4 = Series.from_list([~D[2023-01-07], ~D[2023-01-08]])
-
-      assert Series.format([s1, " / ", s2, " - ", s3, " / ", s4]) |> Series.to_list() == [
-               "2023-01-01 / 2023-01-03 - 2023-01-05 / 2023-01-07",
-               "2023-01-02 / 2023-01-04 - 2023-01-06 / 2023-01-08"
-             ]
-    end
-
     test "with two datetime series" do
       s1 = Series.from_list([~N[2023-01-01 01:00:00.000000], ~N[2023-01-02 02:00:00.000000]])
       s2 = Series.from_list([~N[2023-01-03 03:00:00.000000], ~N[2023-01-04 04:00:00.000000]])
@@ -2422,31 +2336,6 @@ defmodule Explorer.SeriesTest do
       assert Series.format([s1, s2]) |> Series.to_list() == [
                "2023-01-01 01:00:00.0000002023-01-03 03:00:00.000000",
                "2023-01-02 02:00:00.0000002023-01-04 04:00:00.000000"
-             ]
-    end
-
-    test "with two datetimes" do
-      list = [~N[2023-01-01 01:00:00.000000], ~N[2023-01-02 02:00:00.000000]]
-
-      assert Series.format(list) |> Series.to_list() ==
-               ["2023-01-01 01:00:00.0000002023-01-02 02:00:00.000000"]
-    end
-
-    test "with a datetime series and a datetime value" do
-      s1 = Series.from_list([~N[2023-01-01 01:00:00.000000], ~N[2023-01-02 02:00:00.000000]])
-
-      assert Series.format([s1, ~N[2023-01-03 03:00:00.000000]]) |> Series.to_list() == [
-               "2023-01-01 01:00:00.0000002023-01-03 03:00:00.000000",
-               "2023-01-02 02:00:00.0000002023-01-03 03:00:00.000000"
-             ]
-    end
-
-    test "with a datetime value and a datetime series" do
-      s1 = Series.from_list([~N[2023-01-01 01:00:00.000000], ~N[2023-01-02 02:00:00.000000]])
-
-      assert Series.format([~N[2023-01-03 03:00:00.000000], s1]) |> Series.to_list() == [
-               "2023-01-03 03:00:00.0000002023-01-01 01:00:00.000000",
-               "2023-01-03 03:00:00.0000002023-01-02 02:00:00.000000"
              ]
     end
 


### PR DESCRIPTION
This PR resolves https://github.com/elixir-nx/explorer/issues/297.

Thanks for the help @philss!

After this PR:

```elixir
iex> s1 = Explorer.Series.from_list(["a", "b", "c"])
iex> s2 = Explorer.Series.from_list(["d", "e", "f"])
iex> s3 = Explorer.Series.from_list(["g", "h", "i"])
iex> Explorer.Series.format([s1, s2, s3])
#Explorer.Series<
  Polars[3]
  string ["adg", "beh", "cfi"]
>

iex> s1 = Explorer.Series.from_list(["a", "b", "c", "d"])
iex> s2 = Explorer.Series.from_list([1, 2, 3, 4])
iex> s3 = Explorer.Series.from_list([1.5, :nan, :infinity, :neg_infinity])
iex> Explorer.Series.format([s1, "/", s2, "/", s3])
#Explorer.Series<
  Polars[4]
  string ["a/1/1.5", "b/2/NaN", "c/3/inf", "d/4/-inf"]
>

iex> s1 = Explorer.Series.from_list([<<1>>, <<239, 191, 19>>], dtype: :binary)
iex> s2 = Explorer.Series.from_list([<<3>>, <<4>>], dtype: :binary)
iex> Explorer.Series.format([s1, s2])
** (RuntimeError) External error: invalid utf-8 sequence

# With DataFrame:

iex> df = Explorer.DataFrame.new([a: ["a", "b", "c"], b: ["d", "e", "f"]])                                
#Explorer.DataFrame<
  Polars[3 x 2]
  a string ["a", "b", "c"]
  b string ["d", "e", "f"]
>

iex> Explorer.DataFrame.mutate_with(df, fn df -> [c: Explorer.Series.format([df["a"], "/", df["b"]])] end)
#Explorer.DataFrame<
  Polars[3 x 3]
  a string ["a", "b", "c"]
  b string ["d", "e", "f"]
  c string ["a/d", "b/e", "c/f"]
>

iex> ldf = Explorer.DataFrame.new([a: ["a", "b", "c"], b: ["d", "e", "f"]], lazy: true)                   
#Explorer.DataFrame<
  LazyPolars[??? x 2]
  a string ["a", "b", "c"]
  b string ["d", "e", "f"]
>

iex> Explorer.DataFrame.mutate_with(ldf, fn ldf -> [c: Explorer.Series.format([ldf["a"], "/", ldf["b"]])] end)
#Explorer.DataFrame<
  LazyPolars[??? x 3]
  a string ["a", "b", "c"]
  b string ["d", "e", "f"]
  c string ["a/d", "b/e", "c/f"]
>
```