### PR TITLE
support scalars in Series.select/3

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -532,12 +532,12 @@ defmodule Explorer.Backend.LazySeries do
   end
 
   def select(%Series{} = predicate, on_true, on_false) do
-    select(predicate, to_series!(on_true), to_series!(on_false))
+    select(predicate, literal!(on_true), literal!(on_false))
   end
 
-  defp to_series!(%Series{} = series), do: series
+  defp literal!(%Series{} = series), do: series
 
-  defp to_series!(value) do
+  defp literal!(value) do
     dtype = Explorer.Shared.check_types!([value])
     from_list([value], dtype)
   end

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -531,6 +531,17 @@ defmodule Explorer.Backend.LazySeries do
     Backend.Series.new(data, dtype)
   end
 
+  def select(%Series{} = predicate, on_true, on_false) do
+    select(predicate, to_series!(on_true), to_series!(on_false))
+  end
+
+  defp to_series!(%Series{} = series), do: series
+
+  defp to_series!(value) do
+    dtype = Explorer.Shared.check_types!([value])
+    from_list([value], dtype)
+  end
+
   @impl true
   def format(list) do
     series_list = Enum.map(list, &series_or_lazy_series!/1)

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -55,7 +55,11 @@ defmodule Explorer.Backend.Series do
   @callback coalesce(s, s) :: s
   @callback first(s) :: valid_types() | lazy_s()
   @callback last(s) :: valid_types() | lazy_s()
