### PR TITLE
Change Series "concat" callback to be of arity 1

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -39,7 +39,7 @@ defmodule Explorer.Backend.LazySeries do
     pow: 2,
     fill_missing_with_value: 2,
     fill_missing_with_strategy: 2,
-    concat: 2,
+    concat: 1,
     coalesce: 2,
     cast: 2,
     select: 3,
@@ -410,18 +410,11 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   @impl true
-  def concat(%Series{} = left, %Series{} = right) do
-    args = [series_or_lazy_series!(left), series_or_lazy_series!(right)]
-    data = new(:concat, args, aggregations?(args))
+  def concat([%Series{} = head | _tail] = series) do
+    series_list = Enum.map(series, &series_or_lazy_series!/1)
+    data = new(:concat, [series_list], aggregations?(series_list))
 
-    dtype =
-      if left.dtype in [:float, :integer] do
-        resolve_numeric_dtype([left, right])
-      else
-        left.dtype
-      end
-
-    Backend.Series.new(data, dtype)
+    Backend.Series.new(data, head.dtype)
   end
 
   @impl true
@@ -524,15 +517,15 @@ defmodule Explorer.Backend.LazySeries do
 
   @impl true
   def inspect(series, opts) do
-    import Inspect.Algebra
+    alias Inspect.Algebra, as: A
 
-    open = color("(", :list, opts)
-    close = color(")", :list, opts)
-    dtype = color("#{Series.dtype(series)}", :atom, opts)
+    open = A.color("(", :list, opts)
+    close = A.color(")", :list, opts)
+    dtype = A.color("#{Series.dtype(series)}", :atom, opts)
 
