### PR TITLE
Fix dtype for series of nils in DF.new

### DIFF
--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -309,7 +309,16 @@ defmodule Explorer.PolarsBackend.DataFrame do
       column_name = to_column_name!(key)
       values = Enum.to_list(columns[key])
       dtype = Map.get(dtypes, column_name)
-      series_from_list!(column_name, values, dtype)
+
+      column_name
+      |> series_from_list!(values, dtype)
+      |> then(fn series ->
+        if not is_nil(dtype) and series.dtype != dtype do
+          PolarsSeries.cast(series, dtype)
+        else
+          series
+        end
+      end)
     end)
     |> from_series_list()
   end

--- a/lib/explorer/shared.ex
+++ b/lib/explorer/shared.ex
@@ -199,7 +199,7 @@ defmodule Explorer.Shared do
         end
       end)
 
-    type || :float
+    type || preferable_type || :float
   end
 
   defp type(item, type) when is_integer(item) and type == :float, do: :numeric

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -176,6 +176,45 @@ defmodule Explorer.DataFrameTest do
         DF.new(%{binaries: [<<228, 146, 51>>, <<22, 197, 116>>, <<42, 209, 236>>]})
       end
     end
+
+    test "with series of nils and dtype string" do
+      df =
+        DF.new(%{strings: [nil, nil, nil]},
+          dtypes: [{:strings, :string}]
+        )
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               strings: [nil, nil, nil]
+             }
+
+      assert DF.dtypes(df) == %{"strings" => :string}
+    end
+
+    test "with series of nils and dtype integer" do
+      df =
+        DF.new(%{integers: [nil, nil, nil]},
+          dtypes: [{:integers, :integer}]
+        )
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               integers: [nil, nil, nil]
+             }
+
+      assert DF.dtypes(df) == %{"integers" => :integer}
+    end
+
+    test "with series of integers and dtype string" do
+      df =
+        DF.new(%{strings: [1, 2, 3]},
+          dtypes: [{:strings, :string}]
+        )
+
+      assert DF.to_columns(df, atom_keys: true) == %{
+               strings: ["1", "2", "3"]
+             }
+
+      assert DF.dtypes(df) == %{"strings" => :string}
+    end
   end
 
   describe "mask/2" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -167,6 +167,13 @@ defmodule Explorer.SeriesTest do
       assert Series.to_list(s) === ["a", "b", "c"]
       assert Series.dtype(s) == :category
     end
+
+    test "with nils series as string series" do
+      s = Series.from_list([nil, nil, nil], dtype: :string)
+
+      assert Series.to_list(s) === [nil, nil, nil]
+      assert Series.dtype(s) == :string
+    end
   end
 
   describe "fetch/2" do


### PR DESCRIPTION
This is going to respect the desired dtype, and if it's not possible to create with that dtype, then we cast the series.

Closes https://github.com/elixir-nx/explorer/issues/528