### PR TITLE
add Series.lit/1

### DIFF
--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -196,7 +196,9 @@ defmodule Explorer.Backend.LazySeries do
   def lit(%Series{} = s), do: s
 
   def lit(value) do
-    from_list([value], Explorer.Shared.check_types!([value]))
+    dtype = Explorer.Shared.check_types!([value])
+
+    Backend.Series.new(value, dtype)
   end
 
   @impl true

--- a/lib/explorer/backend/lazy_series.ex
+++ b/lib/explorer/backend/lazy_series.ex
@@ -15,6 +15,7 @@ defmodule Explorer.Backend.LazySeries do
 
   @operations [
     # Element-wise
+    lit: 1,
     all_equal: 2,
     equal: 2,
     not_equal: 2,
@@ -189,6 +190,13 @@ defmodule Explorer.Backend.LazySeries do
     args = [data!(left), data!(right)]
     data = new(:divide, args, aggregations?(args))
     Backend.Series.new(data, :float)
+  end
+
+  @impl true
+  def lit(%Series{} = s), do: s
+
+  def lit(value) do
+    from_list([value], Explorer.Shared.check_types!([value]))
   end
 
   @impl true

--- a/lib/explorer/backend/series.ex
+++ b/lib/explorer/backend/series.ex
@@ -23,6 +23,7 @@ defmodule Explorer.Backend.Series do
   @callback to_iovec(s) :: [binary()]
   @callback cast(s, dtype) :: s
   @callback categorise(s, s) :: s
+  @callback lit(s | valid_types() | non_finite()) :: s
   @callback strptime(s, String.t()) :: s
   @callback strftime(s, String.t()) :: s
 

--- a/lib/explorer/polars_backend/expression.ex
+++ b/lib/explorer/polars_backend/expression.ex
@@ -115,6 +115,7 @@ defmodule Explorer.PolarsBackend.Expression do
     # Conversions
     strptime: 2,
     strftime: 2,
+    lit: 1,
 
     # Strings
     contains: 2,

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -25,6 +25,7 @@ defmodule Explorer.PolarsBackend.Native do
       x86_64-unknown-freebsd
     ),
     mode: mode,
+    target: "aarch64-apple-darwin",
     force_build: System.get_env("EXPLORER_BUILD") in ["1", "true"]
 
   defstruct [:inner]

--- a/lib/explorer/polars_backend/native.ex
+++ b/lib/explorer/polars_backend/native.ex
@@ -25,7 +25,6 @@ defmodule Explorer.PolarsBackend.Native do
       x86_64-unknown-freebsd
     ),
     mode: mode,
-    target: "aarch64-apple-darwin",
     force_build: System.get_env("EXPLORER_BUILD") in ["1", "true"]
 
   defstruct [:inner]

--- a/lib/explorer/polars_backend/series.ex
+++ b/lib/explorer/polars_backend/series.ex
@@ -379,6 +379,12 @@ defmodule Explorer.PolarsBackend.Series do
   # Comparisons
 
   @impl true
+  def lit(%Series{} = s), do: s
+
+  def lit(value),
+    do: from_list([value], Explorer.Shared.check_types!([value]))
+
+  @impl true
   def equal(left, right),
     do: Shared.apply_series(to_series(left, right), :s_equal, [to_polars_series(right, left)])
 

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -300,7 +300,26 @@ defmodule Explorer.Series do
   end
 
   @doc """
-    TODO
+  Creates a singleton series based on a scala value.
+
+  ## Examples
+
+    iex> Series.lit(1)
+    #Explorer.Series<
+      Polars[1]
+      integer [1]
+    >
+
+  This is particularly useful for function calls where the arguments are
+  required to be series.
+
+    iex> s = Series.from_list([nil, 2, 3])
+    iex> Series.coalesce(s, Series.lit(1))
+    #Explorer.Series<
+      Polars[3]
+      integer [1, 2, 3]
+    >
+
   """
   @doc type: :conversion
   @spec lit(value :: Series.t() | inferable_scalar()) :: Series.t()

--- a/lib/explorer/series.ex
+++ b/lib/explorer/series.ex
@@ -300,6 +300,15 @@ defmodule Explorer.Series do
   end
 
   @doc """
+    TODO
+  """
+  @doc type: :conversion
+  @spec lit(value :: Series.t() | inferable_scalar()) :: Series.t()
+  def lit(%Series{} = series), do: series
+
+  def lit(value), do: Explorer.PolarsBackend.Series.lit(value)
+
+  @doc """
   Builds a series of `dtype` from `binary`.
 
   All binaries must be in native endianness.

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -1565,6 +1565,20 @@ defmodule Explorer.DataFrameTest do
     end
   end
 
+  describe "lit/1" do
+    test "converts scalars in queries" do
+      df1 = DF.new(a: [1, nil, 2, nil]) |> DF.mutate(a: coalesce(a, lit(3)))
+      assert DF.to_columns(df1, atom_keys: true) == %{a: [1, 3, 2, 3]}
+
+      df2 =
+        DF.new([a: [1, nil, 2, nil]], lazy: true)
+        |> DF.mutate(a: coalesce(a, lit(3)))
+        |> DF.collect()
+
+      assert DF.to_columns(df2, atom_keys: true) == %{a: [1, 3, 2, 3]}
+    end
+  end
+
   describe "arrange/3" do
     test "raises with invalid column names", %{df: df} do
       assert_raise ArgumentError,

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -3960,6 +3960,14 @@ defmodule Explorer.SeriesTest do
     end
   end
 
+  describe "lit/1" do
+    test "casts to singleton when used on its own" do
+      s1 = Series.lit(1)
+      assert Series.to_list(s1) == [1]
+      assert s1.dtype == :integer
+    end
+  end
+
   describe "categorisation functions" do
     test "cut/6 with no nils" do
       series = -30..30//5 |> Enum.map(&(&1 / 10)) |> Enum.to_list() |> Series.from_list()

--- a/test/explorer/series_test.exs
+++ b/test/explorer/series_test.exs
@@ -3965,6 +3965,14 @@ defmodule Explorer.SeriesTest do
       s1 = Series.lit(1)
       assert Series.to_list(s1) == [1]
       assert s1.dtype == :integer
+
+      s2 = Series.lit(:nan)
+      assert Series.to_list(s2) == [:nan]
+      assert s2.dtype == :float
+
+      assert_raise ArgumentError,
+                   ~r/unsupported datatype/,
+                   fn -> Series.lit(:abc) end
     end
   end
 


### PR DESCRIPTION
I'm not sure if this is something that you'd like to introduce to the API, but the implementation is pretty straightforward, so I went directly for the PR.

The motivation here is to enable the use of scalars where the functions require a series. For instance, previously you would have to do something like:

```elixir
        DF.new(a: [1, nil, 2])
        |> DF.new(b: 3)
        |> DF.mutate(a: coalesce(a, b))
        |> DF.discard(:b)
```

The need for the temporary series `b` is because `coalesce/2` expects both arguments to be series. With `lit` you can do `DF.new(a: [1, nil, 2]) |> DF.mutate(a: coalesce(a, lit(3)))`.

Polars has [lit](https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.lit.html) and Spark has [lit and typedLit](https://sparkbyexamples.com/spark/using-lit-and-typedlit-to-add-a-literal-or-constant-to-spark-dataframe/). What do you think?