### PR TITLE
Fix infer_schema_length: nil option

### DIFF
--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -14,7 +14,6 @@ defmodule Explorer.PolarsBackend.DataFrame do
   @type t :: %__MODULE__{resource: reference()}
 
   @behaviour Explorer.Backend.DataFrame
-  @default_infer_schema_length 1000
 
   # IO
 
@@ -35,7 +34,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
       ) do
     infer_schema_length =
       if infer_schema_length == nil,
-        do: max_rows || @default_infer_schema_length,
+        do: max_rows,
         else: infer_schema_length
 
     dtypes =
@@ -118,7 +117,7 @@ defmodule Explorer.PolarsBackend.DataFrame do
       ) do
     infer_schema_length =
       if infer_schema_length == nil,
-        do: max_rows || @default_infer_schema_length,
+        do: max_rows,
         else: infer_schema_length
 
     dtypes =

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -60,8 +60,6 @@ defmodule Explorer.PolarsBackend.LazyFrame do
 
   # IO
 
-  @default_infer_schema_length 1000
-
   @impl true
   def from_csv(
         filename,
@@ -85,7 +83,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
 
     infer_schema_length =
       if infer_schema_length == nil,
-        do: max_rows || @default_infer_schema_length,
+        do: max_rows,
         else: infer_schema_length
 
     dtypes =


### PR DESCRIPTION
Currently, setting `infer_schema_length: nil` when creating a `DataFrame` from CSV has no effect, because there is a redundant fallback to the default value of 1000 rows if the `max_rows` option is not set (or set to `nil`). 

Effectively, it is not possible to use all rows for schema inference without setting `infer_schema_length` (or `max_rows`) to a large enough "guess". I believe this does not match the documented behavior:
> `:max_rows` - Maximum number of lines to read. (default: nil)
> `:infer_schema_length` Maximum number of rows read for schema inference. Setting this to nil will do a full table scan and will be slow (default: 1000).

This PR removes the fallback to the default.

I'm not sure if the changes here are actually preferable to changing the docs, as scanning all rows will be slow for larger files (as stated), but ran into an issue myself with the following situation:
- the files' line count is not known upfront (guessing a large enough `infer_schema_length` / `max_rows` value felt wrong)
- first `N`k lines contain `0`, later lines contain float values. (an issue with the source of the files, but fixing that is not possible)