### PR TITLE
Add integer typecheck guard to Series.shift

### DIFF
--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1056,6 +1056,11 @@ defmodule Explorer.Series do
       when is_integer(offset),
       do: Shared.apply_impl(series, :shift, [offset, nil])
 
+  def shift(_series, offset) do
+    raise ArgumentError,
+          "shift/2 offset requires an :integer, got #{inspect(offset)}"
+  end
+
   @doc """
   Returns a series from two series, based on a predicate.
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1056,11 +1056,6 @@ defmodule Explorer.Series do
       when is_integer(offset),
       do: Shared.apply_impl(series, :shift, [offset, nil])
 
-  def shift(_series, offset) do
-    raise ArgumentError,
-          "shift/2 offset requires an :integer, got #{inspect(offset)}"
-  end
-
   @doc """
   Returns a series from two series, based on a predicate.
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1052,7 +1052,11 @@ defmodule Explorer.Series do
   """
   @doc type: :shape
   @spec shift(series :: Series.t(), offset :: integer()) :: Series.t()
-  def shift(series, offset), do: Shared.apply_impl(series, :shift, [offset, nil])
+  def shift(series, offset)
+      when is_integer(offset),
+      do: Shared.apply_impl(series, :shift, [offset, nil])
+
+  def shift(_series, dtype), do: dtype_error("shift/2", dtype, [:integer])
 
   @doc """
   Returns a series from two series, based on a predicate.

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1056,8 +1056,6 @@ defmodule Explorer.Series do
       when is_integer(offset),
       do: Shared.apply_impl(series, :shift, [offset, nil])
 
-  def shift(_series, dtype), do: dtype_error("shift/2", dtype, [:integer])
-
   @doc """
   Returns a series from two series, based on a predicate.
 


### PR DESCRIPTION
Add an integer typecheck guard to Series.shift, as discussed in issue #523.

This improves the error returned when calling Series.shift with a float or some other invalid datatype.

Before:
```
iex> Explorer.Series.shift(s, 1.0)
** (ArgumentError) argument error
    (explorer 0.6.0-dev) Explorer.PolarsBackend.Native.s_shift(#Explorer.PolarsBackend.Series<
  shape: (5,)
  Series: '' [i64]
  [
        1
        2
        3
        4
        5
  ]
>, 1.0)
    (explorer 0.6.0-dev) lib/explorer/polars_backend/shared.ex:23: Explorer.PolarsBackend.Shared.apply_series/3
    iex:3: (file)
```

After:
```
iex> Explorer.Series.shift(s, 1.0)
** (ArgumentError) Explorer.Series.shift/2 not implemented for dtype 1.0. Valid dtypes are [:integer]
    (explorer 0.6.0-dev) lib/explorer/series.ex:3622: Explorer.Series.dtype_error/3
    iex:3: (file)
```