### PR TITLE
Disable precompilation for ARM 32 bits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,15 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nif: ["2.16", "2.15"]
+        nif: ["2.17", "2.16", "2.15"]
         job:
-          # Disabling for the moment, since polars v0.28 breaks for ARM 32.
-          # - {
-          #     target: arm-unknown-linux-gnueabihf,
-          #     os: ubuntu-20.04,
-          #     use-cross: true,
-          #     disable-polars-json-feature: true,
-          #   }
           - { target: aarch64-unknown-linux-gnu, os: ubuntu-20.04, use-cross: true }
           - { target: aarch64-unknown-linux-musl, os: ubuntu-20.04, use-cross: true }
           - { target: aarch64-apple-darwin, os: macos-11 }

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -16,7 +16,6 @@ defmodule Explorer.PolarsBackend.Native do
       aarch64-apple-darwin
       aarch64-unknown-linux-gnu
       aarch64-unknown-linux-musl
-      arm-unknown-linux-gnueabihf
       riscv64gc-unknown-linux-gnu
       x86_64-apple-darwin
       x86_64-pc-windows-msvc


### PR DESCRIPTION
Also enable precompilation for OTP 26, which has a new NIF versiom, 2.17. This is not a requirement, since the previous version should compatible.