### PR TITLE
Install CMake before building for RISC-V using Cross

### DIFF
--- a/native/explorer/Cross.toml
+++ b/native/explorer/Cross.toml
@@ -2,3 +2,6 @@
 passthrough = [
   "RUSTLER_NIF_VERSION"
 ]
+
+[target.riscv64gc-unknown-linux-gnu]
+pre-build = ["apt update && apt install -y cmake"]


### PR DESCRIPTION
This is needed to build the `libz-ng-sys` crate that is required by Polars when using the `compress-fast` feature.

Would be nice to test it using a RISC-V machine.