### PR TITLE
Add options to control streaming when writing lazy DF

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -70,7 +70,8 @@ defmodule Explorer.Backend.DataFrame do
   @callback to_parquet(
               df,
               filename :: String.t(),
-              compression()
+              compression(),
+              streaming :: boolean()
             ) ::
               ok_result()
   @callback dump_parquet(df, compression()) :: result(binary())
@@ -81,7 +82,7 @@ defmodule Explorer.Backend.DataFrame do
               filename :: String.t(),
               columns :: columns_for_io()
             ) :: result(df)
-  @callback to_ipc(df, filename :: String.t(), compression()) ::
+  @callback to_ipc(df, filename :: String.t(), compression(), streaming :: boolean()) ::
               ok_result()
   @callback dump_ipc(df, compression()) :: result(binary())
   @callback load_ipc(

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -567,14 +567,21 @@ defmodule Explorer.DataFrame do
         * `:zstd` (with levels -7-22)
         * `:lz4raw`.
 
+    * `:streaming` - Tells the backend if it should use streaming, which means
+      that the dataframe is not loaded to the memory at once, and instead it is
+      written in chunks from a lazy dataframe.
+
+      This option has no effect on eager - the default - dataframes.
+      It defaults to `true`.
+
   """
   @doc type: :io
   @spec to_parquet(df :: DataFrame.t(), filename :: String.t(), opts :: Keyword.t()) ::
           :ok | {:error, term()}
   def to_parquet(df, filename, opts \\ []) do
-    opts = Keyword.validate!(opts, compression: nil)
+    opts = Keyword.validate!(opts, compression: nil, streaming: true)
     compression = parquet_compression(opts[:compression])
-    Shared.apply_impl(df, :to_parquet, [filename, compression])
+    Shared.apply_impl(df, :to_parquet, [filename, compression, opts[:streaming]])
   end
 
   defp parquet_compression(nil), do: {nil, nil}
@@ -729,15 +736,22 @@ defmodule Explorer.DataFrame do
         * `:zstd`
         * `:lz4`.
 
+    * `:streaming` - Tells the backend if it should use streaming, which means
+      that the dataframe is not loaded to the memory at once, and instead it is
+      written in chunks from a lazy dataframe.
+
+      This option has no effect on eager - the default - dataframes.
+      It defaults to `true`.
+
   """
   @doc type: :io
   @spec to_ipc(df :: DataFrame.t(), filename :: String.t(), opts :: Keyword.t()) ::
           :ok | {:error, term()}
   def to_ipc(df, filename, opts \\ []) do
-    opts = Keyword.validate!(opts, compression: nil)
+    opts = Keyword.validate!(opts, compression: nil, streaming: true)
     compression = ipc_compression(opts[:compression])
 
-    Shared.apply_impl(df, :to_ipc, [filename, compression])
+    Shared.apply_impl(df, :to_ipc, [filename, compression, opts[:streaming]])
   end
 
   defp ipc_compression(nil), do: {nil, nil}

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -194,7 +194,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def to_parquet(%DataFrame{data: df}, filename, {compression, compression_level}) do
+  def to_parquet(%DataFrame{data: df}, filename, {compression, compression_level}, _streaming) do
     case Native.df_to_parquet(df, filename, parquet_compression(compression, compression_level)) do
       {:ok, _} -> :ok
       {:error, error} -> {:error, error}
@@ -233,7 +233,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
-  def to_ipc(%DataFrame{data: df}, filename, {compression, _level}) do
+  def to_ipc(%DataFrame{data: df}, filename, {compression, _level}, _streaming) do
     case Native.df_to_ipc(df, filename, Atom.to_string(compression)) do
       {:ok, _} -> :ok
       {:error, error} -> {:error, error}

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -214,16 +214,21 @@ defmodule Explorer.PolarsBackend.LazyFrame do
   end
 
   @impl true
-  def to_parquet(%DF{} = df, filename, {compression, level}) do
-    case Native.lf_to_parquet(df.data, filename, Shared.parquet_compression(compression, level)) do
+  def to_parquet(%DF{} = df, filename, {compression, level}, streaming) do
+    case Native.lf_to_parquet(
+           df.data,
+           filename,
+           Shared.parquet_compression(compression, level),
+           streaming
+         ) do
       {:ok, _} -> :ok
       {:error, _} = err -> err
     end
   end
 
   @impl true
-  def to_ipc(%DF{} = df, filename, {compression, _level}) do
-    case Native.lf_to_ipc(df.data, filename, Atom.to_string(compression)) do
+  def to_ipc(%DF{} = df, filename, {compression, _level}, streaming) do
+    case Native.lf_to_ipc(df.data, filename, Atom.to_string(compression), streaming) do
       {:ok, _} -> :ok
       {:error, _} = err -> err
     end

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -199,8 +199,8 @@ defmodule Explorer.PolarsBackend.Native do
   def lf_join(_df, _other, _left_on, _right_on, _how, _suffix), do: err()
   def lf_concat_rows(_dfs), do: err()
   def lf_concat_columns(_df, _others), do: err()
-  def lf_to_parquet(_df, _filename, _compression), do: err()
-  def lf_to_ipc(_df, _filename, _compression), do: err()
+  def lf_to_parquet(_df, _filename, _compression, _streaming), do: err()
+  def lf_to_ipc(_df, _filename, _compression, _streaming), do: err()
 
   # Series
   def s_as_str(_s), do: err()

--- a/test/explorer/data_frame/lazy_test.exs
+++ b/test/explorer/data_frame/lazy_test.exs
@@ -203,11 +203,37 @@ defmodule Explorer.DataFrame.LazyTest do
   end
 
   @tag :tmp_dir
+  test "to_ipc/2 - without streaming", %{ldf: ldf, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.ipc"])
+
+    ldf = DF.head(ldf, 15)
+    DF.to_ipc!(ldf, path, streaming: false)
+
+    df = DF.collect(ldf)
+    df1 = DF.from_ipc!(path)
+
+    assert DF.to_rows(df1) |> Enum.sort() == DF.to_rows(df) |> Enum.sort()
+  end
+
+  @tag :tmp_dir
   test "to_parquet/2 - with defaults", %{ldf: ldf, tmp_dir: tmp_dir} do
     path = Path.join([tmp_dir, "fossil_fuels.parquet"])
 
     ldf = DF.head(ldf, 15)
     DF.to_parquet!(ldf, path)
+
+    df = DF.collect(ldf)
+    df1 = DF.from_parquet!(path)
+
+    assert DF.to_rows(df1) |> Enum.sort() == DF.to_rows(df) |> Enum.sort()
+  end
+
+  @tag :tmp_dir
+  test "to_parquet/2 - with streaming disabled", %{ldf: ldf, tmp_dir: tmp_dir} do
+    path = Path.join([tmp_dir, "fossil_fuels.parquet"])
+
+    ldf = DF.head(ldf, 15)
+    DF.to_parquet!(ldf, path, streaming: false)
 
     df = DF.collect(ldf)
     df1 = DF.from_parquet!(path)


### PR DESCRIPTION
This has only effects in lazy dataframes, and only the `to_ipc/3` and `to_parquet/3` functions.