### PR TITLE
Fix encoding of special float values for Series

### DIFF
--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -12,6 +12,7 @@ defmodule Explorer.Backend.Series do
   @type df :: Explorer.DataFrame.t()
   @type dtype :: Explorer.Series.dtype()
   @type valid_types :: number() | boolean() | String.t() | Date.t() | Time.t() | NaiveDateTime.t()
+  @type special_float :: Explorer.Series.special_float()
   @type option(type) :: type | nil
 
   # Conversion
@@ -58,14 +59,15 @@ defmodule Explorer.Backend.Series do
   # Aggregation
 
   @callback count(s) :: number() | lazy_s()
-  @callback sum(s) :: number() | lazy_s() | nil
-  @callback min(s) :: number() | Date.t() | NaiveDateTime.t() | lazy_s() | nil
-  @callback max(s) :: number() | Date.t() | NaiveDateTime.t() | lazy_s() | nil
-  @callback mean(s) :: float() | lazy_s() | nil
-  @callback median(s) :: float() | lazy_s() | nil
-  @callback variance(s) :: float() | lazy_s() | nil
-  @callback standard_deviation(s) :: float() | lazy_s() | nil
-  @callback quantile(s, float()) :: number | Date.t() | NaiveDateTime.t() | lazy_s() | nil
+  @callback sum(s) :: number() | special_float() | lazy_s() | nil
+  @callback min(s) :: number() | special_float() | Date.t() | NaiveDateTime.t() | lazy_s() | nil
+  @callback max(s) :: number() | special_float() | Date.t() | NaiveDateTime.t() | lazy_s() | nil
+  @callback mean(s) :: float() | special_float() | lazy_s() | nil
+  @callback median(s) :: float() | special_float() | lazy_s() | nil
+  @callback variance(s) :: float() | special_float() | lazy_s() | nil
+  @callback standard_deviation(s) :: float() | special_float() | lazy_s() | nil
+  @callback quantile(s, float()) ::
+              number() | special_float() | Date.t() | NaiveDateTime.t() | lazy_s() | nil
   @callback nil_count(s) :: number() | lazy_s()
 
   # Cumulative

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -76,6 +76,8 @@ defmodule Explorer.Series do
   @type t :: %Series{data: Explorer.Backend.Series.t(), dtype: dtype()}
   @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
 
+  @type special_float :: :nan | :infinity | :neg_infinity
+
   @doc false
   @enforce_keys [:data, :dtype]
   defstruct [:data, :dtype, :name]
@@ -1571,7 +1573,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.sum/1 not implemented for dtype :date. Valid dtypes are [:integer, :float, :boolean]
   """
   @doc type: :aggregation
-  @spec sum(series :: Series.t()) :: number() | nil
+  @spec sum(series :: Series.t()) :: number() | special_float() | nil
   def sum(%Series{dtype: dtype} = series) when is_numeric_or_bool_dtype(dtype),
     do: Shared.apply_impl(series, :sum)
 
@@ -1615,7 +1617,8 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.min/1 not implemented for dtype :string. Valid dtypes are [:integer, :float, :date, :time, :datetime]
   """
   @doc type: :aggregation
-  @spec min(series :: Series.t()) :: number() | Date.t() | Time.t() | NaiveDateTime.t() | nil
+  @spec min(series :: Series.t()) ::
+          number() | special_float() | Date.t() | Time.t() | NaiveDateTime.t() | nil
   def min(%Series{dtype: dtype} = series) when is_numeric_or_date_dtype(dtype),
     do: Shared.apply_impl(series, :min)
 
