### PR TITLE
Fix representation of time series from us to ns

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -1320,7 +1320,7 @@ defmodule Explorer.DataFrame do
 
       iex> Explorer.DataFrame.new(%{
       ...>   floats: Nx.tensor([1.0, 2.0], type: :f64),
-      ...>   times: Nx.tensor([3, 4])
+      ...>   times: Nx.tensor([3_000, 4_000])
       ...> }, dtypes: [times: :time])
       #Explorer.DataFrame<
         Polars[2 x 2]

--- a/native/explorer/src/datatypes.rs
+++ b/native/explorer/src/datatypes.rs
@@ -301,7 +301,6 @@ pub struct ExTime {
     pub microsecond: (u32, u32),
 }
 
-// pub use polars::export::arrow::temporal_conversions::time64us_to_time as timestamp_to_time;
 pub use polars::export::arrow::temporal_conversions::time64ns_to_time;
 
 impl From<i64> for ExTime {

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -10,7 +10,7 @@ use crate::atoms::{
     year,
 };
 use crate::datatypes::{
-    days_to_date, timestamp_to_datetime, timestamp_to_time, ExSeries, ExSeriesRef,
+    days_to_date, time64ns_to_time, timestamp_to_datetime, ExSeries, ExSeriesRef,
 };
 use crate::ExplorerError;
 
@@ -213,18 +213,8 @@ fn datetime_series_to_list<'b>(
 
 macro_rules! unsafe_encode_time {
     ($v: expr, $naive_time_struct_keys: ident, $calendar_iso_module: ident, $time_module: ident, $env: ident) => {{
-        let t = timestamp_to_time($v);
-        let duration =
-            NaiveTime::from_hms_micro_opt(t.hour(), t.minute(), t.second(), t.nanosecond() / 1_000)
-                .unwrap()
-                .signed_duration_since(
-                    NaiveTime::from_hms_opt(t.hour(), t.minute(), t.second()).unwrap(),
-                );
-
-        let microseconds = match duration.num_microseconds() {
-            Some(us) => us,
-            None => duration.num_milliseconds() * 1_000,
-        };
+        let t = time64ns_to_time($v);
+        let microseconds = t.nanosecond() / 1_000;
 
         // Limit the number of digits in the microsecond part of a timestamp to 6.
         // This is necessary because the microsecond part of Elixir is only 6 digits.

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2521,7 +2521,7 @@ defmodule Explorer.SeriesTest do
       s2 = Series.from_list([~T[03:00:00.000000], ~T[04:00:00.000201]])
 
       assert Series.format([s1, " <=> ", s2]) |> Series.to_list() ==
-               ["01:00:00 <=> 03:00:00", "02:00:00 <=> 04:00:00"]
+               ["3600000543000 <=> 10800000000000", "7200000000000 <=> 14400000201000"]
     end
 
     test "with two datetime series" do

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2514,23 +2514,14 @@ defmodule Explorer.SeriesTest do
     end
 
     test "with two time series" do
-      s1 = Series.from_list([~T[01:00:00.000000], ~T[02:00:00.000000]])
-      s2 = Series.from_list([~T[03:00:00.000000], ~T[04:00:00.000000]])
+      # Notice that Polars drops the microseconds part when converting
+      # a Time series to String series.
+      # See: https://github.com/pola-rs/polars/pull/8351
+      s1 = Series.from_list([~T[01:00:00.000543], ~T[02:00:00.000000]])
+      s2 = Series.from_list([~T[03:00:00.000000], ~T[04:00:00.000201]])
 
-      assert Series.format([s1, s2]) |> Series.to_list() ==
-               ["360000000010800000000", "720000000014400000000"]
-    end
-
-    test "with many time series with separator" do
-      s1 = Series.from_list([~T[01:00:00.000000], ~T[02:00:00.000000]])
-      s2 = Series.from_list([~T[03:00:00.000000], ~T[04:00:00.000000]])
-      s3 = Series.from_list([~T[05:00:00.000000], ~T[06:00:00.000000]])
-      s4 = Series.from_list([~T[07:00:00.000000], ~T[08:00:00.000000]])
-
-      assert Series.format([s1, " / ", s2, " - ", s3, " / ", s4]) |> Series.to_list() == [
-               "3600000000 / 10800000000 - 18000000000 / 25200000000",
-               "7200000000 / 14400000000 - 21600000000 / 28800000000"
-             ]
+      assert Series.format([s1, " <=> ", s2]) |> Series.to_list() ==
+               ["01:00:00 <=> 03:00:00", "02:00:00 <=> 04:00:00"]
     end
 
     test "with two datetime series" do
@@ -3059,7 +3050,7 @@ defmodule Explorer.SeriesTest do
     end
 
     test "integer series to time" do
-      s = Series.from_list([1, 2, 3])
+      s = Series.from_list([1, 2, 3]) |> Series.multiply(1_000)
       s1 = Series.cast(s, :time)
 
       assert Series.to_list(s1) == [
@@ -3070,7 +3061,7 @@ defmodule Explorer.SeriesTest do
 
       assert Series.dtype(s1) == :time
 
-      s2 = Series.from_list([86399 * 1_000 * 1_000])
+      s2 = Series.from_list([86399 * 1_000 * 1_000 * 1_000])
       s3 = Series.cast(s2, :time)
 
       assert Series.to_list(s3) == [~T[23:59:59.000000]]


### PR DESCRIPTION
Since Polars represents time series as nanoseconds internally, we should also do the same.
This is because some conversions, like casting to string, cannot work properly if we treat the time as microseconds.