### PR TITLE
Update the way Rust returns errors

### DIFF
--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -150,7 +150,6 @@ defmodule Explorer.PolarsBackend.Shared do
   def internal_from_dtype(:string), do: "str"
 
   defp error_message(error) when is_binary(error), do: error
-  defp error_message(error), do: inspect(error)
 
   def parquet_compression(nil, _), do: :uncompressed
 

--- a/lib/explorer/polars_backend/shared.ex
+++ b/lib/explorer/polars_backend/shared.ex
@@ -149,7 +149,7 @@ defmodule Explorer.PolarsBackend.Shared do
   def internal_from_dtype(:integer), do: "i64"
   def internal_from_dtype(:string), do: "str"
 
-  defp error_message({_err_type, error}) when is_binary(error), do: error
+  defp error_message(error) when is_binary(error), do: error
   defp error_message(error), do: inspect(error)
 
   def parquet_compression(nil, _), do: :uncompressed

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1423,7 +1423,7 @@ defmodule Explorer.Series do
       iex> s1 = Explorer.Series.from_list([<<1>>, <<239, 191, 19>>], dtype: :binary)
       iex> s2 = Explorer.Series.from_list([<<3>>, <<4>>], dtype: :binary)
       iex> Explorer.Series.format([s1, s2])
-      ** (RuntimeError) External error: invalid utf-8 sequence
+      ** (RuntimeError) Polars Error: External error: invalid utf-8 sequence
   """
   @doc type: :shape
   @spec format([Series.t() | String.t()]) :: Series.t()

--- a/native/explorer/src/error.rs
+++ b/native/explorer/src/error.rs
@@ -1,4 +1,4 @@
-use rustler::{Atom, Encoder, Env, Term};
+use rustler::{Encoder, Env, Term};
 use std::io;
 use thiserror::Error;
 
@@ -16,15 +16,15 @@ rustler::atoms! {
 
 #[derive(Error, Debug)]
 pub enum ExplorerError {
-    #[error("IO Error")]
+    #[error("IO Error: {0}")]
     Io(#[from] io::Error),
-    #[error("Utf8 Conversion Error")]
+    #[error("Utf8 Conversion Error: {0}")]
     Utf8(#[from] std::string::FromUtf8Error),
-    #[error("Polars Error")]
+    #[error("Polars Error: {0}")]
     Polars(#[from] polars::prelude::PolarsError),
     #[error("Internal Error: {0}")]
     Internal(String),
-    #[error("Other error: {0}")]
+    #[error("Generic Error: {0}")]
     Other(String),
     #[error(transparent)]
     TryFromInt(#[from] std::num::TryFromIntError),
@@ -36,24 +36,6 @@ pub enum ExplorerError {
 
 impl Encoder for ExplorerError {
     fn encode<'b>(&self, env: Env<'b>) -> Term<'b> {
-        match self {
-            ExplorerError::Io(ref value) => error_tuple(env, io(), value.to_string()),
-            ExplorerError::Utf8(ref value) => error_tuple(env, utf8(), value.to_string()),
-            ExplorerError::Polars(ref value) => error_tuple(env, polars(), value.to_string()),
-
-            ExplorerError::Internal(ref value) => error_tuple(env, internal(), value.to_string()),
-
-            ExplorerError::Other(ref value) => error_tuple(env, other(), value.to_string()),
-            ExplorerError::TryFromInt(ref value) => {
-                error_tuple(env, try_from_int(), value.to_string())
-            }
-            ExplorerError::Parquet(ref value) => error_tuple(env, parquet(), value.to_string()),
-            ExplorerError::Unknown(ref value) => error_tuple(env, unknown(), value.to_string()),
-        }
+        format!("{self}").encode(env)
     }
-}
-
-// Encode an error tuple for better context at the Elixir side.
-fn error_tuple(env: Env, atom: Atom, error_str: String) -> Term {
-    (atom.encode(env), error_str.encode(env)).encode(env)
 }

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -334,7 +334,7 @@ defmodule Explorer.SeriesTest do
     test "mixing string series with a binary that is an invalid string" do
       s1 = Series.from_list(["1", "2", nil, "4"])
 
-      assert_raise RuntimeError, "cannot cast to string", fn ->
+      assert_raise RuntimeError, "Generic Error: cannot cast to string", fn ->
         Series.fill_missing(s1, <<239, 191, 19>>)
       end
     end
@@ -493,9 +493,9 @@ defmodule Explorer.SeriesTest do
     test "boolean series with mean strategy" do
       s1 = Series.from_list([true, nil, false])
 
-      assert_raise RuntimeError, fn ->
-        Series.fill_missing(s1, :mean)
-      end
+      assert_raise RuntimeError,
+                   "Polars Error: invalid operation: `mean` operation not supported for dtype `Boolean`",
+                   fn -> Series.fill_missing(s1, :mean) end
     end
 
     test "with nan" do
@@ -1811,7 +1811,7 @@ defmodule Explorer.SeriesTest do
       s1 = Series.from_list([1, 2, 3])
       s2 = Series.from_list([1, -2, 3])
 
-      assert_raise RuntimeError, "negative exponent with an integer base", fn ->
+      assert_raise RuntimeError, "Generic Error: negative exponent with an integer base", fn ->
         Series.pow(s1, s2)
       end
     end
@@ -1940,7 +1940,7 @@ defmodule Explorer.SeriesTest do
     test "pow of an integer series that contains negative integer with an integer scalar value on the left-hand side" do
       s1 = Series.from_list([1, -2, 3])
 
-      assert_raise RuntimeError, "negative exponent with an integer base", fn ->
+      assert_raise RuntimeError, "Polars Error: negative exponent with an integer base", fn ->
         Series.pow(2, s1)
       end
     end
@@ -2472,7 +2472,7 @@ defmodule Explorer.SeriesTest do
       s2 = Series.from_list([<<3>>, <<4>>], dtype: :binary)
 
       assert_raise RuntimeError,
-                   "External error: invalid utf-8 sequence",
+                   "Polars Error: External error: invalid utf-8 sequence",
                    fn -> Series.format([s1, s2]) end
     end
 
@@ -3196,16 +3196,18 @@ defmodule Explorer.SeriesTest do
     test "from a series of indices with a negative number" do
       s = Series.from_list(["a", "b", "c"])
 
-      assert_raise RuntimeError, "slice/2 expects a series of positive integers", fn ->
-        Series.slice(s, Series.from_list([0, 2, -1]))
-      end
+      assert_raise RuntimeError,
+                   "Generic Error: slice/2 expects a series of positive integers",
+                   fn ->
+                     Series.slice(s, Series.from_list([0, 2, -1]))
+                   end
     end
 
     test "from a series of indices out-of-bounds" do
       s = Series.from_list(["a", "b", "c"])
 
       assert_raise RuntimeError,
-                   "slice/2 cannot select from indices that are out-of-bounds",
+                   "Generic Error: slice/2 cannot select from indices that are out-of-bounds",
                    fn ->
                      Series.slice(s, Series.from_list([0, 2, 20]))
                    end


### PR DESCRIPTION
This PR resolves https://github.com/elixir-nx/explorer/issues/584

After this PR, all errors returned from Rust will be strings instead of tuples