### PR TITLE
Add experimental IO writer that talks to a process

### DIFF
--- a/lib/explorer/polars_backend/experimental_io.ex
+++ b/lib/explorer/polars_backend/experimental_io.ex
@@ -1,0 +1,29 @@
+defmodule Explorer.PolarsBackend.ExperimentalIo do
+  @moduledoc false
+
+  # To try it:
+  #
+  # iex> df = Explorer.Datasets.wine()
+  # iex> {:ok, pid} = GenServer.start_link(Explorer.PolarsBackend.ExperimentalIo, df)
+  # iex> GenServer.cast(pid, :write_ipc)
+  #
+  alias Explorer.PolarsBackend.Native
+  use GenServer
+
+  @impl true
+  def init(dataframe) do
+    {:ok, dataframe}
+  end
+
+  @impl true
+  def handle_cast(:write_ipc, dataframe) do
+    _ = Native.df_to_ipc_via_pid(dataframe.data, self(), nil)
+    {:noreply, dataframe}
+  end
+
+  @impl true
+  def handle_info(msg, state) do
+    IO.inspect(msg, label: "from rust")
+    {:noreply, state}
+  end
+end

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -124,6 +124,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_to_dummies(_df, _columns), do: err()
   def df_to_ipc(_df, _filename, _compression), do: err()
   def df_to_ipc_stream(_df, _filename, _compression), do: err()
+  def df_to_ipc_via_pid(_df, _pid, _compression), do: err()
   def df_to_lazy(_df), do: err()
   def df_to_ndjson(_df, _filename), do: err()
   def df_to_parquet(_df, _filename, _compression), do: err()

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -10,6 +10,9 @@ use crate::{ExDataFrame, ExExpr, ExLazyFrame, ExSeries, ExplorerError};
 // Loads the IO functions for read/writing CSV, NDJSON, Parquet, etc.
 pub mod io;
 
+// Experimental IO
+pub mod experimental_io;
+
 // Helper to normalize integers and float column dtypes.
 pub fn normalize_numeric_dtypes(df: &mut DataFrame) -> Result<DataFrame, crate::ExplorerError> {
     let dtypes = df.dtypes().into_iter().enumerate();

--- a/native/explorer/src/dataframe/experimental_io.rs
+++ b/native/explorer/src/dataframe/experimental_io.rs
@@ -1,0 +1,54 @@
+use polars::prelude::*;
+
+use rustler::{Binary, Env, LocalPid, NewBinary};
+use std::io::BufWriter;
+use std::io::Write;
+use std::result::Result;
+
+use crate::{ExDataFrame, ExplorerError};
+
+pub struct PidWriter<'a> {
+    pub env: Env<'a>,
+    pub pid: LocalPid,
+}
+
+impl Write for &PidWriter<'_> {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let len = buf.len();
+        let mut values_binary = NewBinary::new(self.env, len);
+        values_binary.copy_from_slice(buf);
+
+        let message: Binary = values_binary.into();
+
+        self.env.send(&self.pid, message.to_term(self.env));
+
+        Ok(len)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[rustler::nif(schedule = "DirtyIo")]
+pub fn df_to_ipc_via_pid(
+    env: Env,
+    data: ExDataFrame,
+    pid: rustler::LocalPid,
+    compression: Option<&str>,
+) -> Result<(), ExplorerError> {
+    // Select the compression algorithm.
+    let compression = match compression {
+        Some("lz4") => Some(IpcCompression::LZ4),
+        Some("zstd") => Some(IpcCompression::ZSTD),
+        _ => None,
+    };
+
+    let pid_writer = PidWriter { env, pid };
+
+    let mut buf_writer = BufWriter::new(&pid_writer);
+    IpcWriter::new(&mut buf_writer)
+        .with_compression(compression)
+        .finish(&mut data.clone())?;
+    Ok(())
+}

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -22,6 +22,7 @@ mod expressions;
 mod lazyframe;
 mod series;
 
+use dataframe::experimental_io::*;
 use dataframe::io::*;
 use dataframe::*;
 pub use datatypes::{
@@ -119,6 +120,7 @@ rustler::init!(
         df_to_dummies,
         df_to_ipc,
         df_to_ipc_stream,
+        df_to_ipc_via_pid,
         df_to_lazy,
         df_to_ndjson,
         df_to_parquet,


### PR DESCRIPTION
This is an experiment to prove a concept about sending the chunks of a dataframe to Elixir, in a given format - this case we are using IPC - in order to send them via web.

It's feasible, although we need to obey some restrictions: https://docs.rs/rustler/latest/rustler/env/struct.Env.html#method.send

PS: open a PR just to keep the reference. It's going to be closed.