### PR TITLE
Fix pivot wider if the series of column names contains nil

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -161,7 +161,6 @@ defmodule Explorer.Backend.DataFrame do
   @callback drop_nil(df, columns :: [column_name()]) :: df
   @callback pivot_wider(
               df,
-              out_df :: df(),
               id_columns :: [column_name()],
               names_from :: column_name(),
               values_from :: column_name(),

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -3926,7 +3926,13 @@ defmodule Explorer.DataFrame do
       df[names_from]
       |> Series.distinct()
       |> Series.to_list()
-      |> Enum.map(&String.replace_prefix(&1, "", opts[:names_prefix]))
+      |> Enum.map(
+        &String.replace_prefix(
+          &1 || "nil",
+          "",
+          opts[:names_prefix]
+        )
+      )
 
     out_columns = id_columns ++ distinct_pivot_columns
 

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -534,8 +534,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
            names_prefix_optional
          ) do
       {:ok, %__MODULE__{} = polars_df} ->
-        out_df = Shared.create_dataframe(polars_df)
-        %{out_df | groups: df.groups -- [names_from, values_from]}
+        Shared.create_dataframe(polars_df)
 
       {:error, error} ->
         raise "cannot pivot wider due to Polars error: #{inspect(error)}"

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -524,7 +524,15 @@ defmodule Explorer.PolarsBackend.DataFrame do
 
   @impl true
   def pivot_wider(df, id_columns, names_from, values_from, names_prefix) do
-    case Native.df_pivot_wider(df.data, id_columns, names_from, values_from, names_prefix) do
+    names_prefix_optional = unless names_prefix == "", do: names_prefix
+
+    case Native.df_pivot_wider(
+           df.data,
+           id_columns,
+           names_from,
+           values_from,
+           names_prefix_optional
+         ) do
       {:ok, %__MODULE__{} = polars_df} ->
         out_df = Shared.create_dataframe(polars_df)
         %{out_df | groups: df.groups -- [names_from, values_from]}

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -523,16 +523,14 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def pivot_wider(df, out_df, id_columns, names_from, values_from, names_prefix) do
-    result =
-      Shared.apply_dataframe(df, out_df, :df_pivot_wider, [id_columns, names_from, values_from])
+  def pivot_wider(df, id_columns, names_from, values_from, names_prefix) do
+    case Native.df_pivot_wider(df.data, id_columns, names_from, values_from, names_prefix) do
+      {:ok, %__MODULE__{} = polars_df} ->
+        out_df = Shared.create_dataframe(polars_df)
+        %{out_df | groups: df.groups -- [names_from, values_from]}
 
-    if names_prefix == "" do
-      result
-    else
-      new_names = Shared.apply_dataframe(result, :df_names, []) -- id_columns
-      rename_pairs = for new_name <- new_names, do: {new_name, names_prefix <> new_name}
-      rename(result, out_df, rename_pairs)
+      {:error, error} ->
+        raise "cannot pivot wider due to Polars error: #{inspect(error)}"
     end
   end
 

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -370,7 +370,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
     from_ipc_stream: 2,
     mask: 2,
     n_rows: 1,
-    pivot_wider: 6,
+    pivot_wider: 5,
     pull: 2,
     put: 4,
     sample: 5,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -106,7 +106,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_n_rows(_df), do: err()
   def df_names(_df), do: err()
   def df_pivot_longer(_df, _id_vars, _value_vars, _names_to, _values_to), do: err()