-  @callback select(predicate :: s, s, s) :: s
+  @callback select(
+              predicate :: s,
+              s | valid_types() | non_finite(),
+              s | valid_types() | non_finite()
+            ) :: s
   @callback shift(s, offset :: integer, default :: nil) :: s
   @callback rank(
               s,

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -180,6 +180,10 @@ defmodule Explorer.PolarsBackend.Series do
     Shared.apply_series(predicate, :s_select, [on_true.data, on_false.data])
   end
 
+  def select(%Series{} = predicate, on_true, on_false) do
+    select(predicate, literal!(on_true), literal!(on_false))
+  end
+
   # Aggregation
 
   @impl true
@@ -682,6 +686,11 @@ defmodule Explorer.PolarsBackend.Series do
 
   defp to_mod_series(value, %{dtype: dtype}, mod),
     do: mod.from_list([value], dtype)
+
+  defp literal!(%Series{} = series), do: series
+
+  defp literal!(value),
+    do: from_list([value], Explorer.Shared.check_types!([value]))
 end
 
 defimpl Inspect, for: Explorer.PolarsBackend.Series do

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -11,7 +11,8 @@ defmodule Explorer.PolarsBackend.Series do
 
   @behaviour Explorer.Backend.Series
 
-  defguardp is_numerical(n) when is_number(n) or n in [:nan, :infinity, :neg_infinity]
+  defguardp is_non_finite(n) when n in [:nan, :infinity, :neg_infinity]
+  defguardp is_numerical(n) when is_number(n) or is_non_finite(n)
 
   # Conversion
 
@@ -180,8 +181,15 @@ defmodule Explorer.PolarsBackend.Series do
     Shared.apply_series(predicate, :s_select, [on_true.data, on_false.data])
   end
 
+  def select(%Series{} = predicate, %Series{} = on_true, on_false),
+    do: select(predicate, on_true, to_series(on_false, on_true))
+
+  def select(%Series{} = predicate, on_true, %Series{} = on_false),
+    do: select(predicate, to_series(on_true, on_false), on_false)
+
   def select(%Series{} = predicate, on_true, on_false) do
-    select(predicate, literal!(on_true), literal!(on_false))
+    on_true = from_list([on_true], Explorer.Shared.check_types!([on_true]))
+    select(predicate, on_true, on_false)
   end
 
   # Aggregation
@@ -681,16 +689,11 @@ defmodule Explorer.PolarsBackend.Series do
   defp to_mod_series(value, %{dtype: :float}, mod) when is_integer(value),
     do: mod.from_list([1.0 * value], :float)
 
-  defp to_mod_series(value, %{dtype: :integer}, mod) when is_float(value),
+  defp to_mod_series(value, %{dtype: :integer}, mod) when is_float(value) or is_non_finite(value),
     do: mod.from_list([value], :float)
 
   defp to_mod_series(value, %{dtype: dtype}, mod),
     do: mod.from_list([value], dtype)
-
-  defp literal!(%Series{} = series), do: series
-
-  defp literal!(value),
-    do: from_list([value], Explorer.Shared.check_types!([value]))
 end
 
 defimpl Inspect, for: Explorer.PolarsBackend.Series do

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -77,6 +77,14 @@ defmodule Explorer.Series do
   @type lazy_t :: %Series{data: Explorer.Backend.LazySeries.t(), dtype: dtype()}
 
   @type non_finite :: :nan | :infinity | :neg_infinity
+  @type inferable_scalar ::
+          number()
+          | non_finite()
+          | boolean()
+          | String.t()
+          | Date.t()
+          | Time.t()
+          | NaiveDateTime.t()
 
   @doc false
   @enforce_keys [:data, :dtype]
@@ -1137,7 +1145,11 @@ defmodule Explorer.Series do
   a series of the same size as `predicate` or a series of size 1.
   """
   @doc type: :element_wise
-  @spec select(predicate :: Series.t(), on_true :: Series.t(), on_false :: Series.t()) ::
+  @spec select(
+          predicate :: Series.t(),
+          on_true :: Series.t() | inferable_scalar(),
+          on_false :: Series.t() | inferable_scalar()
+        ) ::
           Series.t()
   def select(
         %Series{dtype: predicate_dtype} = predicate,

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1161,6 +1161,17 @@ defmodule Explorer.Series do
     end
   end
 
+  def select(%Series{} = predicate, on_true, on_false) do
+    select(predicate, to_series!(on_true), to_series!(on_false))
+  end
+
+  defp to_series!(%Series{} = series), do: series
+
+  defp to_series!(value) do
+    dtype = Explorer.Shared.check_types!([value])
+    from_list([value], dtype: dtype)
+  end
+
   @doc """
   Returns a random sample of the series.
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -1174,14 +1174,7 @@ defmodule Explorer.Series do
   end
 
   def select(%Series{} = predicate, on_true, on_false) do
-    select(predicate, to_series!(on_true), to_series!(on_false))
-  end
-
-  defp to_series!(%Series{} = series), do: series
-
-  defp to_series!(value) do
-    dtype = Explorer.Shared.check_types!([value])
-    from_list([value], dtype: dtype)
+    apply_series_list(:select, [predicate, on_true, on_false])
   end
 
   @doc """

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1537,8 +1537,8 @@ defmodule Explorer.DataFrameTest do
       df1 = DF.new(a: [1, 2, 3]) |> DF.mutate(x: select(a <= 2.5, a, 2.5))
       assert Series.to_list(df1[:x]) == [1.0, 2.0, 2.5]
 
-      df2 = DF.new(a: [1, 2, 3]) |> DF.mutate(x: select(a <= 2.5, 2.5, a))
-      assert Series.to_list(df2[:x]) == [2.5, 2.5, 3.0]
+      df2 = DF.new(a: [1, 2, 3]) |> DF.mutate(x: select(a <= 2.5, :nan, a))
+      assert Series.to_list(df2[:x]) == [:nan, :nan, 3.0]
 
       df3 = DF.new(a: [true, false, nil]) |> DF.mutate(x: select(a, false, a))
       assert Series.to_list(df3[:x]) == [false, false, nil]

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1556,7 +1556,12 @@ defmodule Explorer.DataFrameTest do
         DF.new(a: [~D[2023-01-15], ~D[2022-02-16], nil])
         |> DF.mutate(x: select(a == ~D[2023-01-15], a, ~D[2023-01-01]))
 
-      assert Series.to_list(df7[:x]) == [~D[2023-01-15], ~D[2023-01-01], ~D[2023-01-01]]
+      assert Series.to_list(df7[:x]) ==
+               [
+                 ~N[2023-01-15 00:00:00.000000],
+                 ~N[2023-01-01 00:00:00.000000],
+                 ~N[2023-01-01 00:00:00.000000]
+               ]
     end
   end
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1532,6 +1532,33 @@ defmodule Explorer.DataFrameTest do
                "k" => :integer
              }
     end
+
+    @tag current: true
+    test "add columns with select/3" do
+      df1 = DF.new(a: [1, 2, 3]) |> DF.mutate(x: select(a <= 2.5, a, 2.5))
+      assert Series.to_list(df1[:x]) == [1.0, 2.0, 2.5]
+
+      df2 = DF.new(a: [1, 2, 3]) |> DF.mutate(x: select(a <= 2.5, 2.5, a))
+      assert Series.to_list(df2[:x]) == [2.5, 2.5, 3.0]
+
+      df3 = DF.new(a: [true, false, nil]) |> DF.mutate(x: select(a, false, a))
+      assert Series.to_list(df3[:x]) == [false, false, nil]
+
+      df4 = DF.new(a: [true, false, nil]) |> DF.mutate(x: select(not a, a, true))
+      assert Series.to_list(df4[:x]) == [true, false, true]
+
+      df5 = DF.new(a: ["a", "b", "c"]) |> DF.mutate(x: select(a == "a", "x", a))
+      assert Series.to_list(df5[:x]) == ["x", "b", "c"]
+
+      df6 = DF.new(a: ["a", "b", "c"]) |> DF.mutate(x: select(a == "a", a, "x"))
+      assert Series.to_list(df6[:x]) == ["a", "x", "x"]
+
+      df7 =
+        DF.new(a: [~D[2023-01-15], ~D[2022-02-16], nil])
+        |> DF.mutate(x: select(a == ~D[2023-01-15], a, ~D[2023-01-01]))
+
+      assert Series.to_list(df7[:x]) == [~D[2023-01-15], ~D[2023-01-01], ~D[2023-01-01]]
+    end
   end
 
   describe "arrange/3" do

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1533,7 +1533,6 @@ defmodule Explorer.DataFrameTest do
              }
     end
 
-    @tag current: true
     test "add columns with select/3" do
       df1 = DF.new(a: [1, 2, 3]) |> DF.mutate(x: select(a <= 2.5, a, 2.5))
       assert Series.to_list(df1[:x]) == [1.0, 2.0, 2.5]

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2789,8 +2789,8 @@ defmodule Explorer.SeriesTest do
       s = Series.from_list([1, 2, 3])
       s1 = Series.select(Series.less_equal(s, 2), -1, 1)
       assert Series.to_list(s1) == [-1, -1, 1]
-      s2 = Series.select(Series.less_equal(s, 2), s, 1)
-      assert Series.to_list(s2) == [1, 2, 1]
+      s2 = Series.select(Series.less_equal(s, 2), s, :infinity)
+      assert Series.to_list(s2) == [1, 2, :infinity]
       s3 = Series.select(Series.less_equal(s, 2), -1, s)
       assert Series.to_list(s3) == [-1, -1, 3]
     end

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -2784,6 +2784,16 @@ defmodule Explorer.SeriesTest do
 
       assert Series.select(predicate, on_true, on_false) |> Series.to_list() == [1, 0, 1, 0]
     end
+
+    test "select allows if on_true or on_false is a series or a scalar" do
+      s = Series.from_list([1, 2, 3])
+      s1 = Series.select(Series.less_equal(s, 2), -1, 1)
+      assert Series.to_list(s1) == [-1, -1, 1]
+      s2 = Series.select(Series.less_equal(s, 2), s, 1)
+      assert Series.to_list(s2) == [1, 2, 1]
+      s3 = Series.select(Series.less_equal(s, 2), -1, s)
+      assert Series.to_list(s3) == [-1, -1, 3]
+    end
   end
 
   describe "sort/2" do


### PR DESCRIPTION
This is to follow up [this remark](https://github.com/elixir-nx/explorer/pull/636#issuecomment-1616468623) in #636 

Not sure if there's a better way to do `to_series!` - please let me know if there is.

Also, I feel like there's a lot of these functions that support series, but not scalars. I wonder if it makes to have something like [lit](https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.lit.html) that just infers the scalar type using `Shared.check_types!` instead of supporting scalars for every function. What do you think? 