### PR TITLE
Traverse categories once and reuse terms in categorial series

### DIFF
--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -359,14 +359,14 @@ fn categorical_series_to_list<'b>(
     let cat_size = mapping.len();
     let mut terms: Vec<NIF_TERM> = vec![nil_as_c_arg; cat_size];
 
-    for index in 0..cat_size {
+    for (index, term) in terms.iter_mut().enumerate() {
         if let Some(existing_str) = mapping.get_optional(index as u32) {
             let mut binary = NewBinary::new(env, existing_str.len());
             binary.copy_from_slice(existing_str.as_bytes());
 
             let binary_term: Term = binary.into();
 
-            terms[index] = binary_term.as_c_arg();
+            *term = binary_term.as_c_arg();
         }
     }
 

--- a/native/explorer/src/encoding.rs
+++ b/native/explorer/src/encoding.rs
@@ -2,7 +2,6 @@ use chrono::prelude::*;
 use polars::export::arrow::array::GenericBinaryArray;
 use polars::prelude::*;
 use rustler::{Encoder, Env, NewBinary, OwnedBinary, ResourceArc, Term};
-use std::collections::HashMap;
 use std::{mem, slice};
 
 use crate::atoms::{
@@ -356,35 +355,28 @@ fn categorical_series_to_list<'b>(
     let nil_as_c_arg = atom::nil().to_term(env).as_c_arg();
     let mut list = unsafe { list::make_list(env_as_c_arg, &[]) };
 
-    let mut terms: HashMap<u32, NIF_TERM> = HashMap::new();
-
     let logical = s.categorical()?.logical();
-    let cat_size = mapping.len() as u32;
+    let cat_size = mapping.len();
+    let mut terms: Vec<NIF_TERM> = vec![nil_as_c_arg; cat_size];
 
-    for maybe_id in &logical.reverse() {
-        let term_as_c_arg = match maybe_id {
-            None => &nil_as_c_arg,
-            Some(id) => terms.entry(id).or_insert_with(|| {
-                // TODO: update to `get_optional` once available:
-                // https://pola-rs.github.io/polars/polars/datatypes/enum.RevMapping.html#method.get_optional
-                let maybe_str = if id < cat_size {
-                    Some(mapping.get(id))
-                } else {
-                    None
-                };
-                if let Some(existing_str) = maybe_str {
-                    let mut binary = NewBinary::new(env, existing_str.len());
-                    binary.copy_from_slice(existing_str.as_bytes());
+    for index in 0..cat_size {
+        if let Some(existing_str) = mapping.get_optional(index as u32) {
+            let mut binary = NewBinary::new(env, existing_str.len());
+            binary.copy_from_slice(existing_str.as_bytes());
 
-                    let binary_term: Term = binary.into();
-                    binary_term.as_c_arg()
-                } else {
-                    nil_as_c_arg
-                }
-            }),
+            let binary_term: Term = binary.into();
+
+            terms[index] = binary_term.as_c_arg();
+        }
+    }
+
+    for maybe_index in &logical.reverse() {
+        let term_ref = match maybe_index {
+            Some(index) if index < (cat_size as u32) => terms[index as usize],
+            _ => nil_as_c_arg,
         };
 
-        list = unsafe { list::make_list_cell(env_as_c_arg, *term_as_c_arg, list) }
+        list = unsafe { list::make_list_cell(env_as_c_arg, term_ref, list) }
     }
 
     Ok(unsafe { Term::new(env, list) })


### PR DESCRIPTION
Resolves #562 

This PR changes from a `HashMap` to a `Vector` when converting a categorical series to a list. 
The vector is as big as the the cardinality of the category, which means we're reusing the vector across the category indices.

I ran some very unscientific micro benchmarks with benchee and got the following results
```
Name                  ips        average  deviation         median         99th %
old_to_list        468.96        2.13 ms    ±10.91%        2.02 ms        2.71 ms
new_to_list        1.19 K      838.64 μs    ±19.62%      857.04 μs     1330.65 μs
```
Keeping in mind that the bench is very unscientific, the speedup seems reasonable!

As it's an internal change I expect the existing test suite to cover the cases of the changes.

<details><summary>Bench code</summary>

```elixir
alias Explorer.Series

gen_cat = fn x ->  for _ <- 1..x, into: "", do: <<Enum.random('0123456789abcdef')>> end

Benchee.run(
  %{
    "to_list" => fn series ->
      Series.to_list(series)
    end,
  },
  before_each: fn _ ->
      categories = Series.from_list(Enum.map(0..10_000, fn _ ->  gen_cat.(5) end), dtype: :category)
      indexes = Series.from_list(Enum.map(0..100_000, fn _ -> :rand.uniform(10_000 - 1) end))
      Series.categorise(indexes, categories)
  end
)
```

<details>