@@ -1660,7 +1663,8 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.max/1 not implemented for dtype :string. Valid dtypes are [:integer, :float, :date, :time, :datetime]
   """
   @doc type: :aggregation
-  @spec max(series :: Series.t()) :: number() | Date.t() | Time.t() | NaiveDateTime.t() | nil
+  @spec max(series :: Series.t()) ::
+          number() | special_float() | Date.t() | Time.t() | NaiveDateTime.t() | nil
   def max(%Series{dtype: dtype} = series) when is_numeric_or_date_dtype(dtype),
     do: Shared.apply_impl(series, :max)
 
@@ -1690,7 +1694,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.mean/1 not implemented for dtype :date. Valid dtypes are [:integer, :float]
   """
   @doc type: :aggregation
-  @spec mean(series :: Series.t()) :: float() | nil
+  @spec mean(series :: Series.t()) :: float() | special_float() | nil
   def mean(%Series{dtype: dtype} = series) when is_numeric_dtype(dtype),
     do: Shared.apply_impl(series, :mean)
 
@@ -1719,7 +1723,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.median/1 not implemented for dtype :date. Valid dtypes are [:integer, :float]
   """
   @doc type: :aggregation
-  @spec median(series :: Series.t()) :: float() | nil
+  @spec median(series :: Series.t()) :: float() | special_float() | nil
   def median(%Series{dtype: dtype} = series) when is_numeric_dtype(dtype),
     do: Shared.apply_impl(series, :median)
 
@@ -1748,7 +1752,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.variance/1 not implemented for dtype :datetime. Valid dtypes are [:integer, :float]
   """
   @doc type: :aggregation
-  @spec variance(series :: Series.t()) :: float() | nil
+  @spec variance(series :: Series.t()) :: float() | special_float() | nil
   def variance(%Series{dtype: dtype} = series) when is_numeric_dtype(dtype),
     do: Shared.apply_impl(series, :variance)
 
