### PR TITLE
add Series.argmin/1 and Series.argmax/1

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -90,6 +90,8 @@ defmodule Explorer.Backend.LazySeries do
     sum: 1,
     min: 1,
     max: 1,
+    argmin: 1,
+    argmax: 1,
     mean: 1,
     median: 1,
     n_distinct: 1,
@@ -131,6 +133,8 @@ defmodule Explorer.Backend.LazySeries do
     :sum,
     :min,
     :max,
+    :argmin,
+    :argmax,
     :mean,
     :median,
     :variance,
@@ -580,8 +584,9 @@ defmodule Explorer.Backend.LazySeries do
 
   defp dtype_for_agg_operation(op, _) when op in [:count, :nil_count, :n_distinct], do: :integer
 
-  defp dtype_for_agg_operation(op, series) when op in [:first, :last, :sum, :min, :max],
-    do: series.dtype
+  defp dtype_for_agg_operation(op, series)
+       when op in [:first, :last, :sum, :min, :max, :argmin, :argmax],
+       do: series.dtype
 
   defp dtype_for_agg_operation(_, _), do: :float
 

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -69,6 +69,8 @@ defmodule Explorer.Backend.Series do
   @callback sum(s) :: number() | non_finite() | lazy_s() | nil
   @callback min(s) :: number() | non_finite() | Date.t() | NaiveDateTime.t() | lazy_s() | nil
   @callback max(s) :: number() | non_finite() | Date.t() | NaiveDateTime.t() | lazy_s() | nil
