### PR TITLE
add DataFrame.nil_count/1

### DIFF
--- a/lib/explorer/backend/data_frame.ex
+++ b/lib/explorer/backend/data_frame.ex
@@ -180,6 +180,7 @@ defmodule Explorer.Backend.DataFrame do
             ) :: df
   @callback put(df, out_df :: df(), column_name(), series()) :: df
   @callback describe(df, percentiles :: option(list(float()))) :: df()
+  @callback nil_count(df) :: df()
 
   # Two or more table verbs
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5013,7 +5013,20 @@ defmodule Explorer.DataFrame do
   end
 
   @doc """
-  TODO
+  Count the number of nils in each column.
+
+  Groups are ignored if the dataframe is using any.
+
+  ## Examples
+
+      iex> df = Explorer.DataFrame.new(a: ["d", nil, "f"], b: [nil, 2, nil], c: ["a", "b", "c"])
+      iex> Explorer.DataFrame.nil_count(df)
+      #Explorer.DataFrame<
+        Polars[1 x 3]
+        a integer [1]
+        b integer [2]
+        c integer [0]
+      >
   """
   @doc type: :single
   @spec nil_count(df :: DataFrame.t()) :: DataFrame.t()

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5013,9 +5013,7 @@ defmodule Explorer.DataFrame do
   end
 
   @doc """
-  Count the number of nils in each column.
-
-  Groups are ignored if the dataframe is using any.
+  Counts the number of null elements in each column.
 
   ## Examples
 

--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -5012,6 +5012,13 @@ defmodule Explorer.DataFrame do
     Shared.apply_impl(df, :describe, [opts[:percentiles]])
   end
 
+  @doc """
+  TODO
+  """
+  @doc type: :single
+  @spec nil_count(df :: DataFrame.t()) :: DataFrame.t()
+  def nil_count(df), do: Shared.apply_impl(df, :nil_count)
+
   # Helpers
 
   defp backend_from_options!(opts) do

--- a/lib/explorer/polars_backend/data_frame.ex
+++ b/lib/explorer/polars_backend/data_frame.ex
@@ -447,6 +447,14 @@ defmodule Explorer.PolarsBackend.DataFrame do
   end
 
   @impl true
+  def nil_count(%DataFrame{} = df) do
+    case Native.df_nil_count(df.data) do
+      {:ok, polars_df} -> Shared.create_dataframe(polars_df)
+      {:error, error} -> raise "cannot count nils. Reason: #{inspect(error)}"
+    end
+  end
+
+  @impl true
   def arrange_with(%DataFrame{} = df, out_df, column_pairs) do
     {directions, expressions} =
       column_pairs

--- a/lib/explorer/polars_backend/lazy_frame.ex
+++ b/lib/explorer/polars_backend/lazy_frame.ex
@@ -387,6 +387,7 @@ defmodule Explorer.PolarsBackend.LazyFrame do
 
   not_available_funs = [
     describe: 2,
+    nil_count: 1,
     dummies: 3,
     dump_csv: 3,
     dump_ipc: 2,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -131,6 +131,7 @@ defmodule Explorer.PolarsBackend.Native do
   def df_to_parquet(_df, _filename, _compression), do: err()
   def df_width(_df), do: err()
   def df_describe(_df, _percentiles), do: err()
+  def df_nil_count(_df), do: err()
 
   # Expressions (for lazy queries)
   @multi_arity_expressions [slice: 2, slice: 3, log: 1, log: 2]

--- a/native/explorer/src/dataframe.rs
+++ b/native/explorer/src/dataframe.rs
@@ -430,6 +430,13 @@ pub fn df_describe(
 }
 
 #[rustler::nif(schedule = "DirtyCpu")]
+pub fn df_nil_count(df: ExDataFrame) -> Result<ExDataFrame, ExplorerError> {
+    let mut new_df = df.null_count();
+    let new_df = normalize_numeric_dtypes(&mut new_df)?;
+    Ok(ExDataFrame::new(new_df))
+}
+
+#[rustler::nif(schedule = "DirtyCpu")]
 pub fn df_mutate_with_exprs(
     df: ExDataFrame,
     columns: Vec<ExExpr>,

--- a/native/explorer/src/lib.rs
+++ b/native/explorer/src/lib.rs
@@ -71,6 +71,7 @@ rustler::init!(
         df_concat_columns,
         df_concat_rows,
         df_describe,
+        df_nil_count,
         df_distinct,
         df_drop,
         df_drop_nils,

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2976,7 +2976,16 @@ defmodule Explorer.DataFrameTest do
   describe "nil_count/1" do
     test "various dtypes" do
       require Explorer.DataFrame, as: DF
-      df = DF.new(a: [1, nil, 3], b: [6.0, nil, :nan], c: ["a", "b", "c"], d: ["a", nil, nil], e: [nil, nil, nil])
+
+      df =
+        DF.new(
+          a: [1, nil, 3],
+          b: [6.0, nil, :nan],
+          c: ["a", "b", "a"],
+          d: ["a", nil, nil],
+          e: [nil, nil, nil]
+        )
+
       df1 = DF.nil_count(df)
       assert DF.to_columns(df1, atom_keys: true) == %{a: [1], b: [1], c: [0], d: [2], e: [3]}
     end

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -2973,6 +2973,15 @@ defmodule Explorer.DataFrameTest do
     end
   end
 
+  describe "nil_count/1" do
+    test "various dtypes" do
+      require Explorer.DataFrame, as: DF
+      df = DF.new(a: [1, nil, 3], b: [6.0, nil, :nan], c: ["a", "b", "c"], d: ["a", nil, nil], e: [nil, nil, nil])
+      df1 = DF.nil_count(df)
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [1], b: [1], c: [0], d: [2], e: [3]}
+    end
+  end
+
   describe "concat_columns/1" do
     test "combine columns of both data frames" do
       df1 = DF.new(x: [1, 2, 3], y: ["a", "b", "c"])


### PR DESCRIPTION
`Series.nil_count/1` already exists, but in the Python API, there is also a shortcut for the dataframe to compute all of the nil counts per column - see [null_count](https://pola-rs.github.io/polars/py-polars/html/reference/dataframe/api/polars.DataFrame.null_count.html).