-  def df_pivot_wider(_df, _id_columns, _pivot_column, _values_column), do: err()
+  def df_pivot_wider(_df, _id_columns, _pivot_column, _values_column, _names_prefix), do: err()
   def df_pull(_df, _name), do: err()
   def df_put_column(_df, _series), do: err()
   def df_rename_columns(_df, _old_new_pairs), do: err()

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -504,7 +504,8 @@ pub fn df_pivot_wider(
     pivot_column: &str,
     values_column: &str,
 ) -> Result<ExDataFrame, ExplorerError> {
-    let new_df = pivot_stable(
+    let original_names = df.get_column_names();
+    let mut new_df = pivot_stable(
         &df,
         [values_column],
         id_columns,
@@ -512,6 +513,12 @@ pub fn df_pivot_wider(
         PivotAgg::First,
         false,
     )?;
+
+    // Rename possible "null" column to "nil".
+    if new_df.get_column_names().contains(&"null") && !original_names.contains(&"null") {
+        new_df.rename("null", "nil")?;
+    }
+
     Ok(ExDataFrame::new(new_df))
 }
 

--- a/test/explorer/data_frame/grouped_test.exs
+++ b/test/explorer/data_frame/grouped_test.exs
@@ -1051,6 +1051,33 @@ defmodule Explorer.DataFrame.GroupedTest do
 
       assert DF.groups(pivoted) == []
     end
+
+    test "remove groups that are not in the list of id_columns" do
+      df =
+        DF.new(
+          weekday: [
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday"
+          ],
+          team: ["A", "B", "C", "A", "B", "C", "A", "B", "C", "A"],
+          other: [1, 2, 1, 2, 1, 2, 1, 2, 1, 2],
+          hour: [10, 9, 10, 10, 11, 15, 14, 16, 14, 16]
+        )
+
+      grouped = DF.group_by(df, ["team", "other"])
+      pivoted = DF.pivot_wider(grouped, "weekday", "hour", id_columns: ["team"])
+
+      assert DF.names(pivoted) == ["team", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+      assert DF.groups(pivoted) == ["team"]
+    end
   end
 
   describe "dummies/2" do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2107,7 +2107,7 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(id: [1, 1], variable: ["a", "b"], value: [1, 2], other_id: [4, 5])
 
       assert_raise ArgumentError,
-                   "id_columns must select at least one existing column, but [] selects none",
+                   "id_columns must select at least one existing column, but [] selects none. Note that float columns are discarded from the selection.",
                    fn ->
                      DF.pivot_wider(df, "variable", "value", id_columns: [])
                    end
@@ -2125,13 +2125,13 @@ defmodule Explorer.DataFrameTest do
       df = DF.new(float_id: [1.5, 1.6], variable: ["a", "b"], value: [1, 2])
 
       assert_raise ArgumentError,
-                   "id_columns cannot have columns of the type float, but \"float_id\" column is float",
+                   "id_columns must select at least one existing column, but 0..-1//1 selects none. Note that float columns are discarded from the selection.",
                    fn ->
                      DF.pivot_wider(df, "variable", "value")
                    end
 
       assert_raise ArgumentError,
-                   "id_columns cannot have columns of the type float, but \"float_id\" column is float",
+                   "id_columns must select at least one existing column, but [:float_id] selects none. Note that float columns are discarded from the selection.",
                    fn ->
                      DF.pivot_wider(df, "variable", "value", id_columns: [:float_id])
                    end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1986,6 +1986,19 @@ defmodule Explorer.DataFrameTest do
       assert df4.names == ["id", "column_1", "column_2"]
     end
 
+    test "with a single id but with a nil value in the variable series" do
+      df1 = DF.new(id: [1, 1, 1], variable: ["a", "b", nil], value: [1, 2, 3])
+
+      df2 = DF.pivot_wider(df1, "variable", "value")
+
+      assert DF.to_columns(df2) == %{
+               "id" => [1],
+               "a" => [1],
+               "b" => [2],
+               "nil" => [3]
+             }
+    end
+
     test "with multiple id columns" do
       df = DF.new(id: [1, 1], variable: ["a", "b"], value: [1, 2], other_id: [4, 5])
       df1 = DF.pivot_wider(df, "variable", "value")

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2014,6 +2014,20 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "with multiple id columns and one id equal to a variable name" do
+      df = DF.new(id: [1, 1], variable: ["a", "b"], value: [1, 2], b: [4, 5])
+      df1 = DF.pivot_wider(df, "variable", "value")
+
+      assert DF.names(df1) == ["id", "b", "a", "b_1"]
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               id: [1, 1],
+               b: [4, 5],
+               a: [1, nil],
+               b_1: [nil, 2]
+             }
+    end
+
     test "with a single id column ignoring other columns" do
       df = DF.new(id: [1, 1], variable: ["a", "b"], value: [1, 2], other: [4, 5])
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1971,6 +1971,18 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "with a single id discarding any other column" do
+      df1 = DF.new(id: [1, 1], x: [6, 12], variable: ["a", "b"], value: [1, 2])
+
+      df2 = DF.pivot_wider(df1, "variable", "value", id_columns: [:id])
+
+      assert DF.to_columns(df2, atom_keys: true) == %{
+               id: [1],
+               a: [1],
+               b: [2]
+             }
+    end
+
     test "with a single id and names prefix" do
       df1 = DF.new(id: [1, 1], variable: ["1", "2"], value: [1.0, 2.0])
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1969,21 +1969,23 @@ defmodule Explorer.DataFrameTest do
                a: [1],
                b: [2]
              }
+    end
 
-      df3 = DF.new(id: [1, 1], variable: ["1", "2"], value: [1.0, 2.0])
+    test "with a single id and names prefix" do
+      df1 = DF.new(id: [1, 1], variable: ["1", "2"], value: [1.0, 2.0])
 
-      df4 =
-        DF.pivot_wider(df3, "variable", "value",
+      df2 =
+        DF.pivot_wider(df1, "variable", "value",
           id_columns: ["id"],
           names_prefix: "column_"
         )
 
       assert DF.to_columns(
-               df4,
+               df2,
                atom_keys: true
              ) == %{id: [1], column_1: [1.0], column_2: [2.0]}
 
-      assert df4.names == ["id", "column_1", "column_2"]
+      assert df2.names == ["id", "column_1", "column_2"]
     end
 
     test "with a single id but with a nil value in the variable series" do
@@ -2025,6 +2027,20 @@ defmodule Explorer.DataFrameTest do
                b: [4, 5],
                a: [1, nil],
                b_1: [nil, 2]
+             }
+    end
+
+    test "with multiple id columns and one id equal to a variable name, but with prefix option" do
+      df = DF.new(id: [1, 1], variable: ["a", "b"], value: [1, 2], b: [4, 5])
+      df1 = DF.pivot_wider(df, "variable", "value", names_prefix: "col_")
+
+      assert DF.names(df1) == ["id", "b", "col_a", "col_b"]
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               id: [1, 1],
+               b: [4, 5],
+               col_a: [1, nil],
+               col_b: [nil, 2]
              }
     end
 


### PR DESCRIPTION
This is going to correct name the column as "nil" instead of breaking.

There is a potential caveat that is when a dataframe contains already a "null" column, and is going to create another "null" column. This is going go break.
Since that case is less plausable, we are ignoring it.