+  @callback argmin(s) :: number() | non_finite() | lazy_s() | nil
+  @callback argmax(s) :: number() | non_finite() | lazy_s() | nil
   @callback mean(s) :: float() | non_finite() | lazy_s() | nil
   @callback median(s) :: float() | non_finite() | lazy_s() | nil
   @callback variance(s) :: float() | non_finite() | lazy_s() | nil

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -15,6 +15,8 @@ defmodule Explorer.PolarsBackend.Expression do
   @all_expressions [
     add: 2,
     all_equal: 2,
+    argmax: 1,
+    argmin: 1,
     binary_and: 2,
     binary_or: 2,
     binary_in: 2,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -209,6 +209,8 @@ defmodule Explorer.PolarsBackend.Native do
   def s_as_str(_s), do: err()
   def s_add(_s, _other), do: err()
   def s_and(_s, _s2), do: err()
+  def s_argmax(_s), do: err()
+  def s_argmin(_s), do: err()
   def s_argsort(_s, _descending?, _nils_last?), do: err()
   def s_cast(_s, _dtype), do: err()
   def s_categories(_s), do: err()

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -198,6 +198,12 @@ defmodule Explorer.PolarsBackend.Series do
   def max(series), do: Shared.apply_series(series, :s_max)
 
   @impl true
+  def argmin(series), do: Shared.apply_series(series, :s_argmin)
+
+  @impl true
+  def argmax(series), do: Shared.apply_series(series, :s_argmax)
+
+  @impl true
   def mean(series), do: Shared.apply_series(series, :s_mean)
 
   @impl true

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1797,7 +1797,41 @@ defmodule Explorer.Series do
     do: dtype_error("max/1", dtype, [:integer, :float, :date, :time, :datetime])
 
   @doc """
-    TODO
+  Gets the index of the maximum value of the series.
+
+  ## Supported dtypes
+
+    * `:integer`
+    * `:float`
+    * `:date`
+    * `:time`
+    * `:datetime`
+
+  ## Examples
+
+      iex> s = Explorer.Series.from_list([1, 2, nil, 3])
+      iex> Explorer.Series.argmax(s)
+      3
+
+      iex> s = Explorer.Series.from_list([1.0, 2.0, nil, 3.0])
+      iex> Explorer.Series.argmax(s)
+      3
+
+      iex> s = Explorer.Series.from_list([~D[2021-01-01], ~D[1999-12-31]])
+      iex> Explorer.Series.argmax(s)
+      0
+
+      iex> s = Explorer.Series.from_list([~N[2021-01-01 00:00:00], ~N[1999-12-31 00:00:00]])
+      iex> Explorer.Series.argmax(s)
+      0
+
+      iex> s = Explorer.Series.from_list([~T[00:02:03.000212], ~T[00:05:04.000456]])
+      iex> Explorer.Series.argmax(s)
+      1
+
+      iex> s = Explorer.Series.from_list(["a", "b", "c"])
+      iex> Explorer.Series.argmax(s)
+      ** (ArgumentError) Explorer.Series.argmax/1 not implemented for dtype :string. Valid dtypes are [:integer, :float, :date, :time, :datetime]
   """
   @doc type: :aggregation
   @spec argmax(series :: Series.t()) :: number() | non_finite() | nil
@@ -1808,7 +1842,43 @@ defmodule Explorer.Series do
     do: dtype_error("argmax/1", dtype, [:integer, :float, :date, :time, :datetime])
 
   @doc """
-    TODO
+  Gets the index of the minimum value of the series.
+
+  Note that `nil` is treated as a minimum value.
+
+  ## Supported dtypes
+
+    * `:integer`
+    * `:float`
+    * `:date`
+    * `:time`
+    * `:datetime`
+
+  ## Examples
+
+      iex> s = Explorer.Series.from_list([1, 2, nil, 3])
+      iex> Explorer.Series.argmin(s)
+      2
+
+      iex> s = Explorer.Series.from_list([1.0, 2.0, nil, 3.0])
+      iex> Explorer.Series.argmin(s)
+      2
+
+      iex> s = Explorer.Series.from_list([~D[2021-01-01], ~D[1999-12-31]])
+      iex> Explorer.Series.argmin(s)
+      1
+
+      iex> s = Explorer.Series.from_list([~N[2021-01-01 00:00:00], ~N[1999-12-31 00:00:00]])
+      iex> Explorer.Series.argmin(s)
+      1
+
+      iex> s = Explorer.Series.from_list([~T[00:02:03.000212], ~T[00:05:04.000456]])
+      iex> Explorer.Series.argmin(s)
+      0
+
+      iex> s = Explorer.Series.from_list(["a", "b", "c"])
+      iex> Explorer.Series.argmin(s)
+      ** (ArgumentError) Explorer.Series.argmin/1 not implemented for dtype :string. Valid dtypes are [:integer, :float, :date, :time, :datetime]
   """
   @doc type: :aggregation
   @spec argmin(series :: Series.t()) :: number() | non_finite() | nil

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1797,6 +1797,28 @@ defmodule Explorer.Series do
     do: dtype_error("max/1", dtype, [:integer, :float, :date, :time, :datetime])
 
   @doc """
+    TODO
+  """
+  @doc type: :aggregation
+  @spec argmax(series :: Series.t()) :: number() | non_finite() | nil
+  def argmax(%Series{dtype: dtype} = series) when is_numeric_or_date_dtype(dtype),
+    do: apply_series(series, :argmax)
+
+  def argmax(%Series{dtype: dtype}),
+    do: dtype_error("argmax/1", dtype, [:integer, :float, :date, :time, :datetime])
+
+  @doc """
+    TODO
+  """
+  @doc type: :aggregation
+  @spec argmin(series :: Series.t()) :: number() | non_finite() | nil
+  def argmin(%Series{dtype: dtype} = series) when is_numeric_or_date_dtype(dtype),
+    do: apply_series(series, :argmin)
+
+  def argmin(%Series{dtype: dtype}),
+    do: dtype_error("argmin/1", dtype, [:integer, :float, :date, :time, :datetime])
+
+  @doc """
   Gets the mean value of the series.
 
   ## Supported dtypes

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -414,6 +414,20 @@ pub fn expr_max(expr: ExExpr) -> ExExpr {
 }
 
 #[rustler::nif]
+pub fn expr_argmax(expr: ExExpr) -> ExExpr {
+    let expr = expr.clone_inner();
+
+    ExExpr::new(expr.arg_max().cast(DataType::Int64))
+}
+
+#[rustler::nif]
+pub fn expr_argmin(expr: ExExpr) -> ExExpr {
+    let expr = expr.clone_inner();
+
+    ExExpr::new(expr.arg_min().cast(DataType::Int64))
+}
+
+#[rustler::nif]
 pub fn expr_mean(expr: ExExpr) -> ExExpr {
     let expr = expr.clone_inner();
 

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -199,6 +199,8 @@ rustler::init!(
         expr_select,
         // agg expressions
         expr_alias,
+        expr_argmax,
+        expr_argmin,
         expr_count,
         expr_first,
         expr_last,
@@ -271,6 +273,8 @@ rustler::init!(
         s_abs,
         s_add,
         s_and,
+        s_argmax,
+        s_argmin,
         s_argsort,
         s_acos,
         s_asin,

--- a/native/explorer/src/series.rs
+++ b/native/explorer/src/series.rs
@@ -741,6 +741,16 @@ pub fn s_max(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_argmax(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
+    Ok(s.arg_max().encode(env))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
+pub fn s_argmin(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
+    Ok(s.arg_min().encode(env))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn s_mean(env: Env, s: ExSeries) -> Result<Term, ExplorerError> {
     match s.dtype() {
         DataType::Boolean => Ok(s.mean().encode(env)),

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -3073,5 +3073,66 @@ defmodule Explorer.DataFrameTest do
                solid_fuel_mean: [18212.27970749543]
              }
     end
+
+    test "argmax/1 and argmin/1" do
+      df =
+        DF.new(
+          a: [1, 2, 3, nil],
+          b: [1.3, nil, 5.4, 2.6],
+          c: [nil, ~D[2023-01-01], ~D[2022-01-01], ~D[2021-01-01]],
+          d: [
+            ~N[2023-01-01 00:00:00],
+            ~N[2022-01-01 00:00:00],
+            ~N[2021-01-01 00:00:00],
+            nil
+          ],
+          e: [
+            ~N[2023-01-01 10:00:00],
+            ~N[2022-01-01 01:00:00],
+            ~N[2021-01-01 00:10:00],
+            nil
+          ],
+          f: [1.0, :infinity, :neg_infinity, nil]
+        )
+        |> DF.mutate(e: cast(e, :time))
+
+      df1 =
+        DF.summarise(df,
+          a: argmax(a),
+          b: argmax(b),
+          c: argmax(c),
+          d: argmax(d),
+          e: argmax(e),
+          f: argmax(f)
+        )
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [2],
+               b: [2],
+               c: [1],
+               d: [0],
+               e: [0],
+               f: [1]
+             }
+
+      df2 =
+        DF.summarise(df,
+          a: argmin(a),
+          b: argmin(b),
+          c: argmin(c),
+          d: argmin(d),
+          e: argmin(e),
+          f: argmin(f)
+        )
+
+      assert DF.to_columns(df2, atom_keys: true) == %{
+               a: [0],
+               b: [0],
+               c: [3],
+               d: [2],
+               e: [2],
+               f: [2]
+             }
+    end
   end
 end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -3117,12 +3117,12 @@ defmodule Explorer.DataFrameTest do
 
       df2 =
         DF.summarise(df,
-          a: argmin(a),
-          b: argmin(b),
-          c: argmin(c),
-          d: argmin(d),
-          e: argmin(e),
-          f: argmin(f)
+          a: argmin(fill_missing(a, :max)),
+          b: argmin(fill_missing(b, :max)),
+          c: argmin(fill_missing(c, :max)),
+          d: argmin(fill_missing(d, :max)),
+          e: argmin(fill_missing(e, :max)),
+          f: argmin(fill_missing(f, :max))
         )
 
       assert DF.to_columns(df2, atom_keys: true) == %{
@@ -3132,6 +3132,25 @@ defmodule Explorer.DataFrameTest do
                d: [2],
                e: [2],
                f: [2]
+             }
+
+      df3 =
+        DF.summarise(df,
+          a: argmin(a),
+          b: argmin(b),
+          c: argmin(c),
+          d: argmin(d),
+          e: argmin(e),
+          f: argmin(f)
+        )
+
+      assert DF.to_columns(df3, atom_keys: true) == %{
+               a: [3],
+               b: [1],
+               c: [0],
+               d: [3],
+               e: [3],
+               f: [3]
              }
     end
   end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -3834,6 +3834,36 @@ defmodule Explorer.SeriesTest do
     end
   end
 
+  describe "argmax/1 and argmin/1" do
+    test "argmax and argmin for different dtypes" do
+      quads = [
+        {[1, 2, 3, nil], 2, 3, 0},
+        {[1.3, nil, 5.4, 2.6], 2, 1, 0},
+        {[nil, ~D[2023-01-01], ~D[2022-01-01], ~D[2021-01-01]], 1, 0, 3},
+        {[
+           ~N[2023-01-01 00:00:00],
+           ~N[2022-01-01 00:00:00],
+           ~N[2021-01-01 00:00:00],
+           nil
+         ], 0, 3, 2},
+        {[
+           ~N[2023-01-01 10:00:00],
+           ~N[2022-01-01 01:00:00],
+           ~N[2021-01-01 00:10:00],
+           nil
+         ], 0, 3, 2},
+        {[1.0, :infinity, :neg_infinity, nil], 1, 3, 2}
+      ]
+
+      for {list, exp_argmax, exp_argmin, exp_argmin_filled} <- quads do
+        series = Series.from_list(list)
+        assert Series.argmax(series) == exp_argmax
+        assert Series.argmin(series) == exp_argmin
+        assert Series.argmin(Series.fill_missing(series, :max)) == exp_argmin_filled
+      end
+    end
+  end
+
   describe "strptime/2 and strftime/2" do
     test "parse datetime from string" do
       series = Series.from_list(["2023-01-05 12:34:56", "XYZ", nil])

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -3836,26 +3836,16 @@ defmodule Explorer.SeriesTest do
 
   describe "argmax/1 and argmin/1" do
     test "argmax and argmin for different dtypes" do
-      quads = [
-        {[1, 2, 3, nil], 2, 3, 0},
-        {[1.3, nil, 5.4, 2.6], 2, 1, 0},
-        {[nil, ~D[2023-01-01], ~D[2022-01-01], ~D[2021-01-01]], 1, 0, 3},
-        {[
-           ~N[2023-01-01 00:00:00],
-           ~N[2022-01-01 00:00:00],
-           ~N[2021-01-01 00:00:00],
-           nil
-         ], 0, 3, 2},
-        {[
-           ~N[2023-01-01 10:00:00],
-           ~N[2022-01-01 01:00:00],
-           ~N[2021-01-01 00:10:00],
-           nil
-         ], 0, 3, 2},
-        {[1.0, :infinity, :neg_infinity, nil], 1, 3, 2}
-      ]
-
-      for {list, exp_argmax, exp_argmin, exp_argmin_filled} <- quads do
+      for {list, exp_argmax, exp_argmin, exp_argmin_filled} <- [
+            {[1, 2, 3, nil], 2, 3, 0},
+            {[1.3, nil, 5.4, 2.6], 2, 1, 0},
+            {[nil, ~D[2023-01-01], ~D[2022-01-01], ~D[2021-01-01]], 1, 0, 3},
+            {[~N[2023-01-01 00:00:00], ~N[2022-01-01 00:00:00], ~N[2021-01-01 00:00:00], nil], 0,
+             3, 2},
+            {[~N[2023-01-01 10:00:00], ~N[2022-01-01 01:00:00], ~N[2021-01-01 00:10:00], nil], 0,
+             3, 2},
+            {[1.0, :infinity, :neg_infinity, nil], 1, 3, 2}
+          ] do
         series = Series.from_list(list)
         assert Series.argmax(series) == exp_argmax
         assert Series.argmin(series) == exp_argmin


### PR DESCRIPTION
Hi, I'm trying to get a better understanding of the codebase by doing simpler tasks. These two aggregate functions seem to be missing. Please let me know if you'd rather have an open issue first.

I need some advice regarding `argmin` though. Out of the box, it seems to treat `nil` as a minimum, and I can confirm that this seems to be consistent with Polars' Python API - here's a one liner to verify that:

```bash
python -c "import polars as pl; s = pl.Series([2, 1, 3, None, 4]); print(s); print(s.arg_min())"
```

Do we want to import this behaviour from Polars? If not, any suggestions on how to deal with it? In the tests, I pipe into `fill_missing(:max)` first, but perhaps there's a better approach.