### PR TITLE
Change compression backend for Polars

### DIFF
--- a/native/explorer/Cargo.lock
+++ b/native/explorer/Cargo.lock
@@ -255,9 +255,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -266,6 +266,15 @@ dependencies = [
  "time",
  "wasm-bindgen",
  "winapi",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -401,6 +410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
+ "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -761,6 +771,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-ng-sys"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468756f34903b582fe7154dc1ffdebd89d0562c4a43b53c621bb0f1b1043ccb"
+dependencies = [
+ "cmake",
+ "libc",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebffdb73fe72e917997fad08bdbf31ac50b0fa91cec93e69a0662e4264d454c"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",

--- a/native/explorer/Cargo.toml
+++ b/native/explorer/Cargo.toml
@@ -34,7 +34,7 @@ features = [
   "cross_join",
   "cum_agg",
   "csv",
-  "decompress",
+  "decompress-fast",
   "describe",
   "dtype-date",
   "dtype-time",


### PR DESCRIPTION
This is needed because of an odd problem we got recently after the update of Rust Nightly version: the existing backend - `miniz_oxide`, is breaking the BEAM because it is using a stack size that is greater than the default value.

We have to manually change the size at boot time to make it work.

Using `ELIXIR_ERL_OPTIONS="+sssdcpu 128"` does the trick - thanks @josevalim! :tada: - , but is not very flexible.

To be precise, the problem started after the following Nightly version:

```
nightly-2023-03-02-x86_64-unknown-linux-gnu (default)
rustc 1.69.0-nightly (f77bfb733 2023-03-01)
```