@@ -1777,7 +1781,7 @@ defmodule Explorer.Series do
       ** (ArgumentError) Explorer.Series.standard_deviation/1 not implemented for dtype :string. Valid dtypes are [:integer, :float]
   """
   @doc type: :aggregation
-  @spec standard_deviation(series :: Series.t()) :: float() | nil
+  @spec standard_deviation(series :: Series.t()) :: float() | special_float() | nil
   def standard_deviation(%Series{dtype: dtype} = series) when is_numeric_dtype(dtype),
     do: Shared.apply_impl(series, :standard_deviation)
 

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -491,7 +491,7 @@ pub fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Result<Term<'b>, Explor
 }
 
 // Useful for series functions that can return float.
-pub fn term_from_float<'b>(float: f64, env: Env<'b>) -> Term<'b> {
+pub fn term_from_float(float: f64, env: Env<'_>) -> Term<'_> {
     if float.is_finite() {
         float.encode(env)
     } else {

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -481,12 +481,25 @@ pub fn term_from_value<'b>(v: AnyValue, env: Env<'b>) -> Result<Term<'b>, Explor
         AnyValue::Boolean(v) => Ok(Some(v).encode(env)),
         AnyValue::Utf8(v) => Ok(Some(v).encode(env)),
         AnyValue::Int64(v) => Ok(Some(v).encode(env)),
-        AnyValue::Float64(v) => Ok(Some(v).encode(env)),
+        AnyValue::Float64(v) => Ok(Some(term_from_float(v, env)).encode(env)),
         AnyValue::Date(v) => encode_date(v, env),
         AnyValue::Time(v) => encode_time(v, env),
         AnyValue::Datetime(v, time_unit, None) => encode_datetime(v, time_unit, env),
         AnyValue::Categorical(idx, mapping, _) => Ok(mapping.get(idx).encode(env)),
         dt => panic!("cannot encode value {dt:?} to term"),
+    }
+}
+
+// Useful for series functions that can return float.
+pub fn term_from_float<'b>(float: f64, env: Env<'b>) -> Term<'b> {
+    if float.is_finite() {
+        float.encode(env)
+    } else {
+        match (float.is_nan(), float.is_sign_negative()) {
+            (true, _) => nan().encode(env),
+            (false, true) => neg_infinity().encode(env),
+            (false, false) => infinity().encode(env),
+        }
     }
 }
 

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -763,7 +763,7 @@ pub fn s_standard_deviation(env: Env, s: ExSeries) -> Result<Term, ExplorerError
     }
 }
 
-fn term_from_optional_float<'b>(option: Option<f64>, env: Env<'b>) -> Term<'b> {
+fn term_from_optional_float(option: Option<f64>, env: Env<'_>) -> Term<'_> {
     match option {
         Some(float) => encoding::term_from_float(float, env),
         None => rustler::types::atom::nil().to_term(env),

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -3266,4 +3266,221 @@ defmodule Explorer.SeriesTest do
              ]
     end
   end
+
+  describe "mean/1" do
+    test "returns the mean of an integer series" do
+      s = Series.from_list([1, 2, nil, 3])
+      assert Series.mean(s) == 2.0
+    end
+
+    test "returns the mean of a float series" do
+      s = Series.from_list([1.2, 2.4, nil, 3.9])
+      assert Series.mean(s) == 2.5
+    end
+
+    test "returns the mean of a float series with an infinity number" do
+      s = Series.from_list([1.2, 2.4, nil, 3.9, :infinity])
+      assert Series.mean(s) == :infinity
+    end
+
+    test "returns the mean of a float series with an infinity number and a nan" do
+      s = Series.from_list([1.2, 2.4, nil, 3.9, :infinity, :nan])
+      assert Series.mean(s) == :nan
+    end
+  end
+
+  describe "median/1" do
+    test "returns the median of an integer series" do
+      s = Series.from_list([1, 2, nil, 3])
+      assert Series.median(s) == 2.0
+    end
+
+    test "returns the median of a float series" do
+      s = Series.from_list([1.2, 2.4, nil, 3.9])
+      assert Series.median(s) == 2.4
+    end
+
+    test "returns the median of a float series with an infinity number" do
+      s = Series.from_list([1.2, 2.4, nil, 3.9, :infinity])
+      assert Series.median(s) == 3.15
+    end
+
+    test "returns the median of a float series with an infinity number and nan" do
+      s = Series.from_list([1.2, 2.4, nil, 3.9, :infinity, :nan])
+      assert Series.median(s) == 3.9
+    end
+  end
+
+  describe "sum/1" do
+    test "sum of integers" do
+      s = Series.from_list([1, 2, nil, 3])
+      assert Series.sum(s) === 6
+    end
+
+    test "sum of floats" do
+      s = Series.from_list([1.0, 2.0, nil, 3.0])
+      assert Series.sum(s) === 6.0
+    end
+
+    test "sum of floats with nan" do
+      s = Series.from_list([1.0, 2.0, nil, :nan, 3.0])
+      assert Series.sum(s) == :nan
+    end
+
+    test "sum of floats with infinity" do
+      s = Series.from_list([1.0, 2.0, nil, :infinity, 3.0])
+      assert Series.sum(s) == :infinity
+    end
+
+    test "sum of floats with infinity and nan" do
+      s = Series.from_list([1.0, :nan, 2.0, nil, :infinity, 3.0])
+      assert Series.sum(s) == :nan
+    end
+
+    test "sum of boolean values" do
+      s = Series.from_list([true, false, true])
+      assert Series.sum(s) === 2
+    end
+  end
+
+  describe "min/1" do
+    test "min of an integer series" do
+      s = Series.from_list([-3, 1, 2, nil, -2, -42, 3])
+      assert Series.min(s) === -42
+    end
+
+    test "min of a float series" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, 3.9])
+      assert Series.min(s) === -12.6
+    end
+
+    test "min of a float series with a nan" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :nan, 3.9])
+      assert Series.min(s) === -12.6
+    end
+
+    test "min of a float series with infinity positive" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :infinity, 3.9])
+      assert Series.min(s) === -12.6
+    end
+
+    test "min of a float series with infinity negative" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :neg_infinity, 3.9])
+      assert Series.min(s) === :neg_infinity
+    end
+  end
+
+  describe "max/1" do
+    test "max of an integer series" do
+      s = Series.from_list([-3, 1, 2, nil, -2, -42, 3])
+      assert Series.max(s) === 3
+    end
+
+    test "max of a float series" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, 3.9])
+      assert Series.max(s) === 3.9
+    end
+
+    test "max of a float series with a nan" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :nan, 3.9])
+      assert Series.max(s) === 3.9
+    end
+
+    test "max of a float series with infinity positive" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :infinity, 3.9])
+      assert Series.max(s) === :infinity
+    end
+
+    test "max of a float series with infinity negative" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :neg_infinity, 3.9])
+      assert Series.max(s) === 3.9
+    end
+  end
+
+  describe "variance/1" do
+    test "variance of an integer series" do
+      s = Series.from_list([1, 2, nil, 3])
+      assert Series.variance(s) === 1.0
+    end
+
+    test "variance of a float series" do
+      s = Series.from_list([1.0, 2.0, nil, 3.0])
+      assert Series.variance(s) === 1.0
+    end
+
+    test "variance of a float series with a nan" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :nan, 3.9])
+      assert Series.variance(s) == :nan
+    end
+
+    test "variance of a float series with infinity positive" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :infinity, 3.9])
+      assert Series.variance(s) === :nan
+    end
+
+    test "variance of a float series with infinity negative" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :neg_infinity, 3.9])
+      assert Series.variance(s) === :nan
+    end
+  end
+
+  describe "standard_deviation/1" do
+    test "standard deviation of an integer series" do
+      s = Series.from_list([1, 2, nil, 3])
+      assert Series.standard_deviation(s) === 1.0
+    end
+
+    test "standard deviation of a float series" do
+      s = Series.from_list([1.0, 2.0, nil, 3.0])
+      assert Series.standard_deviation(s) === 1.0
+    end
+
+    test "standard deviation of a float series with a nan" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :nan, 3.9])
+      assert Series.standard_deviation(s) == :nan
+    end
+
+    test "standard deviation of a float series with infinity positive" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :infinity, 3.9])
+      assert Series.standard_deviation(s) === :nan
+    end
+
+    test "standard deviation of a float series with infinity negative" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :neg_infinity, 3.9])
+      assert Series.standard_deviation(s) === :nan
+    end
+  end
+
+  describe "quantile/1" do
+    test "quantile of an integer series" do
+      s = Series.from_list([1, 2, nil, 3])
+      assert Series.quantile(s, 0.2) === 1
+    end
+
+    test "quantile of a float series" do
+      s = Series.from_list([1.0, 2.0, nil, 3.0])
+      assert Series.quantile(s, 0.2) === 1.0
+    end
+
+    test "quantile of a float series with a nan" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :nan, 3.9])
+
+      assert Series.quantile(s, 0.2) == -3.1
+      assert Series.quantile(s, 0.9) == :nan
+    end
+
+    test "quantile of a float series with infinity positive" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :infinity, 3.9])
+
+      assert Series.quantile(s, 0.2) == -3.1
+      assert Series.quantile(s, 0.9) == :infinity
+    end
+
+    test "quantile of a float series with infinity negative" do
+      s = Series.from_list([-3.1, 1.2, 2.3, nil, -2.4, -12.6, :neg_infinity, 3.9])
+
+      assert Series.quantile(s, 0.2) == -12.6
+      assert Series.quantile(s, 0.1) == :neg_infinity
+    end
+  end
 end


### PR DESCRIPTION
This commit fixes the encoding of the return of some aggregation functions for the Series module.

We don't have the same problem for expressions because the result of a lazy series evaluation is always a series.

Closes https://github.com/elixir-nx/explorer/issues/550