### PR TITLE
Add libatomic as a link to the generated NIF

### DIFF
--- a/native/explorer/.cargo/config
+++ b/native/explorer/.cargo/config
@@ -22,6 +22,13 @@ rustflags = [
   "-C", "target-feature=-crt-static"
 ]
 
+# Libatomic is needed for 32 bits ARM.
+# See: https://github.com/philss/rustler_precompiled/issues/53
+[target.arm-unknown-linux-gnueabihf]
+rustflags = [
+  "-l", "dylib=atomic"
+]
+
 # Provides a small build size, but takes more time to build.
 [profile.release]
 lto = true


### PR DESCRIPTION
This is needed in order to make the precompiled NIF work on ARM 32 bits that is used in some Raspbery Pi machines (32 bits).

See: https://github.com/philss/rustler_precompiled/issues/53