### PR TITLE
fix upcasted date to datetime for literal expressions

### DIFF
--- a/lib/explorer/data_frame.ex
+++ b/lib/explorer/data_frame.ex
@@ -2449,6 +2449,16 @@ defmodule Explorer.DataFrame do
 
             Explorer.Backend.Series.new(lazy_s, :boolean)
 
+          date = %Date{} ->
+            lazy_s = LazySeries.new(:to_lazy, [date])
+
+            Explorer.Backend.Series.new(lazy_s, :date)
+
+          datetime = %NaiveDateTime{} ->
+            lazy_s = LazySeries.new(:to_lazy, [datetime])
+
+            Explorer.Backend.Series.new(lazy_s, :datetime)
+
           other ->
             raise ArgumentError,
                   "expecting a lazy series or scalar value, but instead got #{inspect(other)}"

--- a/native/explorer/src/expressions.rs
+++ b/native/explorer/src/expressions.rs
@@ -55,7 +55,7 @@ pub fn expr_atom(atom: &str) -> ExExpr {
 #[rustler::nif]
 pub fn expr_date(date: ExDate) -> ExExpr {
     let naive_date = NaiveDate::from(date);
-    let expr = naive_date.lit();
+    let expr = naive_date.lit().dt().date();
     ExExpr::new(expr)
 }
 

--- a/test/explorer/data_frame_test.exs
+++ b/test/explorer/data_frame_test.exs
@@ -620,7 +620,17 @@ defmodule Explorer.DataFrameTest do
     test "adds new columns" do
       df = DF.new(a: [1, 2, 3], b: ["a", "b", "c"])
 
-      df1 = DF.mutate(df, c: a + 5, d: 2 + a, e: 42, f: 842.1, g: "Elixir", h: true)
+      df1 =
+        DF.mutate(df,
+          c: a + 5,
+          d: 2 + a,
+          e: 42,
+          f: 842.1,
+          g: "Elixir",
+          h: true,
+          i: ~D[2023-01-01],
+          j: ~N[2023-01-01 12:34:56]
+        )
 
       assert DF.to_columns(df1, atom_keys: true) == %{
                a: [1, 2, 3],
@@ -630,10 +640,16 @@ defmodule Explorer.DataFrameTest do
                e: [42, 42, 42],
                f: [842.1, 842.1, 842.1],
                g: ["Elixir", "Elixir", "Elixir"],
-               h: [true, true, true]
+               h: [true, true, true],
+               i: [~D[2023-01-01], ~D[2023-01-01], ~D[2023-01-01]],
+               j: [
+                 ~N[2023-01-01 12:34:56.000000],
+                 ~N[2023-01-01 12:34:56.000000],
+                 ~N[2023-01-01 12:34:56.000000]
+               ]
              }
 
-      assert df1.names == ["a", "b", "c", "d", "e", "f", "g", "h"]
+      assert df1.names == ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
 
       assert df1.dtypes == %{
                "a" => :integer,
@@ -643,7 +659,9 @@ defmodule Explorer.DataFrameTest do
                "e" => :integer,
                "f" => :float,
                "g" => :string,
-               "h" => :boolean
+               "h" => :boolean,
+               "i" => :date,
+               "j" => :datetime
              }
     end
 
@@ -1572,12 +1590,7 @@ defmodule Explorer.DataFrameTest do
         DF.new(a: [~D[2023-01-15], ~D[2022-02-16], nil])
         |> DF.mutate(x: select(a == ~D[2023-01-15], a, ~D[2023-01-01]))
 
-      assert Series.to_list(df7[:x]) ==
-               [
-                 ~N[2023-01-15 00:00:00.000000],
-                 ~N[2023-01-01 00:00:00.000000],
-                 ~N[2023-01-01 00:00:00.000000]
-               ]
+      assert Series.to_list(df7[:x]) == [~D[2023-01-15], ~D[2023-01-01], ~D[2023-01-01]]
     end
   end
 


### PR DESCRIPTION
This is to follow up [this comment](https://github.com/elixir-nx/explorer/pull/638#issuecomment-1618579395).

This was quite tricky to debug, because it turned out it had nothing to do with `binary_args` as mentioned in #638. There were two bugs:

1. It turned out you can't do `DF.mutate(a: ~D[2023-01-01])`. This is a simple fix in `Explorer.DataFrame`.
2. When a date literal reaches Rust, `NaiveDate`'s `lit` method defaults to `DateTime` [here](https://github.com/pola-rs/polars/blob/rs-0.29.0/polars/polars-lazy/polars-plan/src/logical_plan/lit.rs#L282). In this case, the fix is to cast this expr into date.