### PR TITLE
Allow pivot_wider to use category fields

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -4048,7 +4048,7 @@ defmodule Explorer.DataFrame do
     dtypes = df.dtypes
 
     for column <- values_from do
-      unless dtypes[column] in [:integer, :float, :date, :datetime] do
+      unless dtypes[column] in [:integer, :float, :date, :datetime, :category] do
         raise ArgumentError,
               "the values_from column must be numeric, but found #{dtypes[values_from]}"
       end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2063,6 +2063,16 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "with a category" do
+      df1 =
+        DF.new(id: [1, 1, 1])
+        |> DF.put(:category, Series.from_list(["a", "b", "a"], dtype: :category))
+        |> DF.pivot_wider("category", "category")
+
+      assert DF.dtypes(df1) == %{"a" => :category, "b" => :category, "id" => :integer}
+      assert DF.to_columns(df1, atom_keys: true) == %{id: [1], a: ["a"], b: ["b"]}
+    end
+
     test "with a single id discarding any other column" do
       df1 = DF.new(id: [1, 1], x: [6, 12], variable: ["a", "b"], value: [1, 2])
 


### PR DESCRIPTION
 
 Currently, a data frame can't be created when passing a series directly - I had to update it in tests.
 #585 
 
``` 
DF.new(category: Series.from_list(["a", "b", "a"], dtype: :category))
```