### PR TITLE
fix Series.round/2 when used in expressions

### DIFF
--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -60,7 +60,6 @@ defmodule Explorer.PolarsBackend.Expression do
     quotient: 2,
     remainder: 2,
     reverse: 1,
-    round: 2,
     floor: 1,
     ceil: 1,
     select: 3,
@@ -90,6 +89,7 @@ defmodule Explorer.PolarsBackend.Expression do
     sample_frac: 5,
     exp: 1,
     skew: 2,
+    round: 2,
 
     # Trigonometric operations
     acos: 1,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1334,6 +1334,17 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
+    test "adds a column with round" do
+      df = DF.new(a: [1.2345, 2.3456, 3.4567, 4.5678])
+
+      df1 = DF.mutate(df, b: round(a, 2))
+
+      assert DF.to_columns(df1, atom_keys: true) == %{
+               a: [1.2345, 2.3456, 3.4567, 4.5678],
+               b: [1.23, 2.35, 3.46, 4.57]
+             }
+    end
+
     test "adds a column with exponential" do
       df = DF.new(a: [1, 2, 3])
 


### PR DESCRIPTION
## Before

The following:

```elixir
DF.new(a: [1.2345, 2.3456, 3.4567, 4.5678])
|> DF.mutate(b: round(a, 2))
```

gives this error:

```
  1) test mutate/2 adds a column with round (Explorer.DataFrameTest)
     test/explorer/data_frame_test.exs:1357
     ** (ArgumentError) argument error
     code: df1 = DF.mutate(df, b: round(a, 2))
     stacktrace:
       (explorer 0.5.8-dev) Explorer.PolarsBackend.Native.expr_round(%Explorer.PolarsBackend.Expression{resource: #Reference<0.3815557547.222167042.37314>}, %Explorer.PolarsBacke
nd.Expression{resource: #Reference<0.3815557547.222167042.37315>})
       (explorer 0.5.8-dev) lib/explorer/polars_backend/data_frame.ex:427: anonymous fn/2 in Explorer.PolarsBackend.DataFrame.mutate_with/3
       (elixir 1.14.4) lib/enum.ex:2468: Enum."-reduce/3-lists^foldl/2-0-"/3
       (explorer 0.5.8-dev) lib/explorer/polars_backend/data_frame.ex:425: Explorer.PolarsBackend.DataFrame.mutate_with/3
       test/explorer/data_frame_test.exs:1360: (test)
```

## After

```elixir
DF.new(a: [1.2345, 2.3456, 3.4567, 4.5678])
|> DF.mutate(b: round(a, 2))

# #Explorer.DataFrame<
#   Polars[4 x 2]
#   a float [1.2345, 2.3456, 3.4567, 4.5678]
#   b float [1.23, 2.35, 3.46, 4.57]
# >
```