-    concat([
-      color("LazySeries[???]", :atom, opts),
-      line(),
+    A.concat([
+      A.color("LazySeries[???]", :atom, opts),
+      A.line(),
       dtype,
       " ",
       open,

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -47,7 +47,7 @@ defmodule Explorer.Backend.Series do
   @callback mask(s, mask :: s) :: s
   @callback slice(s, indices :: list()) :: s
   @callback slice(s, offset :: integer(), length :: integer()) :: s
-  @callback concat(s, s) :: s
+  @callback concat([s]) :: s
   @callback coalesce(s, s) :: s
   @callback first(s) :: valid_types() | lazy_s()
   @callback last(s) :: valid_types() | lazy_s()
@@ -177,7 +177,7 @@ defmodule Explorer.Backend.Series do
     %Explorer.Series{data: data, dtype: dtype}
   end
 
-  import Inspect.Algebra
+  alias Inspect.Algebra, as: A
   alias Explorer.Series
 
   @doc """
@@ -185,12 +185,12 @@ defmodule Explorer.Backend.Series do
   """
   def inspect(series, backend, n_rows, inspect_opts, opts \\ [])
       when is_binary(backend) and (is_integer(n_rows) or is_nil(n_rows)) and is_list(opts) do
-    open = color("[", :list, inspect_opts)
-    close = color("]", :list, inspect_opts)
-    dtype = color("#{Series.dtype(series)} ", :atom, inspect_opts)
+    open = A.color("[", :list, inspect_opts)
+    close = A.color("]", :list, inspect_opts)
+    dtype = A.color("#{Series.dtype(series)} ", :atom, inspect_opts)
 
     data =
-      container_doc(
+      A.container_doc(
         open,
         series |> Series.slice(0, inspect_opts.limit + 1) |> Series.to_list(),
         close,
@@ -198,12 +198,12 @@ defmodule Explorer.Backend.Series do
         &Explorer.Shared.to_string/2
       )
 
-    concat([
-      color(backend, :atom, inspect_opts),
+    A.concat([
+      A.color(backend, :atom, inspect_opts),
       open,
       "#{n_rows || "???"}",
       close,
-      line(),
+      A.line(),
       dtype,
       data
     ])

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -476,13 +476,15 @@ defmodule Explorer.PolarsBackend.DataFrame do
     {:ok, group_indices} = Native.df_group_indices(df.data, df.groups)
 
     idx =
-      Enum.reduce(group_indices, Native.s_from_list_u32("idx", []), fn series, acc ->
+      Enum.map(group_indices, fn series ->
         {:ok, size} = Native.s_size(series)
         indices = Enum.slice(0..(size - 1)//1, range)
+
         {:ok, sliced} = Native.s_slice_by_indices(series, indices)
-        {:ok, acc} = Native.s_concat(acc, sliced)
-        acc
+        sliced
       end)
+
+    {:ok, idx} = Native.s_concat(idx)
 
     Shared.apply_dataframe(df, df, :df_slice_by_series, [idx])
   end

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -19,7 +19,6 @@ defmodule Explorer.PolarsBackend.Expression do
     binary_or: 2,
     binary_in: 2,
     coalesce: 2,
-    concat: 2,
     count: 1,
     day_of_week: 1,
     distinct: 1,
@@ -99,6 +98,7 @@ defmodule Explorer.PolarsBackend.Expression do
     from_binary: 2,
     to_lazy: 1,
     shift: 3,
+    concat: 1,
     column: 1
   ]
 
@@ -140,6 +140,12 @@ defmodule Explorer.PolarsBackend.Expression do
 
   def to_expr(%LazySeries{op: :column, args: [name]}) do
     Native.expr_column(name)
+  end
+
+  def to_expr(%LazySeries{op: :concat, args: [series_list]}) when is_list(series_list) do
+    expr_list = Enum.map(series_list, &to_expr/1)
+
+    Native.expr_concat(expr_list)
   end
 
   for {op, _arity} <- @first_only_expressions do

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -202,7 +202,7 @@ defmodule Explorer.PolarsBackend.Native do
   def s_categories(_s), do: err()
   def s_categorise(_s, _s_categories), do: err()
   def s_coalesce(_s, _other), do: err()
-  def s_concat(_s, _other), do: err()
+  def s_concat(_series_list), do: err()
   def s_contains(_s, _pattern), do: err()
   def s_cumulative_max(_s, _reverse), do: err()
   def s_cumulative_min(_s, _reverse), do: err()

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1398,17 +1398,18 @@ defmodule Explorer.Series do
     dtypes = series |> Enum.map(& &1.dtype) |> Enum.uniq()
 
     case dtypes do
-      [_single] ->
+      [_dtype] ->
         Shared.apply_series_impl(:concat, [series])
 
       [a, b] when K.and(is_numeric_dtype(a), is_numeric_dtype(b)) ->
         casted_series = Enum.map(series, &cast(&1, :float))
+
         Shared.apply_series_impl(:concat, [casted_series])
 
       incompatible ->
         raise ArgumentError,
               "cannot concatenate series with mismatched dtypes: #{inspect(incompatible)}. " <>
-                "First cast the series to the desired dtypes."
+                "First cast the series to the desired dtype."
     end
   end
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1386,7 +1386,7 @@ defmodule Explorer.Series do
 
       iex> s1 = Explorer.Series.from_list([1, 2, 3])
       iex> s2 = Explorer.Series.from_list([4.0, 5.0, 6.4])
-      iex> Explorer.Series.concat(s1, s2)
+      iex> Explorer.Series.concat([s1, s2])
       #Explorer.Series<
         Polars[6]
         float [1.0, 2.0, 3.0, 4.0, 5.0, 6.4]
@@ -1394,12 +1394,26 @@ defmodule Explorer.Series do
   """
   @doc type: :shape
   @spec concat([Series.t()]) :: Series.t()
-  def concat([%Series{} = h | t] = _series) do
-    Enum.reduce(t, h, &concat_reducer/2)
+  def concat([%Series{} | _t] = series) do
+    dtypes = series |> Enum.map(& &1.dtype) |> Enum.uniq()
+
+    case dtypes do
+      [_single] ->
+        Shared.apply_series_impl(:concat, [series])
+
+      [a, b] when K.and(is_numeric_dtype(a), is_numeric_dtype(b)) ->
+        casted_series = Enum.map(series, &cast(&1, :float))
+        Shared.apply_series_impl(:concat, [casted_series])
+
+      incompatible ->
+        raise ArgumentError,
+              "cannot concatenate series with mismatched dtypes: #{inspect(incompatible)}. " <>
+                "First cast the series to the desired dtypes."
+    end
   end
 
   @doc """
-  Concatenate one or more series.
+  Concatenate two series.
 
   `concat(s1, s2)` is equivalent to `concat([s1, s2])`.
   """
@@ -1407,20 +1421,6 @@ defmodule Explorer.Series do
   @spec concat(s1 :: Series.t(), s2 :: Series.t()) :: Series.t()
   def concat(%Series{} = s1, %Series{} = s2),
     do: concat([s1, s2])
-
-  defp concat_reducer(%Series{dtype: dtype} = s, %Series{dtype: dtype} = acc),
-    do: Shared.apply_series_impl(:concat, [acc, s])
-
-  defp concat_reducer(%Series{dtype: s_dtype} = s, %Series{dtype: acc_dtype} = acc)
-       when K.and(s_dtype == :float, acc_dtype == :integer),
-       do: Shared.apply_series_impl(:concat, [cast(acc, :float), s])
-
-  defp concat_reducer(%Series{dtype: s_dtype} = s, %Series{dtype: acc_dtype} = acc)
-       when K.and(s_dtype == :integer, acc_dtype == :float),
-       do: Shared.apply_series_impl(:concat, [acc, cast(s, :float)])
-
-  defp concat_reducer(%Series{dtype: dtype1}, %Series{dtype: dtype2}),
-    do: raise(ArgumentError, "dtypes must match, found #{dtype1} and #{dtype2}")
 
   @doc """
   Finds the first non-missing element at each position.

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -140,6 +140,8 @@ defmodule Explorer.Shared do
     apply(impl, fun, series_or_scalars)
   end
 
+  defp series_impl!([[%{data: _} | _others] = series_list]), do: series_impl!(series_list)
+
   defp series_impl!(series_or_scalars) when is_list(series_or_scalars) do
     impl =
       Enum.reduce(series_or_scalars, nil, fn

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -457,11 +457,15 @@ pub fn expr_last(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
-pub fn expr_concat(left: ExExpr, right: ExExpr) -> ExExpr {
-    let left_expr = left.clone_inner();
-    let right_expr = right.clone_inner();
+pub fn expr_concat(exprs: Vec<ExExpr>) -> ExExpr {
+    let mut iter = exprs.iter();
+    let mut result = iter.next().unwrap().clone_inner();
 
-    ExExpr::new(left_expr.append(right_expr, false))
+    for expr in iter {
+        result = result.append(expr.clone_inner(), false);
+    }
+
+    ExExpr::new(result)
 }
 
 #[rustler::nif]

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -162,11 +162,15 @@ pub fn s_slice(series: ExSeries, offset: i64, length: usize) -> Result<ExSeries,
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn s_concat(data: ExSeries, other: ExSeries) -> Result<ExSeries, ExplorerError> {
-    let mut s = data.clone_inner();
-    let s1 = other.clone_inner();
-    s.append(&s1)?;
-    Ok(ExSeries::new(s))
+pub fn s_concat(series_vec: Vec<ExSeries>) -> Result<ExSeries, ExplorerError> {
+    let mut iter = series_vec.iter();
+    let mut series = iter.next().unwrap().clone_inner();
+
+    for s in iter {
+        series.append(s)?;
+    }
+
+    Ok(ExSeries::new(series))
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2648,4 +2648,52 @@ defmodule Explorer.SeriesTest do
       end
     end
   end
+
+  describe "concat/1" do
+    test "concat integer series" do
+      s1 = Series.from_list([1, 2, 3])
+      s2 = Series.from_list([4, 5, 6])
+
+      s3 = Series.concat([s1, s2])
+
+      assert Series.size(s3) == 6
+      assert Series.to_list(s3) == [1, 2, 3, 4, 5, 6]
+      assert Series.dtype(s3) == :integer
+    end
+
+    test "concat float series" do
+      s1 = Series.from_list([1.0, 2.1, 3.2])
+      s2 = Series.from_list([4.3, 5.4, 6.5])
+
+      s3 = Series.concat([s1, s2])
+
+      assert Series.size(s3) == 6
+      assert Series.to_list(s3) == [1.0, 2.1, 3.2, 4.3, 5.4, 6.5]
+      assert Series.dtype(s3) == :float
+    end
+
+    test "concat integer and float series" do
+      s1 = Series.from_list([1, 2, 3])
+      s2 = Series.from_list([4.3, 5.4, 6.5])
+
+      s3 = Series.concat([s1, s2])
+
+      assert Series.size(s3) == 6
+      assert Series.to_list(s3) == [1.0, 2.0, 3.0, 4.3, 5.4, 6.5]
+      assert Series.dtype(s3) == :float
+    end
+
+    test "concat incompatible dtypes" do
+      s1 = Series.from_list([1, 2, 3])
+      s2 = Series.from_list(["a", "b", "c"])
+
+      error_message =
+        "cannot concatenate series with mismatched dtypes: [:integer, :string]. " <>
+          "First cast the series to the desired dtypes."
+
+      assert_raise ArgumentError, error_message, fn ->
+        Series.concat([s1, s2])
+      end
+    end
+  end
 end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2689,7 +2689,7 @@ defmodule Explorer.SeriesTest do
 
       error_message =
         "cannot concatenate series with mismatched dtypes: [:integer, :string]. " <>
-          "First cast the series to the desired dtypes."
+          "First cast the series to the desired dtype."
 
       assert_raise ArgumentError, error_message, fn ->
         Series.concat([s1, s2])


### PR DESCRIPTION
This is needed to reduce the back-and-forth between Elixir and Rust. The idea is to have fewer copies.

Closes https://github.com/elixir-nx/explorer/issues/521